### PR TITLE
Show academic year in student finance forms

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/_when_you_can_apply.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/_when_you_can_apply.govspeak.erb
@@ -1,1 +1,1 @@
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^

--- a/test/artefacts/student-finance-forms/eu-full-time/year-1516/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/eu-full-time/year-1516/continuing-student.txt
@@ -18,7 +18,7 @@ Form | When to use the form
 [Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your forms
 

--- a/test/artefacts/student-finance-forms/eu-full-time/year-1516/new-student.txt
+++ b/test/artefacts/student-finance-forms/eu-full-time/year-1516/new-student.txt
@@ -18,7 +18,7 @@ Form | When to use the form
 [Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your forms
 

--- a/test/artefacts/student-finance-forms/eu-full-time/year-1617/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/eu-full-time/year-1617/continuing-student.txt
@@ -18,7 +18,7 @@ Form | When to use the form
 [Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/1617/eu/eu_certifier_checklist_form_1617_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1617/eu/eu_co1_form_1617_d.pdf) | To update your course, name and other details
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your forms
 

--- a/test/artefacts/student-finance-forms/eu-full-time/year-1617/new-student.txt
+++ b/test/artefacts/student-finance-forms/eu-full-time/year-1617/new-student.txt
@@ -18,7 +18,7 @@ Form | When to use the form
 [Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/1617/eu/eu_certifier_checklist_form_1617_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1617/eu/eu_co1_form_1617_d.pdf) | To update your course, name and other details
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your forms
 

--- a/test/artefacts/student-finance-forms/eu-part-time/year-1415/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/eu-part-time/year-1415/continuing-student.txt
@@ -25,7 +25,7 @@ Form | When to use the form
 [Certifier checklist (PDF, 75KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 483KB)](http://media.slc.co.uk/sfe/1415/eu/eu_co1_1415_d.pdf) | To update your course, name and other details
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your forms
 

--- a/test/artefacts/student-finance-forms/eu-part-time/year-1415/new-student.txt
+++ b/test/artefacts/student-finance-forms/eu-part-time/year-1415/new-student.txt
@@ -18,7 +18,7 @@ Form | When to use the form
 [Certifier checklist (PDF, 75KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 483KB)](http://media.slc.co.uk/sfe/1415/eu/eu_co1_1415_d.pdf) | To update your course, name and other details
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your forms
 

--- a/test/artefacts/student-finance-forms/eu-part-time/year-1516/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/eu-part-time/year-1516/continuing-student.txt
@@ -24,7 +24,7 @@ Form | When to use the form
 [Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your forms
 

--- a/test/artefacts/student-finance-forms/eu-part-time/year-1516/new-student.txt
+++ b/test/artefacts/student-finance-forms/eu-part-time/year-1516/new-student.txt
@@ -17,7 +17,7 @@ Form | When to use the form
 [Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your forms
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/continuing-student.txt
@@ -11,7 +11,7 @@ Academic Year | Form
 2015 to 2016 | [PR1 - form (PDF, 573KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_form_1516_d.pdf)
 2015 to 2016 | [PR1 - guidance notes (PDF, 189KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_notes_1516_d.pdf)
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your form(s)
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/new-student.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/new-student.txt
@@ -11,7 +11,7 @@ Academic Year | Form
 2015 to 2016 | [PN1 - form (PDF, 465KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_form_1516_d.pdf)
 2015 to 2016 | [PN1 - guidance notes (PDF, 300KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_notes_1516_d.pdf)
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your form(s)
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1617/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1617/continuing-student.txt
@@ -12,7 +12,7 @@ Academic Year | Form
 2016 to 2017 | [PR1 - guidance notes (PDF, 177KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_pr1_notes_1617_d.pdf)
 2016 to 2017 | [Tax return guide (PDF, 591KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_paper_tax_return_guide_1617_d.pdf)
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your form(s)
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1617/new-student.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1617/new-student.txt
@@ -12,7 +12,7 @@ Academic Year | Form
 2016 to 2017 | [PN1 - guidance notes (PDF, 584KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_pn1_notes_1617_d.pdf)
 2016 to 2017 | [Tax return guide (PDF, 591KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_paper_tax_return_guide_1617_d.pdf)
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your form(s)
 

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1415/continuing-student/course-start-after-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1415/continuing-student/course-start-after-01092012.txt
@@ -9,7 +9,7 @@ Academic Year | Form
 2014 to 2015 | [PTLC - form (PDF, 128KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptlc_1415_d.pdf)
 2014 to 2015 | [PTLC - guidance notes (PDF, 96KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptlc_notes_1415_d.pdf)
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your form(s)
 

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1415/new-student/course-start-after-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1415/new-student/course-start-after-01092012.txt
@@ -9,7 +9,7 @@ Academic Year | Form
 2014 to 2015 | [PTL1 - form (PDF, 237KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptl1_1415_d.pdf)
 2014 to 2015 | [PTL1 - guidance notes (PDF, 182KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptl1_notes_1415_d.pdf)
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your form(s)
 

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/new-student/course-start-after-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/new-student/course-start-after-01092012.txt
@@ -9,7 +9,7 @@ Academic Year | Form
 2015 to 2016 | [PTL1 - form (PDF, 728KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_form_1516_d.pdf)
 2015 to 2016 | [PTL1 - guidance notes (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_notes_1516_d.pdf)
 
-^The deadline is 9 months after the first day of the month that your course started. This would be 31 May if your course started on 20 September.^
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
 
 ##Where to send your form(s)
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/student-finance-forms.rb: d359d46a211b2aff4e0acc0062b6142
 test/data/student-finance-forms-questions-and-responses.yml: 59efd7bff0de61c0a9e707415cca4608
 test/data/student-finance-forms-responses-and-expected-results.yml: 9e1a5b712cf384edb874d8902debe279
 lib/smart_answer_flows/student-finance-forms/outcomes/_circumstances_changed_co2_form.govspeak.erb: 236d81f3660a1958bb0dd3a8f229baf4
-lib/smart_answer_flows/student-finance-forms/outcomes/_when_you_can_apply.govspeak.erb: 80a3d97a8480d5791411bbb02d4a99d1
+lib/smart_answer_flows/student-finance-forms/outcomes/_when_you_can_apply.govspeak.erb: c3459b01f8733370279520306716f895
 lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_non_uk.govspeak.erb: 7cc0f616b4df674cd314ba6ffc0a675b
 lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_uk.govspeak.erb: e32479a47518d9f72b5786d00bbf8ca7
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1516.govspeak.erb: 8c4197c95ee1efd165da56a007540829


### PR DESCRIPTION
### Trello card
* [student-finance-form-finder-update-partial-for-deadlines](https://trello.com/c/fo4vok6c/105-student-finance-form-finder-update-partial-for-deadlines)

## Description
Supersede https://github.com/alphagov/smart-answers/pull/2450
Student must get information about the academic year when getting information about when to apply.

## Factcheck
[student-finance-form-finder-update-partial-for-deadlines](https://smart-answers-pr-2451.herokuapp.com/student-finance-forms/y/eu-full-time/year-1516/continuing-student)

## Expected changes

* [URL on GOV.UK](https://www.gov.uk/student-finance-forms/y/eu-full-time/year-1516/continuing-student)

### Before
<img width="696" alt="screen shot 2016-04-08 at 11 18 06" src="https://cloud.githubusercontent.com/assets/227328/14381097/9bb017c8-fd7b-11e5-8d32-1fb9c61fccbd.png">

### After
<img width="696" alt="screen shot 2016-04-08 at 11 17 43" src="https://cloud.githubusercontent.com/assets/227328/14381109/aa71f740-fd7b-11e5-8217-0ae13ea31c22.png">