### PR TITLE
Refactor Benefit cap calculator (Making benefit rates and type configurable)

### DIFF
--- a/lib/data/benefit_cap_data.yml
+++ b/lib/data/benefit_cap_data.yml
@@ -1,4 +1,21 @@
 ---
-single: 350
-couple: 500
-parent: 500
+rates:
+  single: 350
+  couple: 500
+  parent: 500
+benefits:
+  - bereavement
+  - carers
+  - child_benefit
+  - child_tax
+  - esa
+  - guardian
+  - incapacity
+  - income_support
+  - jsa
+  - maternity
+  - sda
+  - widowed_mother
+  - widowed_parent
+  - widow_pension
+  - widows_aged

--- a/lib/data/benefit_cap_data.yml
+++ b/lib/data/benefit_cap_data.yml
@@ -1,5 +1,5 @@
 ---
-rates:
+weekly_benefit_cap:
   single: 350
   couple: 500
   parent: 500

--- a/lib/data/benefit_cap_data.yml
+++ b/lib/data/benefit_cap_data.yml
@@ -4,18 +4,18 @@ rates:
   couple: 500
   parent: 500
 benefits:
-  - bereavement
-  - carers
-  - child_benefit
-  - child_tax
-  - esa
-  - guardian
-  - incapacity
-  - income_support
-  - jsa
-  - maternity
-  - sda
-  - widowed_mother
-  - widowed_parent
-  - widow_pension
-  - widows_aged
+  bereavement: :bereavement_amount?
+  carers: :carers_amount?
+  child_benefit: :child_benefit_amount?
+  child_tax: :child_tax_amount?
+  esa: :esa_amount?
+  guardian: :guardian_amount?
+  incapacity: :incapacity_amount?
+  income_support: :income_support_amount?
+  jsa: :jsa_amount?
+  maternity: :maternity_amount?
+  sda: :sda_amount?
+  widowed_mother: :widowed_mother_amount?
+  widowed_parent: :widowed_parent_amount?
+  widow_pension: :widow_pension_amount?
+  widows_aged: :widows_aged_amount?

--- a/lib/data/benefit_cap_data.yml
+++ b/lib/data/benefit_cap_data.yml
@@ -1,8 +1,14 @@
 ---
-weekly_benefit_cap:
-  single: 350
-  couple: 500
-  parent: 500
+weekly_benefit_caps:
+  single:
+    amount: 350
+    description: "Single"
+  couple:
+    amount: 500
+    description: "Living as a couple (with or without children)"
+  parent:
+    amount: 500
+    description: "A lone parent with 1 or more dependent children"
 exempt_benefits:
   - Attendance Allowance
   - Disability Living Allowance

--- a/lib/data/benefit_cap_data.yml
+++ b/lib/data/benefit_cap_data.yml
@@ -4,18 +4,48 @@ rates:
   couple: 500
   parent: 500
 benefits:
-  bereavement: :bereavement_amount?
-  carers: :carers_amount?
-  child_benefit: :child_benefit_amount?
-  child_tax: :child_tax_amount?
-  esa: :esa_amount?
-  guardian: :guardian_amount?
-  incapacity: :incapacity_amount?
-  income_support: :income_support_amount?
-  jsa: :jsa_amount?
-  maternity: :maternity_amount?
-  sda: :sda_amount?
-  widowed_mother: :widowed_mother_amount?
-  widowed_parent: :widowed_parent_amount?
-  widow_pension: :widow_pension_amount?
-  widows_aged: :widows_aged_amount?
+  bereavement:
+    question: :bereavement_amount?
+    description: "Bereavement Allowance"
+  carers:
+    question: :carers_amount?
+    description: "Carer's Allowance"
+  child_benefit:
+    question: :child_benefit_amount?
+    description: "Child Benefit"
+  child_tax:
+    question: :child_tax_amount?
+    description: "Child Tax Credit"
+  esa:
+    question: :esa_amount?
+    description: "Employment and Support Allowance"
+  guardian:
+    question: :guardian_amount?
+    description: "Guardian's Allowance"
+  incapacity:
+    question: :incapacity_amount?
+    description: "Incapacity Benefit"
+  income_support:
+    question: :income_support_amount?
+    description: "Income Support"
+  jsa:
+    question: :jsa_amount?
+    description: "Jobseeker’s Allowance"
+  maternity:
+    question: :maternity_amount?
+    description: "Maternity Allowance"
+  sda:
+    question: :sda_amount?
+    description: "Severe Disablement Allowance"
+  widowed_mother:
+    question: :widowed_mother_amount?
+    description: "Widowed Mother's Allowance"
+  widowed_parent:
+    question: :widowed_parent_amount?
+    description: "Widowed Parent's Allowance"
+  widow_pension:
+    question: :widow_pension_amount?
+    description: "Widow's Pension"
+  widows_aged:
+    question: :widows_aged_amount?
+    description: "Widow's Pension (age related)"

--- a/lib/data/benefit_cap_data.yml
+++ b/lib/data/benefit_cap_data.yml
@@ -1,0 +1,4 @@
+---
+single: 350
+couple: 500
+parent: 500

--- a/lib/data/benefit_cap_data.yml
+++ b/lib/data/benefit_cap_data.yml
@@ -3,6 +3,15 @@ rates:
   single: 350
   couple: 500
   parent: 500
+exempt_benefits:
+  - Attendance Allowance
+  - Disability Living Allowance
+  - Industrial Injuries Benefit
+  - Personal Independence Payment
+  - Employment and Support Allowance (support component)
+  - War Widow’s or War Widower’s Pension
+  - Armed Forces Compensation Scheme
+  - Armed Forces Independence Payment
 benefits:
   bereavement:
     question: :bereavement_amount?

--- a/lib/graph_presenter.rb
+++ b/lib/graph_presenter.rb
@@ -1,4 +1,5 @@
 class GraphPresenter
+  EXEMPTIONS_LIST = ['benefit-cap-calculator']
   def initialize(flow)
     @flow = flow
   end
@@ -28,7 +29,11 @@ class GraphPresenter
 
   def visualisable?
     @flow.questions.all? do |node|
-      node.permitted_next_nodes.any?
+      if EXEMPTIONS_LIST.include?(@flow.name)
+        true
+      else
+        node.permitted_next_nodes.any?
+      end
     end
   end
 

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -1,7 +1,19 @@
 module SmartAnswer::Calculators
   class BenefitCapCalculatorConfiguration
