### PR TITLE
Avoid fixtures in WorldwideOrganisation tests

### DIFF
--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -150,10 +150,4 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
       end
     end
   end
-
-  def load_fixture(country)
-    json = read_fixture_file("worldwide/#{country}_organisations.json")
-    worldwide_api_has_organisations_for_location(country, json)
-    WorldwideOrganisation.for_location(country)
-  end
 end

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -4,11 +4,22 @@ require 'gds_api/test_helpers/worldwide'
 class WorldwideOrganisationTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
-  context "finding organisations in a location" do
-    should "return organisations for the location" do
-      results = load_fixture('australia')
-      assert results[0].is_a?(WorldwideOrganisation)
-      assert_equal ["UK Trade & Investment Australia", "British High Commission Canberra"], results.map(&:title)
+  context '.for_location' do
+    should 'instantiates WorldwideOrganisation objects using data from the API' do
+      organisations_data = [
+        OpenStruct.new(title: 'organisation-1-title'),
+        OpenStruct.new(title: 'organisation-2-title')
+      ]
+      worldwide_api = stub
+      worldwide_api.stubs(:organisations_for_world_location).with('location-slug').returns(organisations_data)
+      Services.stubs(:worldwide_api).returns(worldwide_api)
+
+      worldwide_organisations = WorldwideOrganisation.for_location('location-slug')
+
+      assert_equal 2, worldwide_organisations.count
+      assert worldwide_organisations.first.is_a?(WorldwideOrganisation)
+      assert worldwide_organisations.last.is_a?(WorldwideOrganisation)
+      assert_equal ['organisation-1-title', 'organisation-2-title'], worldwide_organisations.map(&:title)
     end
   end
 

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -24,16 +24,24 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
   end
 
   context "fco_sponsored?" do
-    setup do
-      @orgs = load_fixture('australia')
-    end
-
     should "return true for an organisation sponsored by the FCO" do
-      assert_equal true, @orgs[1].fco_sponsored?
+      organisation_data = OpenStruct.new(
+        sponsors: [
+          OpenStruct.new(
+            details: OpenStruct.new(acronym: 'FCO')
+          )
+        ]
+      )
+      worldwide_organisation = WorldwideOrganisation.new(organisation_data)
+
+      assert_equal true, worldwide_organisation.fco_sponsored?
     end
 
-    should "return false otherwise" do
-      assert_equal false, @orgs[0].fco_sponsored?
+    should "return false for an organisation not sponsored by the FCO" do
+      organisation_data = OpenStruct.new(sponsors: [])
+      worldwide_organisation = WorldwideOrganisation.new(organisation_data)
+
+      assert_equal false, worldwide_organisation.fco_sponsored?
     end
   end
 

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -70,33 +70,47 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
   context "attribute accessors" do
     setup do
-      @organisation = load_fixture('australia')[1]
+      organisation_data = OpenStruct.new(
+        title: 'organisation-title',
+        web_url: 'organisation-web-url',
+        offices: OpenStruct.new(
+          main: OpenStruct.new(
+            title: 'main-office-title'
+          ),
+          other: [
+            OpenStruct.new(
+              title: 'other-office-title'
+            )
+          ]
+        )
+      )
+      @organisation = WorldwideOrganisation.new(organisation_data)
     end
 
     should "allow accessing required top-level attributes" do
-      assert_equal "British High Commission Canberra", @organisation.title
+      assert_equal 'organisation-title', @organisation.title
     end
 
     context "accessing office details" do
       should "allow accessing office details" do
-        assert_equal "British High Commission Canberra", @organisation.offices.main.title
+        assert_equal 'main-office-title', @organisation.offices.main.title
       end
 
       should "have shortcut accessor for main office" do
-        assert_equal "British High Commission Canberra", @organisation.main_office.title
+        assert_equal "main-office-title", @organisation.main_office.title
       end
 
       should "have shortcut accessor for other offices" do
-        assert_equal "British Consulate-General Sydney", @organisation.other_offices.first.title
+        assert_equal 'other-office-title', @organisation.other_offices.first.title
       end
 
       should "have an accessor for all offices" do
-        assert_equal 5, @organisation.all_offices.size
-        assert_equal ["British High Commission Canberra", "British Consulate-General Sydney"], @organisation.all_offices.map(&:title)[0..1]
+        assert_equal 2, @organisation.all_offices.size
+        assert_equal ['main-office-title', 'other-office-title'], @organisation.all_offices.map(&:title)
       end
 
       should "have an accessor for the URL" do
-        assert_equal "https://www.gov.uk/government/world/organisations/british-high-commission-canberra", @organisation.web_url
+        assert_equal 'organisation-web-url', @organisation.web_url
       end
     end
   end

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -74,10 +74,20 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
     end
 
     should "fallback to main office" do
-      organisation = load_fixture('andorra').first
-      matches = organisation.offices_with_service('Obscure service')
+      organisation_data = OpenStruct.new(
+        offices: OpenStruct.new(
+          main: OpenStruct.new(
+            title: 'main-office',
+            services: []
+          ),
+          other: []
+        )
+      )
+      organisation = WorldwideOrganisation.new(organisation_data)
+
+      matches = organisation.offices_with_service('obscure-service')
       assert_equal 1, matches.length, "Wrong number of offices matched"
-      assert_equal 'British Embassy', matches[0].title
+      assert_equal 'main-office', matches[0].title
     end
 
     should "return empty array if no offices" do

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -91,8 +91,15 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
     end
 
     should "return empty array if no offices" do
-      organisation = load_fixture('brazil')[2]
-      matches = organisation.offices_with_service('desired service')
+      organisation_data = OpenStruct.new(
+        offices: OpenStruct.new(
+          main: nil,
+          other: []
+        )
+      )
+      organisation = WorldwideOrganisation.new(organisation_data)
+
+      matches = organisation.offices_with_service('service-name')
       assert_equal [], matches
     end
   end

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -47,11 +47,30 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
   context "offices with services" do
     should "find offices with service" do
-      organisation = load_fixture('argentina').first
-      matches = organisation.offices_with_service('Births and Deaths registration service')
+      organisation_data = OpenStruct.new(
+        offices: OpenStruct.new(
+          main: OpenStruct.new(
+            title: 'main-office',
+            services: []
+          ),
+          other: [
+            OpenStruct.new(
+              title: 'other-office-1',
+              services: [OpenStruct.new(title: 'service-offered')]
+            ),
+            OpenStruct.new(
+              title: 'other-office-2',
+              services: [OpenStruct.new(title: 'service-offered')]
+            )
+          ]
+        )
+      )
+      organisation = WorldwideOrganisation.new(organisation_data)
+
+      matches = organisation.offices_with_service('service-offered')
       assert_equal 2, matches.length, "Wrong number of offices matched"
-      assert_equal 'British Embassy Buenos Aires', matches[0].title
-      assert_equal 'Consular', matches[1].title
+      assert_equal 'other-office-1', matches[0].title
+      assert_equal 'other-office-2', matches[1].title
     end
 
     should "fallback to main office" do


### PR DESCRIPTION
I've updated the tests for `WorldwideOrganisation` to use data setup within the tests rather than data from the organisation fixtures in test/fixtures/worldwide/*.json.

I want to update the organisation fixture data to help with some changes I'm making to marriage-abroad. Updating that data at the moment causes a number of these `WorldwideOrganisation` tests to fail because the data they're relying on changes. The changes in this branch will allow me to update the organisation fixture data without having to also change these tests.