### PR TITLE
Update calculator base rates April 2016

### DIFF
--- a/lib/data/rates/married_couples_allowance.yml
+++ b/lib/data/rates/married_couples_allowance.yml
@@ -25,3 +25,12 @@
   income_limit_for_personal_allowances: 27700.0
   maximum_married_couple_allowance: 8355
   minimum_married_couple_allowance: 3220
+
+- start_date: 2016-04-06
+  end_date: 2017-04-05
+  personal_allowance: 11000
+  over_65_allowance: 11000
+  over_75_allowance: 11000
+  income_limit_for_personal_allowances: 27700.0
+  maximum_married_couple_allowance: 8355
+  minimum_married_couple_allowance: 3220

--- a/lib/data/rates/married_couples_allowance.yml
+++ b/lib/data/rates/married_couples_allowance.yml
@@ -17,8 +17,8 @@
   maximum_married_couple_allowance: 8165
   minimum_married_couple_allowance: 3140
 
-- start_date: 2014-04-06
-  end_date: 2015-04-05
+- start_date: 2015-04-06
+  end_date: 2016-04-05
   personal_allowance: 10600
   over_65_allowance: 10600
   over_75_allowance: 10660

--- a/lib/data/rates/redundancy_pay.yml
+++ b/lib/data/rates/redundancy_pay.yml
@@ -15,3 +15,7 @@
   end_date: 2016-04-05
   max: "14,250"
   rate: 475
+- start_date: 2016-04-06
+  end_date: 2017-04-05
+  max: "14,370"
+  rate: 479

--- a/lib/data/rates/redundancy_pay_northern_ireland.yml
+++ b/lib/data/rates/redundancy_pay_northern_ireland.yml
@@ -12,6 +12,10 @@
   max: "14,100"
   rate: 470
 - start_date: 2015-04-06
-  end_date: 2016-04-05
+  end_date: 2016-02-13
   max: "14,700"
   rate: 490
+- start_date: 2016-02-14
+  end_date: 2017-04-05
+  max: "15,000"
+  rate: 500

--- a/lib/data/rates/statutory_sick_pay.yml
+++ b/lib/data/rates/statutory_sick_pay.yml
@@ -25,6 +25,6 @@
   ssp_weekly_rate: 87.55
 
 - start_date: 2014-04-06
-  end_date: 2015-04-05
+  end_date: 2017-04-05
   lower_earning_limit_rate: 112
   ssp_weekly_rate: 88.45

--- a/test/data/calculate-employee-redundancy-pay-files.yml
+++ b/test/data/calculate-employee-redundancy-pay-files.yml
@@ -11,5 +11,5 @@ lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/weekly_pay_be
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/years_employed.govspeak.erb: 6840413403d9331d79e3b60f04d244a9
 lib/smart_answer_flows/shared_logic/redundancy_pay.rb: 04f4009e5e4bf1620356825f67cdb7e0
 lib/smart_answer/calculators/redundancy_calculator.rb: 1fe3bafe5d283d97f1f3406e0bf56b4e
-lib/data/rates/redundancy_pay.yml: 270b43298e223b28ba7ad3f81f5e0a08
-lib/data/rates/redundancy_pay_northern_ireland.yml: 01a56e2760328e0213318050689f2556
+lib/data/rates/redundancy_pay.yml: a214c01e46e92847f26b1de107997c78
+lib/data/rates/redundancy_pay_northern_ireland.yml: 83dcea5aa4048b6fb5d4aa222343e5c5

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -21,5 +21,5 @@ lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_h
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_highest_earners_income.govspeak.erb: 412dc17e132e6eac48e7b19de53568e5
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_husbands_date_of_birth.govspeak.erb: e4fc026bed0343ef3a2727da6c8ed30a
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_husbands_income.govspeak.erb: dd71c9678c1f2b9eba3471151b2ba839
-lib/data/rates/married_couples_allowance.yml: 2a981979d28576078696119ea1938315
+lib/data/rates/married_couples_allowance.yml: 4963b39377d58a433c033b657f595810
 lib/smart_answer/calculators/married_couples_allowance_calculator.rb: 5933b68549cee3305ea4c9c589b37f29

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -30,4 +30,4 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_bef
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
 lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: e9d02e8ed9aea95c76b2d477af9c78f7
