### PR TITLE
Rename table row on outcome page for pay-leave-for-parents

### DIFF
--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
@@ -26,7 +26,7 @@ Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 9
 
 <% if !calculator.range_in_2013_2014_fin_year?(due_date) && !calculator.range_in_2014_2015_fin_year?(due_date) && !calculator.range_in_2015_2016_fin_year?(due_date) %>
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 <% end %>
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -11,7 +11,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_extra_help.govspeak.erb: 
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: 3ea9d923f9211e88f5bf7627789df482
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.govspeak.erb: 73895add868b874c19b420a92e0817a6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 90a5bd547f0f68c44cd8d4f25fbc42d5
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: 032b77bc087e5ab559684efa099d1427
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: bdee1bf31c33f238d5a937d5ac1a669a
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_leave.govspeak.erb: 11930d6727f1a95f6aba571c6c0148b6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: a172d3e06a949f3a4c679b368abb6360
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_leave.govspeak.erb: b47ba71be320a0b46a42c3e31534af87


### PR DESCRIPTION
Trello story: https://trello.com/c/GyJ4mi3L/82-calculate-your-leave-and-pay-when-you-have-a-child-text-change

## Factcheck

[Child due in 2015-2016 tax year](https://smart-answers-pr-2429.herokuapp.com/pay-leave-for-parents/y/no/2015-06-07/employee/yes/yes/30000.0-year/yes)

[Child due in 2017-2018 tax year](http://smartanswers.dev.gov.uk/pay-leave-for-parents/y/no/2017-06-07/employee/yes/yes/30000.0-year/yes)

## Expected Changes

* [URL on GOV.UK](https://www.gov.uk/pay-leave-for-parents/y/no/2017-06-07/employee/yes/yes/30000.0-year/yes)
    * Change row text on outcome page if the child due after the 2015-2016 tax year

### Before

Child due in 2015-2016 tax year:

![screen shot 2016-04-01 at 16 22 00](https://cloud.githubusercontent.com/assets/5793815/14211433/f89a169c-f825-11e5-9a4d-796413c5d7ba.png)

Child due in 2017-2018 tax year:

![screen shot 2016-04-01 at 16 23 34](https://cloud.githubusercontent.com/assets/5793815/14211454/1b163b60-f826-11e5-9ccb-99b2bd968e7c.png)


### After

Child due in 2015-2016 tax year:

![screen shot 2016-04-01 at 16 25 33](https://cloud.githubusercontent.com/assets/5793815/14211503/62d047de-f826-11e5-8e5d-11e8a7f0b9cb.png)

Child due in 2017-2018 tax year:

![screen shot 2016-04-01 at 16 24 51](https://cloud.githubusercontent.com/assets/5793815/14211486/4b2997ac-f826-11e5-804d-884152522b6f.png)