-    def weekly_benefit_cap
-      @weekly_benefit_cap ||= data.fetch("weekly_benefit_cap").with_indifferent_access
+    def weekly_benefit_caps
+      @weekly_benefit_caps ||= data.fetch("weekly_benefit_caps").with_indifferent_access
+    end
+
+    def weekly_benefit_cap_descriptions
+      @weekly_benefit_cap_descriptions ||=
+        weekly_benefit_caps.inject(HashWithIndifferentAccess.new) do |weekly_benefit_cap_description, (key, value)|
+          weekly_benefit_cap_description[key] = value.fetch("description")
+          weekly_benefit_cap_description
+        end
+    end
+
+    def weekly_benefit_cap_amount(family_type)
+      weekly_benefit_caps.fetch(family_type)["amount"]
     end
 
     def benefits

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -1,9 +1,5 @@
 module SmartAnswer::Calculators
   class BenefitCapCalculatorConfiguration
-    def data
-      @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
-    end
-
     def weekly_benefit_cap
       @weekly_benefit_cap ||= data.fetch("weekly_benefit_cap").with_indifferent_access
     end
@@ -30,6 +26,12 @@ module SmartAnswer::Calculators
           benefits_and_descriptions[key] = value.fetch("description")
           benefits_and_descriptions
         end
+    end
+
+  private
+
+    def data
+      @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
     end
   end
 end

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -1,5 +1,5 @@
 module SmartAnswer::Calculators
-  class BenefitCapCalculatorDataQuery
+  class BenefitCapCalculatorConfiguration
     def data
       @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
     end

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -12,6 +12,10 @@ module SmartAnswer::Calculators
       @benefits ||= data.fetch("benefits").with_indifferent_access
     end
 
+    def exempt_benefits
+      @exempt_benefits ||= data.fetch("exempt_benefits")
+    end
+
     def questions
       @questions ||=
         benefits.inject(HashWithIndifferentAccess.new) do |benefits_and_questions, (key, value)|

--- a/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
@@ -1,8 +1,28 @@
 module SmartAnswer::Calculators
   class BenefitCapCalculatorDataQuery
-    attr_reader :data
+    attr_reader :data, :benefits, :questions
     def data
       @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
+    end
+
+    def benefits
+      @benefits ||=  @data.fetch("benefits").with_indifferent_access
+    end
+
+    def questions
+      @questions ||=
+        benefits.inject(HashWithIndifferentAccess.new) do |benefits_and_questions, (key, value)|
+          benefits_and_questions[key] = value.fetch("question")
+          benefits_and_questions
+        end
+    end
+
+    def descriptions
+      @descriptions ||=
+        benefits.inject(HashWithIndifferentAccess.new) do |benefits_and_descriptions, (key, value)|
+          benefits_and_descriptions[key] = value.fetch("description")
+          benefits_and_descriptions
+        end
     end
   end
 end

--- a/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
@@ -1,12 +1,15 @@
 module SmartAnswer::Calculators
   class BenefitCapCalculatorDataQuery
-    attr_reader :data, :benefits, :questions
     def data
       @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
     end
 
+    def rates
+      @rates ||= data.fetch("rates")
+    end
+
     def benefits
-      @benefits ||=  @data.fetch("benefits").with_indifferent_access
+      @benefits ||= data.fetch("benefits").with_indifferent_access
     end
 
     def questions

--- a/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
@@ -5,7 +5,7 @@ module SmartAnswer::Calculators
     end
 
     def rates
-      @rates ||= data.fetch("rates")
+      @rates ||= data.fetch("rates").with_indifferent_access
     end
 
     def benefits

--- a/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
@@ -4,8 +4,8 @@ module SmartAnswer::Calculators
       @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
     end
 
-    def rates
-      @rates ||= data.fetch("rates").with_indifferent_access
+    def weekly_benefit_cap
+      @weekly_benefit_cap ||= data.fetch("weekly_benefit_cap").with_indifferent_access
     end
 
     def benefits

--- a/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_data_query.rb
@@ -1,0 +1,8 @@
+module SmartAnswer::Calculators
+  class BenefitCapCalculatorDataQuery
+    attr_reader :data
+    def data
+      @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
+    end
+  end
+end

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -109,9 +109,9 @@ module SmartAnswer
 
       #Q6
       multiple_choice :single_couple_lone_parent? do
-        option :single
-        option :couple
-        option :parent
+        query.rates.keys.each do |rate|
+          option rate
+        end
 
         calculate :benefit_cap do |response|
           sprintf("%.2f", query.rates.fetch(response))

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -7,7 +7,7 @@ module SmartAnswer
       satisfies_need "100696"
 
       benefit_cap_query = SmartAnswer::Calculators::BenefitCapCalculatorDataQuery.new
-      benefit_cap_data = benefit_cap_query.data
+      benefit_cap_rates = benefit_cap_query.data.fetch('rates')
 
       # Q1
       multiple_choice :receive_housing_benefit? do
@@ -522,11 +522,11 @@ module SmartAnswer
         option :parent
 
         calculate :benefit_cap do |response|
-          sprintf("%.2f", benefit_cap_data.fetch(response))
+          sprintf("%.2f", benefit_cap_rates.fetch(response))
         end
 
         next_node do |response|
-          if total_benefits > benefit_cap_data.fetch(response)
+          if total_benefits > benefit_cap_rates.fetch(response)
             outcome :outcome_affected_greater_than_cap
           else
             outcome :outcome_not_affected_less_than_cap

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -43,6 +43,13 @@ module SmartAnswer
         option :yes
         option :no
 
+        precalculate :exempt_benefits do
+          exempt_benefits = query.data.fetch("exempt_benefits").map do |exempt_benefit|
+            "- #{exempt_benefit}"
+          end
+          exempt_benefits.join("\n")
+        end
+
         next_node do |response|
           if response == 'yes'
             outcome :outcome_not_affected_exemptions

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -8,7 +8,6 @@ module SmartAnswer
 
       query = Calculators::BenefitCapCalculatorDataQuery.new
       rates = query.data.fetch('rates')
-      benefits = query.data.fetch('benefits').with_indifferent_access
 
       # Q1
       multiple_choice :receive_housing_benefit? do
@@ -56,8 +55,8 @@ module SmartAnswer
 
       #Q4
       checkbox_question :receiving_non_exemption_benefits? do
-        benefits.keys.each do |benefit|
-          option benefit.to_sym
+        query.benefits.keys.each do |benefit|
+          option benefit
         end
 
         next_node_calculation :benefit_types do |response|
@@ -76,13 +75,13 @@ module SmartAnswer
           if response == "none"
             outcome :outcome_not_affected
           else
-            question BenefitCapCalculatorFlow.next_benefit_amount_question(benefits, benefit_types)
+            question BenefitCapCalculatorFlow.next_benefit_amount_question(query.questions, benefit_types)
           end
         end
       end
 
       #Q5a-o
-      benefits.each do |(benefit,method)|
+      query.questions.each do |(_benefit, method)|
         money_question method do
 
           calculate :total_benefits do |response|
