### PR TITLE
Fix minimum wage rates for people aged 24

### DIFF
--- a/lib/data/minimum_wage_data.yml
+++ b/lib/data/minimum_wage_data.yml
@@ -136,7 +136,7 @@
     :max_age: 21
     :rate: 5.30
   - :min_age: 21
-    :max_age: 24
+    :max_age: 25
     :rate: 6.70
   - :min_age: 25
     :max_age: 1000

--- a/lib/data/minimum_wage_data.yml
+++ b/lib/data/minimum_wage_data.yml
@@ -127,6 +127,20 @@
   :apprentice_rate: 2.73
   :accommodation_rate: 5.08
 - :start_date: 2015-10-01
+  :end_date: 2016-03-31
+  :minimum_rates:
+  - :min_age: 0
+    :max_age: 18
+    :rate: 3.87
+  - :min_age: 18
+    :max_age: 21
+    :rate: 5.30
+  - :min_age: 21
+    :max_age: 1000
+    :rate: 6.70
+  :apprentice_rate: 3.30
+  :accommodation_rate: 5.35
+- :start_date: 2016-04-01
   :end_date: 2999-09-30
   :minimum_rates:
   - :min_age: 0

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -35,4 +35,4 @@ lib/smart_answer_flows/am-i-getting-minimum-wage/questions/what_would_you_like_t
 lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb: 582cdf982fa5619072ddd883bf4c1555
 lib/smart_answer_flows/shared_logic/minimum_wage.rb: d27e8aa03ebf55901c24d39118ebef62
 lib/smart_answer/calculators/minimum_wage_calculator.rb: 2c935b38a0cd5e3618c03270f08b8033
-lib/data/minimum_wage_data.yml: c257c01115baeb5ee5427339a416232b
+lib/data/minimum_wage_data.yml: 3eab0fe85f2d8687f486964580df51ff

--- a/test/data/minimum-wage-calculator-employers-files.yml
+++ b/test/data/minimum-wage-calculator-employers-files.yml
@@ -35,4 +35,4 @@ lib/smart_answer_flows/minimum-wage-calculator-employers/questions/what_would_yo
 lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb: 582cdf982fa5619072ddd883bf4c1555
 lib/smart_answer_flows/shared_logic/minimum_wage.rb: d27e8aa03ebf55901c24d39118ebef62
 lib/smart_answer/calculators/minimum_wage_calculator.rb: 2c935b38a0cd5e3618c03270f08b8033
-lib/data/minimum_wage_data.yml: c257c01115baeb5ee5427339a416232b
+lib/data/minimum_wage_data.yml: 3eab0fe85f2d8687f486964580df51ff

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -789,6 +789,33 @@ module SmartAnswer::Calculators
           end
         end
 
+        should 'be 6.70 for people aged over 25' do
+          [25, 999].each do |age|
+            @calculator.age = age
+            assert_equal 6.70, @calculator.per_hour_minimum_wage
+          end
+        end
+      end
+
+      context 'from 1 Apr 2016' do
+        setup do
+          @calculator = MinimumWageCalculator.new(date: Date.parse('2016-04-01'))
+        end
+
+        should 'be 3.87 for people aged under 18' do
+          [0, 17].each do |age|
+            @calculator.age = age
+            assert_equal 3.87, @calculator.per_hour_minimum_wage
+          end
+        end
+
+        should 'be 5.30 for people aged between 18 and 20' do
+          [18, 20].each do |age|
+            @calculator.age = age
+            assert_equal 5.30, @calculator.per_hour_minimum_wage
+          end
+        end
+
         should 'be 6.70 for people aged between 21 and 24' do
           [21, 24].each do |age|
             @calculator.age = age

--- a/test/unit/calculators/minimum_wage_calculator_test.rb
+++ b/test/unit/calculators/minimum_wage_calculator_test.rb
@@ -769,6 +769,40 @@ module SmartAnswer::Calculators
         @calculator = MinimumWageCalculator.new age: 22, date: Date.parse('2009-10-01')
         assert_equal 5.8, @calculator.per_hour_minimum_wage
       end
+
+      context 'from 1 Oct 2015' do
+        setup do
+          @calculator = MinimumWageCalculator.new(date: Date.parse('2015-10-01'))
+        end
+
+        should 'be 3.87 for people aged under 18' do
+          [0, 17].each do |age|
+            @calculator.age = age
+            assert_equal 3.87, @calculator.per_hour_minimum_wage
+          end
+        end
+
+        should 'be 5.30 for people aged between 18 and 20' do
+          [18, 20].each do |age|
+            @calculator.age = age
+            assert_equal 5.30, @calculator.per_hour_minimum_wage
+          end
+        end
+
+        should 'be 6.70 for people aged between 21 and 24' do
+          [21, 24].each do |age|
+            @calculator.age = age
+            assert_equal 6.70, @calculator.per_hour_minimum_wage
+          end
+        end
+
+        should 'be 7.20 for people aged over 25' do
+          [25, 999].each do |age|
+            @calculator.age = age
+            assert_equal 7.20, @calculator.per_hour_minimum_wage
+          end
+        end
+      end
     end
 
     context "accommodation adjustment" do


### PR DESCRIPTION
Trello card: https://trello.com/c/n72PekVB

A problem in the minimum_wage_data.yml file meant that responding to the am-i-getting-minimum-wage "age" question with "24" resulted in exceptions being logged in errbit.

I've fixed the problem in minimum_wage_data.yml and have also updated the data so that the National Living Wage only applies from 1 Apr 2016 (instead of 1 Oct 2015).