### PR TITLE
Fix typo in state pension checker

### DIFF
--- a/lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb
@@ -11,5 +11,5 @@
 
   The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
 
-  You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
+  You can get a 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
 <% end %>

--- a/test/artefacts/state-pension-age/bus_pass/1949-02-01.txt
+++ b/test/artefacts/state-pension-age/bus_pass/1949-02-01.txt
@@ -7,7 +7,7 @@ The date you qualify for a bus pass depends on where you live:
 
 The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
 
-You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
+You can get a 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
 
 
 

--- a/test/artefacts/state-pension-age/bus_pass/1950-02-01.txt
+++ b/test/artefacts/state-pension-age/bus_pass/1950-02-01.txt
@@ -7,7 +7,7 @@ The date you qualify for a bus pass depends on where you live:
 
 The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
 
-You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
+You can get a 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
 
 
 

--- a/test/artefacts/state-pension-age/bus_pass/1953-02-06.txt
+++ b/test/artefacts/state-pension-age/bus_pass/1953-02-06.txt
@@ -7,7 +7,7 @@ The date you qualify for a bus pass depends on where you live:
 
 The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
 
-You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
+You can get a 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
 
 
 

--- a/test/artefacts/state-pension-age/bus_pass/1980-01-01.txt
+++ b/test/artefacts/state-pension-age/bus_pass/1980-01-01.txt
@@ -7,7 +7,7 @@ The date you qualify for a bus pass depends on where you live:
 
 The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
 
-You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
+You can get a 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
 
 
 

--- a/test/artefacts/state-pension-age/bus_pass/2000-01-01.txt
+++ b/test/artefacts/state-pension-age/bus_pass/2000-01-01.txt
@@ -7,7 +7,7 @@ The date you qualify for a bus pass depends on where you live:
 
 The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
 
-You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
+You can get a 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
 
 
 

--- a/test/data/state-pension-age-files.yml
+++ b/test/data/state-pension-age-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/state-pension-age.rb: baa6cd5093a2323d61d42a3184096362
 test/data/state-pension-age-questions-and-responses.yml: 6cf2d7052e044c4367b943077205f882
 test/data/state-pension-age-responses-and-expected-results.yml: 54283e77f05bd42775d6d3d1f1fc4380
-lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb: 9dd637a833ddcf0402a6a38e55fb2ace
+lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb: a59bf774bdaa6613b37509e21842d907
 lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age.govspeak.erb: a10deca136a040377e954ff2f3d2c787
 lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb: 6640ca59fbe0be642649ce6cd03c9e20
 lib/smart_answer_flows/state-pension-age/questions/dob_age.govspeak.erb: 336a91fc32e8fc66011a9ae504111ae0


### PR DESCRIPTION
### Trello card
* [fixing-a-tiny-typo-in-state-pension-age-checker](https://trello.com/c/z5RPbuer/106-fixing-a-tiny-typo-in-state-pension-age-checker)
Supersede #2447 

## Description
Update `an` with `a` in `You can get an 60+ Oyster card from [Transport for London]`

## Factcheck
[fixing-a-tiny-typo-in-state-pension-age-checker](https://smart-answers-pr-2449.herokuapp.com/state-pension-age/y/bus_pass/1949-02-01)

## Expected changes

* [URL on GOV.UK](https://www.gov.uk/state-pension-age/y/bus_pass/1949-02-01)

### Before
<img width="1201" alt="screen shot 2016-04-08 at 10 40 01" src="https://cloud.githubusercontent.com/assets/227328/14380338/d48538c6-fd76-11e5-9fff-9c98acf387c0.png">

### After
<img width="696" alt="screen shot 2016-04-08 at 10 44 58" src="https://cloud.githubusercontent.com/assets/227328/14380360/f9573f46-fd76-11e5-9ef0-452df8bec88f.png">