@@ -90,7 +89,7 @@ module SmartAnswer
           end
 
           next_node do
-            question BenefitCapCalculatorFlow.next_benefit_amount_question(benefits, benefit_types)
+            question BenefitCapCalculatorFlow.next_benefit_amount_question(query.questions, benefit_types)
           end
         end
       end
@@ -175,6 +174,7 @@ module SmartAnswer
       ## Outcome 5
       outcome :outcome_not_affected
     end
+
     def self.next_benefit_amount_question(benefits, selected_benefits)
       benefits.fetch(selected_benefits.shift, :housing_benefit_amount?)
     end

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -44,7 +44,7 @@ module SmartAnswer
         option :no
 
         precalculate :exempt_benefits do
-          exempt_benefits = config.data.fetch("exempt_benefits").map do |exempt_benefit|
+          exempt_benefits = config.exempt_benefits.map do |exempt_benefit|
             "- #{exempt_benefit}"
           end
           exempt_benefits.join("\n")

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -76,12 +76,12 @@ module SmartAnswer
           if response == "none"
             outcome :outcome_not_affected
           else
-            question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
+            question BenefitCapCalculatorFlow.next_benefit_amount_question(benefits, benefit_types)
           end
         end
       end
 
-      #Q5a
+      #Q5a-o
       benefits.each do |(benefit,method)|
         money_question method do
 
@@ -90,7 +90,7 @@ module SmartAnswer
           end
 
           next_node do
-            question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
+            question BenefitCapCalculatorFlow.next_benefit_amount_question(benefits, benefit_types)
           end
         end
       end
@@ -174,6 +174,9 @@ module SmartAnswer
 
       ## Outcome 5
       outcome :outcome_not_affected
+    end
+    def self.next_benefit_amount_question(benefits, selected_benefits)
+      benefits.fetch(selected_benefits.shift, :housing_benefit_amount?)
     end
   end
 end

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -7,7 +7,6 @@ module SmartAnswer
       satisfies_need "100696"
 
       query = Calculators::BenefitCapCalculatorDataQuery.new
-      rates = query.data.fetch('rates')
 
       # Q1
       multiple_choice :receive_housing_benefit? do
@@ -115,11 +114,11 @@ module SmartAnswer
         option :parent
 
         calculate :benefit_cap do |response|
-          sprintf("%.2f", rates.fetch(response))
+          sprintf("%.2f", query.rates.fetch(response))
         end
 
         next_node do |response|
-          if total_benefits > rates.fetch(response)
+          if total_benefits > query.rates.fetch(response)
             outcome :outcome_affected_greater_than_cap
           else
             outcome :outcome_not_affected_less_than_cap

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -117,16 +117,20 @@ module SmartAnswer
 
       #Q6
       multiple_choice :single_couple_lone_parent? do
-        config.weekly_benefit_cap.keys.each do |rate|
-          option rate
+        precalculate :weekly_benefit_cap_descriptions do
+          config.weekly_benefit_cap_descriptions
+        end
+
+        config.weekly_benefit_caps.keys.each do |weekly_benefit_cap|
+          option weekly_benefit_cap
         end
 
         calculate :benefit_cap do |response|
-          sprintf("%.2f", config.weekly_benefit_cap.fetch(response))
+          sprintf("%.2f", config.weekly_benefit_cap_amount(response))
         end
 
         next_node do |response|
-          if total_benefits > config.weekly_benefit_cap.fetch(response)
+          if total_benefits > config.weekly_benefit_cap_amount(response)
             outcome :outcome_affected_greater_than_cap
           else
             outcome :outcome_not_affected_less_than_cap

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -6,8 +6,9 @@ module SmartAnswer
       status :published
       satisfies_need "100696"
 
-      benefit_cap_query = SmartAnswer::Calculators::BenefitCapCalculatorDataQuery.new
-      benefit_cap_rates = benefit_cap_query.data.fetch('rates')
+      query = Calculators::BenefitCapCalculatorDataQuery.new
+      rates = query.data.fetch('rates')
+      benefits = query.data.fetch('benefits')
 
       # Q1
       multiple_choice :receive_housing_benefit? do
@@ -55,21 +56,9 @@ module SmartAnswer
 
       #Q4
       checkbox_question :receiving_non_exemption_benefits? do
-        option :bereavement
-        option :carers
-        option :child_benefit
-        option :child_tax
-        option :esa
-        option :guardian
-        option :incapacity
-        option :income_support
-        option :jsa
-        option :maternity
-        option :sda
-        option :widowed_mother
-        option :widowed_parent
-        option :widow_pension
-        option :widows_aged
+        benefits.each do |benefit|
+          option benefit.to_sym
+        end
 
         next_node_calculation :benefit_types do |response|
           response.split(",").map(&:to_sym)
@@ -522,11 +511,11 @@ module SmartAnswer
         option :parent
 
         calculate :benefit_cap do |response|
-          sprintf("%.2f", benefit_cap_rates.fetch(response))
+          sprintf("%.2f", rates.fetch(response))
         end
 
         next_node do |response|
-          if total_benefits > benefit_cap_rates.fetch(response)
+          if total_benefits > rates.fetch(response)
             outcome :outcome_affected_greater_than_cap
           else
             outcome :outcome_not_affected_less_than_cap

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -44,10 +44,7 @@ module SmartAnswer
         option :no
 
         precalculate :exempt_benefits do
-          exempt_benefits = config.exempt_benefits.map do |exempt_benefit|
-            "- #{exempt_benefit}"
-          end
-          exempt_benefits.join("\n")
+          config.exempt_benefits
         end
 
         next_node do |response|

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -120,16 +120,16 @@ module SmartAnswer
 
       #Q6
       multiple_choice :single_couple_lone_parent? do
-        query.rates.keys.each do |rate|
+        query.weekly_benefit_cap.keys.each do |rate|
           option rate
         end
 
         calculate :benefit_cap do |response|
-          sprintf("%.2f", query.rates.fetch(response))
+          sprintf("%.2f", query.weekly_benefit_cap.fetch(response))
         end
 
         next_node do |response|
-          if total_benefits > query.rates.fetch(response)
+          if total_benefits > query.weekly_benefit_cap.fetch(response)
             outcome :outcome_affected_greater_than_cap
           else
             outcome :outcome_not_affected_less_than_cap

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -8,7 +8,7 @@ module SmartAnswer
 
       query = Calculators::BenefitCapCalculatorDataQuery.new
       rates = query.data.fetch('rates')
-      benefits = query.data.fetch('benefits')
+      benefits = query.data.fetch('benefits').with_indifferent_access
 
       # Q1
       multiple_choice :receive_housing_benefit? do
@@ -76,29 +76,7 @@ module SmartAnswer
           if response == "none"
             outcome :outcome_not_affected
           else
