### PR TITLE
Studentformfinder stw

### DIFF
--- a/lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb
@@ -11,5 +11,5 @@
 
   The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
 
-  You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
+  You can get a 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
 <% end %>

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/_when_you_can_apply.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/_when_you_can_apply.govspeak.erb
@@ -1,1 +1,1 @@
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^


### PR DESCRIPTION
Current text is wrong: it must mention academic year.
(This corrects a previous PR - I don't think I actually committed the change…
For dev trello card:
https://trello.com/c/fo4vok6c/105-student-finance-form-finder-update-partial-for-deadlines)
