### PR TITLE
Remove marriage-abroad unused service data

### DIFF
--- a/lib/data/marriage_abroad_services.yml
+++ b/lib/data/marriage_abroad_services.yml
@@ -515,16 +515,6 @@ romania:
       default:
       - :receiving_notice_of_marriage
       - :issuing_cni_or_nulla_osta
-  same_sex:
-    default:
-      partner_british:
-      - :receiving_notice_of_registration
-      - :registering_marriage
-      - :issuing_marriage_certificate
-      partner_other:
-      - :receiving_notice_of_registration
-      - :registering_marriage
-      - :issuing_marriage_certificate
 russia:
   opposite_sex:
     ceremony_country:

--- a/lib/data/marriage_abroad_services.yml
+++ b/lib/data/marriage_abroad_services.yml
@@ -70,7 +70,10 @@ morocco:
       - :affidavit_or_affirmation_for_marriage
 norway:
   opposite_sex:
-    default:
+    ceremony_country:
+      default:
+      - :affidavit_or_affirmation_for_marriage
+    uk:
       default:
       - :affidavit_or_affirmation_for_marriage
   same_sex:

--- a/lib/data/marriage_abroad_services.yml
+++ b/lib/data/marriage_abroad_services.yml
@@ -814,9 +814,3 @@ wallis-and-futuna:
     default:
       default:
       - :issuing_custom_and_law_certificate
-ukraine:
-  opposite_sex:
-    ceremony_country:
-      default:
-      - :receiving_notice_of_marriage
-      - :issuing_cni_or_nulla_osta

--- a/lib/data/marriage_abroad_services.yml
+++ b/lib/data/marriage_abroad_services.yml
@@ -681,7 +681,10 @@ poland:
       - :issuing_cni_or_nulla_osta
 slovenia:
   opposite_sex:
-    default:
+    ceremony_country:
+      default:
+      - :affidavit_or_affirmation_for_marriage
+    uk:
       default:
       - :affidavit_or_affirmation_for_marriage
   same_sex:

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -142,7 +142,7 @@ lib/smart_answer_flows/marriage-abroad/questions/marriage_or_pacs.govspeak.erb: 
 lib/smart_answer_flows/marriage-abroad/questions/partner_opposite_or_same_sex.govspeak.erb: 40d0c99a5be50f0625c6562f06fe4afd
 lib/smart_answer_flows/marriage-abroad/questions/what_is_your_partners_nationality.govspeak.erb: 80e04f36c75c232bede1a244d621471e
 lib/data/rates/marriage_abroad_consular_fees.yml: db466bd97c7ee1b9a275dec70590d61f
-lib/data/marriage_abroad_services.yml: ebb2ce21754ac2efd10b055de0783bd7
+lib/data/marriage_abroad_services.yml: 7518c784ac69b47c23337230571d6fd1
 lib/smart_answer/calculators/marriage_abroad_calculator.rb: ae01afa9bbaa40ef191b4c2ea066e7c2
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: e224243b2aa50c3c89d68515b16106f7


### PR DESCRIPTION
Trello cards:

* [Opposite sex services in Norway for third_country residents](https://trello.com/c/xQGZ5uuL)
* [Opposite sex services in Slovenia for third_country residents](https://trello.com/c/Vy3XJJVl)
* [Opposite sex services in Ukraine for Ukrainian residents](https://trello.com/c/2jG2LmZi)
* [Same sex services in Romania](https://trello.com/c/NwWDH1m4)

PR #2438 updated the marriage-abroad service data based on a spreadsheet supplied by FCO. The changes to the service data implied that services/fees should be visible in some outcomes that weren't currently showing them. I've now had confirmation that we _shouldn't_ be showing them in four of those cases.

This branch updates the marriage_abroad_services.yml so that it matches our current understanding of when the services/fees should be shown.

This change isn't strictly necessary as logic in the flow/templates meant that these removed services/fees weren't being shown anyway. I think it's good to make this change as it means the data matches our expectations of what's being shown.

## Expected changes

None.