-            case benefit_types.shift
-            when :bereavement then question :bereavement_amount?
-            when :carers then question :carers_amount?
-            when :child_benefit then question :child_benefit_amount?
-            when :child_tax then question :child_tax_amount?
-            when :esa then question :esa_amount?
-            when :guardian then question :guardian_amount?
-            when :incapacity then question :incapacity_amount?
-            when :income_support then question :income_support_amount?
-            when :jsa then question :jsa_amount?
-            when :maternity then question :maternity_amount?
-            when :sda then question :sda_amount?
-            when :widowed_mother then question :widowed_mother_amount?
-            when :widowed_parent then question :widowed_parent_amount?
-            when :widow_pension then question :widow_pension_amount?
-            when :widows_aged then question :widows_aged_amount?
-            else
-              if housing_benefit == 'yes'
-                question :housing_benefit_amount?
-              else
-                question :single_couple_lone_parent?
-              end
-            end
+           question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
           end
         end
       end
@@ -111,28 +89,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :carers then question :carers_amount?
-          when :child_benefit then question :child_benefit_amount?
-          when :child_tax then question :child_tax_amount?
-          when :esa then question :esa_amount?
-          when :guardian then question :guardian_amount?
-          when :incapacity then question :incapacity_amount?
-          when :income_support then question :income_support_amount?
-          when :jsa then question :jsa_amount?
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -144,27 +101,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :child_benefit then question :child_benefit_amount?
-          when :child_tax then question :child_tax_amount?
-          when :esa then question :esa_amount?
-          when :guardian then question :guardian_amount?
-          when :incapacity then question :incapacity_amount?
-          when :income_support then question :income_support_amount?
-          when :jsa then question :jsa_amount?
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -176,26 +113,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :child_tax then question :child_tax_amount?
-          when :esa then question :esa_amount?
-          when :guardian then question :guardian_amount?
-          when :incapacity then question :incapacity_amount?
-          when :income_support then question :income_support_amount?
-          when :jsa then question :jsa_amount?
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -207,25 +125,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :esa then question :esa_amount?
-          when :guardian then question :guardian_amount?
-          when :incapacity then question :incapacity_amount?
-          when :income_support then question :income_support_amount?
-          when :jsa then question :jsa_amount?
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -237,24 +137,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :guardian then question :guardian_amount?
-          when :incapacity then question :incapacity_amount?
-          when :income_support then question :income_support_amount?
-          when :jsa then question :jsa_amount?
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -266,23 +149,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :incapacity then question :incapacity_amount?
-          when :income_support then question :income_support_amount?
-          when :jsa then question :jsa_amount?
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -294,22 +161,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :income_support then question :income_support_amount?
-          when :jsa then question :jsa_amount?
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -321,21 +173,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :jsa then question :jsa_amount?
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -347,20 +185,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :maternity then question :maternity_amount?
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -372,19 +197,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :sda then question :sda_amount?
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -396,18 +209,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widow_pension then question :widow_pension_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -419,17 +221,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :widowed_mother then question :widowed_mother_amount?
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -441,16 +233,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :widowed_parent then question :widowed_parent_amount?
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -462,15 +245,7 @@ module SmartAnswer
         end
 
         next_node do
-          case benefit_types.shift
-          when :widows_aged then question :widows_aged_amount?
-          else
-            if housing_benefit == 'yes'
-              question :housing_benefit_amount?
-            else
-              question :single_couple_lone_parent?
-            end
-          end
+          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
         end
       end
 
@@ -482,11 +257,7 @@ module SmartAnswer
         end
 
         next_node do
-          if housing_benefit == 'yes'
-            question :housing_benefit_amount?
-          else
-            question :single_couple_lone_parent?
-          end
+          question :housing_benefit_amount?
         end
       end
 

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -62,6 +62,10 @@ module SmartAnswer
           response.split(",").map(&:to_sym)
         end
 
+        precalculate :benefit_options do
+          query.descriptions.merge(none_above: "None of the above")
+        end
+
         calculate :total_benefits do
           0
         end

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -6,6 +6,9 @@ module SmartAnswer
       status :published
       satisfies_need "100696"
 
+      benefit_cap_query = SmartAnswer::Calculators::BenefitCapCalculatorDataQuery.new
+      benefit_cap_data = benefit_cap_query.data
+
       # Q1
       multiple_choice :receive_housing_benefit? do
         option :yes
@@ -519,22 +522,11 @@ module SmartAnswer
         option :parent
 
         calculate :benefit_cap do |response|
-          if response == 'single'
-            benefit_cap = 350
-          else
-            benefit_cap = 500
-          end
-          sprintf("%.2f", benefit_cap)
+          sprintf("%.2f", benefit_cap_data.fetch(response))
         end
 
         next_node do |response|
-          if response == 'single'
-            cap = 350
-          else
-            cap = 500
-          end
-
-          if total_benefits > cap
+          if total_benefits > benefit_cap_data.fetch(response)
             outcome :outcome_affected_greater_than_cap
           else
             outcome :outcome_not_affected_less_than_cap

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -141,7 +141,11 @@ module SmartAnswer
       ##OUTCOMES
 
       ## Outcome 1
-      outcome :outcome_not_affected_exemptions
+      outcome :outcome_not_affected_exemptions do
+        precalculate :exempt_benefits do
+          config.exempt_benefits
+        end
+      end
 
       ## Outcome 2
       outcome :outcome_not_affected_no_housing_benefit

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -76,188 +76,22 @@ module SmartAnswer
           if response == "none"
             outcome :outcome_not_affected
           else
-           question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
+            question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
           end
         end
       end
 
       #Q5a
-      money_question :bereavement_amount? do
+      benefits.each do |(benefit,method)|
+        money_question method do
 
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
+          calculate :total_benefits do |response|
+            total_benefits + response.to_f
+          end
 
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5b
-      money_question :carers_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5c
-      money_question :child_benefit_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5d
-      money_question :child_tax_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5e
-      money_question :esa_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5f
-      money_question :guardian_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5g
-      money_question :incapacity_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5h
-      money_question :income_support_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5i
-      money_question :jsa_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5j
-      money_question :maternity_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5k
-      money_question :sda_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5n
-      money_question :widow_pension_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5l
-      money_question :widowed_mother_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5m
-      money_question :widowed_parent_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
-        end
-      end
-
-      #Q5o
-      money_question :widows_aged_amount? do
-
-        calculate :total_benefits do |response|
-          total_benefits + response.to_f
-        end
-
-        next_node do
-          question :housing_benefit_amount?
+          next_node do
+            question benefits.fetch(benefit_types.shift, :housing_benefit_amount?)
+          end
         end
       end
 

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -56,7 +56,7 @@ module SmartAnswer
 
       #Q4
       checkbox_question :receiving_non_exemption_benefits? do