-lib/data/rates/statutory_sick_pay.yml: de2d34118e3016d1137c394745d33280
+lib/data/rates/statutory_sick_pay.yml: b275311f2ec89fc707e6b9cfefec1179

--- a/test/data/calculate-your-redundancy-pay-files.yml
+++ b/test/data/calculate-your-redundancy-pay-files.yml
@@ -11,5 +11,5 @@ lib/smart_answer_flows/calculate-your-redundancy-pay/questions/weekly_pay_before
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/years_employed.govspeak.erb: 6bf4ef75048732fab207104b21cdc6e6
 lib/smart_answer_flows/shared_logic/redundancy_pay.rb: 04f4009e5e4bf1620356825f67cdb7e0
 lib/smart_answer/calculators/redundancy_calculator.rb: 1fe3bafe5d283d97f1f3406e0bf56b4e
-lib/data/rates/redundancy_pay.yml: 270b43298e223b28ba7ad3f81f5e0a08
-lib/data/rates/redundancy_pay_northern_ireland.yml: 01a56e2760328e0213318050689f2556
+lib/data/rates/redundancy_pay.yml: a214c01e46e92847f26b1de107997c78
+lib/data/rates/redundancy_pay_northern_ireland.yml: 83dcea5aa4048b6fb5d4aa222343e5c5

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -134,5 +134,16 @@ module SmartAnswer::Calculators
       end
     end
 
+    test 'rate values for year 2016' do
+      Timecop.freeze(Date.parse('2016-06-01')) do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 11000, calculator.personal_allowance
+        assert_equal 27700.0, calculator.income_limit_for_personal_allowances
+        assert_equal 8355, calculator.maximum_mca
+        assert_equal 3220, calculator.minimum_mca
+      end
+    end
+
   end
 end

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -26,7 +26,6 @@ module SmartAnswer::Calculators
         personal_allowance: @personal_allowance)
     end
 
-
     test "worked example on directgov for 2011-12" do
       hmrc_example_calculator = calculator(
           maximum_mca: 7295,
@@ -101,5 +100,39 @@ module SmartAnswer::Calculators
       result = default_calculator.calculate_adjusted_net_income(income, gross_pension_contributions, net_pension_contributions, gift_aided_donations)
       assert_equal SmartAnswer::Money.new("28250"), result
     end
+
+    test 'rate values for year 2013' do
+      Timecop.freeze(Date.parse('2013-06-01')) do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 9440, calculator.personal_allowance
+        assert_equal 26100.0, calculator.income_limit_for_personal_allowances
+        assert_equal 7915, calculator.maximum_mca
+        assert_equal 3040, calculator.minimum_mca
+      end
+    end
+
+    test 'rate values for year 2014' do
+      Timecop.freeze(Date.parse('2014-06-01')) do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 10000, calculator.personal_allowance
+        assert_equal 27000.0, calculator.income_limit_for_personal_allowances
+        assert_equal 8165, calculator.maximum_mca
+        assert_equal 3140, calculator.minimum_mca
+      end
+    end
+
+    test 'rate values for year 2015' do
+      Timecop.freeze(Date.parse('2015-06-01')) do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 10600, calculator.personal_allowance
+        assert_equal 27700.0, calculator.income_limit_for_personal_allowances
+        assert_equal 8355, calculator.maximum_mca
+        assert_equal 3220, calculator.minimum_mca
+      end
+    end
+
   end
 end

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -37,7 +37,7 @@ module SmartAnswer::Calculators
         assert_equal "13,920", RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 06)).max
         assert_equal "13,920", RedundancyCalculator.redundancy_rates(Date.new(2015, 04, 05)).max
         assert_equal "14,250", RedundancyCalculator.redundancy_rates(Date.new(2015, 04, 06)).max
-        assert_equal "14,250", RedundancyCalculator.redundancy_rates(Date.new(Date.today.year, 12, 31)).max
+        assert_equal "14,370", RedundancyCalculator.redundancy_rates(Date.new(Date.today.year, 12, 31)).max
       end
 
       should "use the most recent rate for far future dates" do


### PR DESCRIPTION
## Motivation

Many of our calculators use .yml files to include the rates and effective dates:
https://github.com/alphagov/smart-answers/tree/master/lib/data/rates

The following [spreadsheet](https://docs.google.com/spreadsheets/d/1Pxe7-4p8WfdOulBDbXz7gjYtriHbWJXzkHYvZT2-wGY/edit) outlines the changes required for April uprating: 