-        benefits.each do |benefit|
+        benefits.keys.each do |benefit|
           option benefit.to_sym
         end
 

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.govspeak.erb
@@ -5,15 +5,9 @@
 <% content_for :body do %>
   These benefits are exempt from the benefit cap:
 
-  - Attendance Allowance
-  - Disability Living Allowance
-  - Industrial Injuries Benefit
-  - Personal Independence Payment
-  - Employment and Support Allowance (support component)
-  - War Widow’s or War Widower’s Pension
-  - Working Tax Credit
-  - Armed Forces Compensation Scheme
-  - Armed Forces Independence Payment
+  <% exempt_benefits.each do |exempt_benefit| %>
+     - <%= exempt_benefit %>
+  <% end %>
 
   You may be affected by the cap if your circumstances change.
 

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.govspeak.erb
@@ -5,6 +5,7 @@
 <% content_for :body do %>
   These benefits are exempt from the benefit cap:
 
+- Working Tax Credit
   <% exempt_benefits.each do |exempt_benefit| %>
      - <%= exempt_benefit %>
   <% end %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Do you or someone in your household get any of the following benefits:
+  Do you or someone in your household get any of the following benefits?
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb
@@ -8,6 +8,7 @@
 ) %>
 
 <% content_for :body do %>
-  <%= exempt_benefits %>
-
+  <% exempt_benefits.each do |exempt_benefit| %>
+     - <%= exempt_benefit %>
+  <% end %>
 <% end %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb
@@ -8,13 +8,6 @@
 ) %>
 
 <% content_for :body do %>
-  - Attendance Allowance
-  - Disability Living Allowance
-  - Industrial Injuries Benefit
-  - Personal Independence Payment
-  - Employment and Support Allowance (support component)
-  - War Widow’s or War Widower’s Pension
-  - Armed Forces Compensation Scheme
-  - Armed Forces Independence Payment
+  <%= exempt_benefits %>
 
 <% end %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.govspeak.erb
@@ -2,24 +2,7 @@
   Do you or someone in your household get any of the following benefits:
 <% end %>
 
-<% options(
-  "bereavement": "Bereavement Allowance",
-  "carers": "Carer's Allowance",
-  "child_benefit": "Child Benefit",
-  "child_tax": "Child Tax Credit",
-  "esa": "Employment and Support Allowance",
-  "guardian": "Guardian's Allowance",
-  "incapacity": "Incapacity Benefit",
-  "income_support": "Income Support",
-  "jsa": "Jobseeker’s Allowance",
-  "maternity": "Maternity Allowance",
-  "sda": "Severe Disablement Allowance",
-  "widowed_mother": "Widowed Mother's Allowance",
-  "widowed_parent": "Widowed Parent's Allowance",
-  "widow_pension": "Widow's Pension",
-  "widows_aged": "Widow's Pension (age related)",
-  "none_above": "None of the above"
-) %>
+<% options(benefit_options) %>
 
 <% content_for :hint do %>
   If you do not receive any of these click Next step.

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.govspeak.erb
@@ -1,9 +1,9 @@
 <% content_for :title do %>
-  Do you or someone in your household get any of the following benefits:
+  Do you or someone in your household get any of the following benefits?
 <% end %>
 
 <% options(benefit_options) %>
 
 <% content_for :hint do %>
-  If you do not receive any of these click Next step.
+  If you do not receive any of these click 'Next step'.
 <% end %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.govspeak.erb
@@ -2,8 +2,4 @@
   Are you:
 <% end %>
 
-<% options(
-  "single": "Single",
-  "couple": "Living as a couple (with or without children)",
-  "parent": "A lone parent with 1 or more dependent children"
-) %>
+<% options(weekly_benefit_cap_descriptions) %>

--- a/test/artefacts/benefit-cap-calculator/yes/no.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no.html
@@ -32,7 +32,7 @@
         <div class="current-question" id="current-question">
           <div class="question">
   <h2>
-    Do you or someone in your household get any of the following benefits:
+    Do you or someone in your household get any of the following benefits?
   </h2>
   <div class="question-body">
       <article role="article">
@@ -46,7 +46,6 @@
   <li>Armed Forces Compensation Scheme</li>
   <li>Armed Forces Independence Payment</li>
 </ul>
-
 
       </article>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no.html
@@ -32,11 +32,11 @@
         <div class="current-question" id="current-question">
           <div class="question">
   <h2>
-    Do you or someone in your household get any of the following benefits:
+    Do you or someone in your household get any of the following benefits?
   </h2>
   <div class="question-body">
 
-      <p class="hint">If you do not receive any of these click Next step.</p>
+      <p class="hint">If you do not receive any of these click 'Next step'.</p>
 
     <div class="">
 
@@ -179,13 +179,13 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.html
@@ -88,18 +88,18 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
       <li>Carer's Allowance</li>
@@ -120,7 +120,7 @@
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement.html
@@ -88,25 +88,25 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
     </ul></td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.html
@@ -106,25 +106,25 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
     </ul></td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.html
@@ -88,25 +88,25 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+  <td class="previous-question-title">Do you or someone in your household get any of the following benefits?</td>
     <td class="previous-question-body"><ul>
       <li>Bereavement Allowance</li>
     </ul></td>
 
   <td class="link-right">
     <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement">
-      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+      Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits?"</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/yes.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/yes.txt
@@ -2,13 +2,13 @@ Based on the answers you’ve given, you’re not affected by the benefit cap.
 
 These benefits are exempt from the benefit cap:
 
+- Working Tax Credit
 - Attendance Allowance
 - Disability Living Allowance
 - Industrial Injuries Benefit
 - Personal Independence Payment
 - Employment and Support Allowance (support component)
 - War Widow’s or War Widower’s Pension
-- Working Tax Credit
 - Armed Forces Compensation Scheme
 - Armed Forces Independence Payment
 

--- a/test/artefacts/benefit-cap-calculator/yes/yes.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/yes.txt
@@ -2,13 +2,13 @@ Based on the answers you’ve given, you’re not affected by the benefit cap.
 
 These benefits are exempt from the benefit cap:
 
+- Working Tax Credit
 - Attendance Allowance
 - Disability Living Allowance
 - Industrial Injuries Benefit
 - Personal Independence Payment
 - Employment and Support Allowance (support component)
 - War Widow’s or War Widower’s Pension
-- Working Tax Credit
 - Armed Forces Compensation Scheme
 - Armed Forces Independence Payment
 

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/benefit-cap-calculator.rb: 0b1c62ec76e9631a9d6f143f568e37d6
+lib/smart_answer_flows/benefit-cap-calculator.rb: cb6ca31f68c9d5919eb44ba7a0281112
 test/data/benefit-cap-calculator-questions-and-responses.yml: b608788e9eb18ad20a066de99259aa84
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 497ab9a2846c8821e61ac28c5b0d6cc1
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: ce5203f11989c0b35bd9c53ade1f3f82
@@ -21,8 +21,8 @@ lib/smart_answer_flows/benefit-cap-calculator/questions/income_support_amount.go
 lib/smart_answer_flows/benefit-cap-calculator/questions/jsa_amount.govspeak.erb: 6178e32ef153b9f37ce489627873c531
 lib/smart_answer_flows/benefit-cap-calculator/questions/maternity_amount.govspeak.erb: 596e15e7ae07174ca4a5b0ca179df8c0
 lib/smart_answer_flows/benefit-cap-calculator/questions/receive_housing_benefit.govspeak.erb: d5eaf64a3eac78bfc0924f6a4ea3030d
-lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb: 3f8e2ee47d98237b298928c1fafbf6dd
-lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.govspeak.erb: 10a438915174d1299f43899c5e2195f0
+lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb: 1b4a1249a14c571f5f7eccdc78aa5a0c
+lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.govspeak.erb: fad8d70cba53ac825fffe27d3f8b16a7
 lib/smart_answer_flows/benefit-cap-calculator/questions/sda_amount.govspeak.erb: db8c57855d8f2f87c060dbd28f6ce4da
 lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.govspeak.erb: dc69d7ba86c9ecc50cc78405e0489510
 lib/smart_answer_flows/benefit-cap-calculator/questions/widow_pension_amount.govspeak.erb: 4facc5d491b403d2e87b6672b2ac5f96

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/benefit-cap-calculator.rb: 5b902a5cc714be91ab6a023530c0b4c9
+lib/smart_answer_flows/benefit-cap-calculator.rb: 80f67946d651afffaad3a7ace78cbc20
 test/data/benefit-cap-calculator-questions-and-responses.yml: b608788e9eb18ad20a066de99259aa84
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 497ab9a2846c8821e61ac28c5b0d6cc1
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: ce5203f11989c0b35bd9c53ade1f3f82

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/benefit-cap-calculator.rb: cb6ca31f68c9d5919eb44ba7a0281112
+lib/smart_answer_flows/benefit-cap-calculator.rb: 5b902a5cc714be91ab6a023530c0b4c9
 test/data/benefit-cap-calculator-questions-and-responses.yml: b608788e9eb18ad20a066de99259aa84
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 497ab9a2846c8821e61ac28c5b0d6cc1
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: ce5203f11989c0b35bd9c53ade1f3f82

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,12 +1,12 @@
 ---
-lib/smart_answer_flows/benefit-cap-calculator.rb: 797b085cb6418b6708160b92ee3f84b7
+lib/smart_answer_flows/benefit-cap-calculator.rb: 64caee85b1b23bbdc9f5af5219af152e
 test/data/benefit-cap-calculator-questions-and-responses.yml: b608788e9eb18ad20a066de99259aa84
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 497ab9a2846c8821e61ac28c5b0d6cc1
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: ce5203f11989c0b35bd9c53ade1f3f82
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb: 3bab6f0d1df0457dbf0ff7548150ba4f
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap.govspeak.erb: cafd15b3ab7a6cc4931a8410529c76ff
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected.govspeak.erb: 4dc17c29820007d202f8d59723de2892
-lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.govspeak.erb: 65323901126c376f34208df0e803175b
+lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.govspeak.erb: 41d68ee32bba9ebe50e60bc6dc4929b5
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_less_than_cap.govspeak.erb: 547dc8a354a8b1aa74de1340c527fc0d
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_no_housing_benefit.govspeak.erb: b30dc987dd60f9ec355cdb6e2903a4b8
 lib/smart_answer_flows/benefit-cap-calculator/questions/bereavement_amount.govspeak.erb: 8e07bb3bfc158ee2cc2af5a705eac587
@@ -21,10 +21,10 @@ lib/smart_answer_flows/benefit-cap-calculator/questions/income_support_amount.go
 lib/smart_answer_flows/benefit-cap-calculator/questions/jsa_amount.govspeak.erb: 6178e32ef153b9f37ce489627873c531
 lib/smart_answer_flows/benefit-cap-calculator/questions/maternity_amount.govspeak.erb: 596e15e7ae07174ca4a5b0ca179df8c0
 lib/smart_answer_flows/benefit-cap-calculator/questions/receive_housing_benefit.govspeak.erb: d5eaf64a3eac78bfc0924f6a4ea3030d
-lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb: 1b4a1249a14c571f5f7eccdc78aa5a0c
-lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.govspeak.erb: fad8d70cba53ac825fffe27d3f8b16a7
+lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.govspeak.erb: 55b55fb2efb3a96ccb31ecca6427539d
+lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.govspeak.erb: 8d0fe6ac62cae963d35b674f996375d1
 lib/smart_answer_flows/benefit-cap-calculator/questions/sda_amount.govspeak.erb: db8c57855d8f2f87c060dbd28f6ce4da
-lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.govspeak.erb: dc69d7ba86c9ecc50cc78405e0489510
+lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.govspeak.erb: edbfa6496d8191e1ccfd3608e12585c7
 lib/smart_answer_flows/benefit-cap-calculator/questions/widow_pension_amount.govspeak.erb: 4facc5d491b403d2e87b6672b2ac5f96
 lib/smart_answer_flows/benefit-cap-calculator/questions/widowed_mother_amount.govspeak.erb: 7a6a57d92c0461042875c4064e55ae39
 lib/smart_answer_flows/benefit-cap-calculator/questions/widowed_parent_amount.govspeak.erb: 7355088c4cbc00513807d90b1930ff5c

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/benefit-cap-calculator.rb: 80f67946d651afffaad3a7ace78cbc20
+lib/smart_answer_flows/benefit-cap-calculator.rb: 797b085cb6418b6708160b92ee3f84b7
 test/data/benefit-cap-calculator-questions-and-responses.yml: b608788e9eb18ad20a066de99259aa84
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 497ab9a2846c8821e61ac28c5b0d6cc1
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: ce5203f11989c0b35bd9c53ade1f3f82

--- a/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
@@ -31,6 +31,12 @@ module SmartAnswer::Calculators
           assert_kind_of Hash, @config.descriptions
         end
       end
+
+      context "exempt_benefits" do
+        should "contain an entry for Disability Living Allowance" do
+          assert_includes @config.exempt_benefits, "Disability Living Allowance"
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
@@ -7,15 +7,15 @@ module SmartAnswer::Calculators
         @config = BenefitCapCalculatorConfiguration.new
       end
 
-      context "weekly_benefit_cap" do
+      context "weekly_benefit_caps" do
         should "be £350 for a single person" do
-          assert_equal 350, @config.weekly_benefit_cap["single"]
+          assert_equal 350, @config.weekly_benefit_cap_amount("single")
         end
         should "be £500 for a couple with or without children" do
-          assert_equal 500, @config.weekly_benefit_cap["couple"]
+          assert_equal 500, @config.weekly_benefit_cap_amount("couple")
         end
         should "be £500 for a lone parent" do
-          assert_equal 500, @config.weekly_benefit_cap["parent"]
+          assert_equal 500, @config.weekly_benefit_cap_amount("parent")
         end
       end
 

--- a/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
@@ -1,34 +1,34 @@
 require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
-  class BenefitCapCalculatorDataQueryTest < ActiveSupport::TestCase
-    context BenefitCapCalculatorDataQuery do
+  class BenefitCapCalculatorConfigurationTest < ActiveSupport::TestCase
+    context BenefitCapCalculatorConfiguration do
       setup do
-        @query = BenefitCapCalculatorDataQuery.new
+        @config = BenefitCapCalculatorConfiguration.new
       end
 
       context "weekly_benefit_cap" do
         should "be £350 for a single person" do
-          assert_equal 350, @query.weekly_benefit_cap["single"]
+          assert_equal 350, @config.weekly_benefit_cap["single"]
         end
         should "be £500 for a couple with or without children" do
-          assert_equal 500, @query.weekly_benefit_cap["couple"]
+          assert_equal 500, @config.weekly_benefit_cap["couple"]
         end
         should "be £500 for a lone parent" do
-          assert_equal 500, @query.weekly_benefit_cap["parent"]
+          assert_equal 500, @config.weekly_benefit_cap["parent"]
         end
       end
 
       context "benefit type data" do
         should "have a question and description for each benefit type" do
-          assert_equal :jsa_amount?, @query.benefits.fetch("jsa")["question"]
-          assert_equal "Jobseeker’s Allowance", @query.benefits.fetch("jsa")["description"]
+          assert_equal :jsa_amount?, @config.benefits.fetch("jsa")["question"]
+          assert_equal "Jobseeker’s Allowance", @config.benefits.fetch("jsa")["description"]
         end
         should "be able get a hash of just benefits and questions" do
-          assert_kind_of Hash, @query.questions
+          assert_kind_of Hash, @config.questions
         end
         should "be able get a hash of just benefits and descriptions" do
-          assert_kind_of Hash, @query.descriptions
+          assert_kind_of Hash, @config.descriptions
         end
       end
     end

--- a/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
@@ -19,8 +19,8 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "benefit type data" do
-        should "have a question and description for each benefit type" do
+      context "benefits data" do
+        should "have a question and description for each benefit" do
           assert_equal :jsa_amount?, @config.benefits.fetch("jsa")["question"]
           assert_equal "Jobseeker’s Allowance", @config.benefits.fetch("jsa")["description"]
         end

--- a/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
@@ -4,19 +4,20 @@ module SmartAnswer::Calculators
   class BenefitCapCalculatorDataQueryTest < ActiveSupport::TestCase
     context BenefitCapCalculatorDataQuery do
       setup do
-        @query = BenefitCapCalculatorDataQuery.new
+        query = BenefitCapCalculatorDataQuery.new
+        @rates = query.data.fetch("rates")
       end
 
       context "benefit_cap_data" do
         context "family types" do
           should "contain value for single person" do
-            assert_equal 350, @query.data["single"]
+            assert_equal 350, @rates["single"]
           end
           should "contain value for a couple with or without children" do
-            assert_equal 500, @query.data["couple"]
+            assert_equal 500, @rates["couple"]
           end
           should "contain value for lone parent" do
-            assert_equal 500, @query.data["parent"]
+            assert_equal 500, @rates["parent"]
           end
         end
       end

--- a/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
@@ -7,17 +7,15 @@ module SmartAnswer::Calculators
         @query = BenefitCapCalculatorDataQuery.new
       end
 
-      context "benefit_cap_data" do
-        context "family types" do
-          should "contain value for single person" do
-            assert_equal 350, @query.rates["single"]
-          end
-          should "contain value for a couple with or without children" do
-            assert_equal 500, @query.rates["couple"]
-          end
-          should "contain value for lone parent" do
-            assert_equal 500, @query.rates["parent"]
-          end
+      context "weekly_benefit_cap" do
+        should "be £350 for a single person" do
+          assert_equal 350, @query.weekly_benefit_cap["single"]
+        end
+        should "be £500 for a couple with or without children" do
+          assert_equal 500, @query.weekly_benefit_cap["couple"]
+        end
+        should "be £500 for a lone parent" do
+          assert_equal 500, @query.weekly_benefit_cap["parent"]
         end
       end
 

--- a/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
@@ -5,19 +5,18 @@ module SmartAnswer::Calculators
     context BenefitCapCalculatorDataQuery do
       setup do
         @query = BenefitCapCalculatorDataQuery.new
-        @rates = @query.data.fetch("rates")
       end
 
       context "benefit_cap_data" do
         context "family types" do
           should "contain value for single person" do
-            assert_equal 350, @rates["single"]
+            assert_equal 350, @query.rates["single"]
           end
           should "contain value for a couple with or without children" do
-            assert_equal 500, @rates["couple"]
+            assert_equal 500, @query.rates["couple"]
           end
           should "contain value for lone parent" do
-            assert_equal 500, @rates["parent"]
+            assert_equal 500, @query.rates["parent"]
           end
         end
       end

--- a/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
@@ -4,8 +4,8 @@ module SmartAnswer::Calculators
   class BenefitCapCalculatorDataQueryTest < ActiveSupport::TestCase
     context BenefitCapCalculatorDataQuery do
       setup do
-        query = BenefitCapCalculatorDataQuery.new
-        @rates = query.data.fetch("rates")
+        @query = BenefitCapCalculatorDataQuery.new
+        @rates = @query.data.fetch("rates")
       end
 
       context "benefit_cap_data" do

--- a/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
@@ -21,6 +21,19 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context "benefit type data" do
+        should "have a question and description for each benefit type" do
+          assert_equal :jsa_amount?, @query.benefits.fetch("jsa")["question"]
+          assert_equal "Jobseeker’s Allowance", @query.benefits.fetch("jsa")["description"]
+        end
+        should "be able get a hash of just benefits and questions" do
+          assert_kind_of Hash, @query.questions
+        end
+        should "be able get a hash of just benefits and descriptions" do
+          assert_kind_of Hash, @query.descriptions
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_data_query_test.rb
@@ -1,0 +1,25 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class BenefitCapCalculatorDataQueryTest < ActiveSupport::TestCase
+    context BenefitCapCalculatorDataQuery do
+      setup do
+        @query = BenefitCapCalculatorDataQuery.new
+      end
+
+      context "benefit_cap_data" do
+        context "family types" do
+          should "contain value for single person" do
+            assert_equal 350, @query.data["single"]
+          end
+          should "contain value for a couple with or without children" do
+            assert_equal 500, @query.data["couple"]
+          end
+          should "contain value for lone parent" do
+            assert_equal 500, @query.data["parent"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/smart_answer_flows/benefit_cap_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/benefit_cap_calculator_flow_test.rb
@@ -1,0 +1,27 @@
+require_relative "../../test_helper"
+require "smart_answer_flows/benefit-cap-calculator"
+
+module SmartAnswer
+  class BenefitCapCalculatorFlowTest < ActiveSupport::TestCase
+    context BenefitCapCalculatorFlow do
+      setup do
+        @benefits = {
+          first_benefit: :first_benefit_amount?,
+          second_benefit: :second_benefit_amount?,
+          third_benefit: :third_benefit_amount?,
+          fourth_benefit: :fourth_benefit_amount?
+        }
+
+        @selected_benefits = [:second_benefit, :fourth_benefit]
+      end
+      context "next question" do
+        should "go the the next selected benefit question" do
+          assert_equal :second_benefit_amount?,
+            BenefitCapCalculatorFlow.next_benefit_amount_question(@benefits, @selected_benefits)
+          assert_equal :fourth_benefit_amount?,
+            BenefitCapCalculatorFlow.next_benefit_amount_question(@benefits, @selected_benefits)
+        end
+      end
+    end
+  end
+end

--- a/test/unit/smart_answer_flows/benefit_cap_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/benefit_cap_calculator_flow_test.rb
@@ -5,7 +5,7 @@ module SmartAnswer
   class BenefitCapCalculatorFlowTest < ActiveSupport::TestCase
     context BenefitCapCalculatorFlow do
       setup do
-        @benefits = {
+        @questions = {
           first_benefit: :first_benefit_amount?,
           second_benefit: :second_benefit_amount?,
           third_benefit: :third_benefit_amount?,
@@ -14,12 +14,23 @@ module SmartAnswer
 
         @selected_benefits = [:second_benefit, :fourth_benefit]
       end
-      context "next question" do
-        should "go the the next selected benefit question" do
+
+      context "order of questions asked" do
+        should "ask the next benefit amount question in the selected_benefits list" do
+          # Should ask the first question in the selected benefits list
           assert_equal :second_benefit_amount?,
-            BenefitCapCalculatorFlow.next_benefit_amount_question(@benefits, @selected_benefits)
+            BenefitCapCalculatorFlow.next_benefit_amount_question(@questions, @selected_benefits)
+
+          # The selected benefits list should only contain unasked questions
+          assert_equal [:fourth_benefit], @selected_benefits
+
+          # Should ask the next question in the selected benefits list
           assert_equal :fourth_benefit_amount?,
-            BenefitCapCalculatorFlow.next_benefit_amount_question(@benefits, @selected_benefits)
+            BenefitCapCalculatorFlow.next_benefit_amount_question(@questions, @selected_benefits)
+
+          # After all questions have been asked, there should not be any unasked
+          # questions in selected_benefits
+          assert_equal [], @selected_benefits
         end
       end
     end


### PR DESCRIPTION
Trello Story: https://trello.com/c/LvffB57l/100-refactor-benefit-cap-calculator

## Motivation 

The benefit caps are going to change in the autumn as follows:

1. There will be higher cap for families inside London compared to those outside London.
2. Two benefits that currently affect the cap (Carer's Allowance and Guardian's Allowance) will be exempt.

To prepare the public for the coming changes, the benefit cap calculator needs to be updated to allow the public to check both i.e. what their cap is now and what it will be this autumn when the new caps are implemented to allow them to prepare for it.

 A new question will be need to be added to the beginning of the benefit cap calculator to route users to the correct flow. If users choose to see the new caps, an extra question needs to be added to check their postcode.

A final consideration is that when the new cap go live this autumn, the existing flow will need to be removed, and the new flow will become the only flow.

See Trello Story: https://trello.com/c/IVrsJIfM/34-22-april-requires-fix-but-hold-deployment-benefit-cap-calculator-2016-2017-changes

### Options

When reviewing the code for the benefit-cap-calculator, a few things became apparent:

1. The benefit caps for the different family types (single, couple, parent) are hard-coded.
2. The question and outcome templates for exempt benefits contains a hard-coded list of benefits
3. The template for Question 4, that asks you to select the benefits you are receiving is a hard-coded list.
4. Question 5, that asks you to enter the amount of each benefit you receive, is comprised of 15 case statements. Each case statement has a decreasing list of the next valid benefit amount question that could be asked. This was done to make sure that the questions are asked in the order that they are displayed in the checkbox list.

**Option 1: Duplicate the entire flow**

Have a routing question at the beginning that directs to one of two flow sub classes. The two sub classes would be virtually identical except for the points raised in 1-4 above. i.e. the case statements would need to be edited to change the lists of valid next questions.

All of the flow tests would also have to be duplicated.

We decided that this was inefficient, and could lead to things being missed in the interim if the exempt benefits/benefits that affect the cap change before the new caps are applied.

**Option 2: Assign a flag**

Have a routing question at the beginning that assigns a flag value. This flag holds the value of which flow the user is on. 

Using the flag, something like question 5 would have an if/else added to each case statement to determine whether or not the benefit amount question is valid for that flow.

This option appears messy to implement and even harder to unpick come the autumn.

**Option 3: Read config from a YAML file**

To be inline with existing calculators, this option is to move cap values (rates) into a YAML file. This would make it easier to update the benefit caps in the future when they inevitably change again.

Then we looked at the two lists of benefits (exempt and not exempt) and determined that we could also read those from a YAML file as they are also subject to change by policy.

We decided to go with this option as going forward (after the new caps are applied) it will be easier to make changes to exempt benefits, benefits that affect the cap and cap limits in a YAML file rather than throughout the code base.

## Changes

* Introduce YAML to hold benefit cap data:
   * Rates or Weekly benefits cap (For different family types)
   * Exempt Benefits
   *  Benefits that are affected by the cap

*  Update benefit cap calculator flow to read data from YAML for benefit cap calculator.

*  Refactored Question 5 a to o 
     * Replace hard coded case/switch with dynamic loop driven by data from the YAML.
 
* Updated all affected tests.

## Factcheck 

 Link: https://smart-answers-pr-2452.herokuapp.com/benefit-cap-calculator/
 Link on GOV.UK: https://gov.uk/benefit-cap-calculator/

The [factcheck](https://smart-answers-pr-2452.herokuapp.com/benefit-cap-calculator/) should work exactly the same as [GOV.UK](https://gov.uk/benefit-cap-calculator)
