### PR TITLE
Restore indexable_content behaviour for outcome nodes (rebased)

### DIFF
--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -45,12 +45,20 @@ class FlowRegistrationPresenter
         when SmartAnswer::Question::Base
           pres = QuestionPresenter.new(node, nil, helpers: [MethodMissingHelper])
           acc.concat([:title, :body, :hint].map { |method|
-            pres.send(method)
+            begin
+              pres.send(method)
+            rescue ActionView::Template::Error
+              ''
+            end
           })
         when SmartAnswer::Outcome
           pres = OutcomePresenter.new(node, nil, helpers: [MethodMissingHelper])
           acc.concat([:title, :body].map { |method|
-            pres.send(method)
+            begin
+              pres.send(method)
+            rescue ActionView::Template::Error
+              ''
+            end
           })
         end
       }.compact.join(" ").gsub(/(?:<[^>]+>|\s)+/, " ")

--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -40,7 +40,7 @@ class FlowRegistrationPresenter
 
   def indexable_content
     HTMLEntities.new.decode(
-      text = @flow.nodes.inject([start_node.body]) { |acc, node|
+      @flow.nodes.inject([start_node.body]) { |acc, node|
         case node
         when SmartAnswer::Question::Base
           pres = QuestionPresenter.new(node, nil, helpers: [MethodMissingHelper])

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -1,6 +1,7 @@
 class OutcomePresenter < NodePresenter
   def initialize(node, state = nil, options = {})
     super(node, state)
+    helpers = options[:helpers] || []
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(
       template_directory: @node.template_directory.join('outcomes'),
       template_name: @node.name.to_s,
@@ -9,7 +10,7 @@ class OutcomePresenter < NodePresenter
         SmartAnswer::FormattingHelper,
         SmartAnswer::OverseasPassportsHelper,
         SmartAnswer::MarriageAbroadHelper
-      ]
+      ] + helpers
     )
   end
 

--- a/test/fixtures/smart_answer_flows/flow-sample/outcomes/outcome_raising_exception.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/flow-sample/outcomes/outcome_raising_exception.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  OUTCOME_RAISING_EXCEPTION_TITLE
+<% end %>
+
+<% content_for :body do %>
+  <% raise 'exception' %>
+<% end %>

--- a/test/fixtures/smart_answer_flows/flow-sample/outcomes/outcome_with_interpolation.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/flow-sample/outcomes/outcome_with_interpolation.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  OUTCOME_WITH_INTERPOLATION_TITLE
+<% end %>
+
+<% content_for :body do %>
+  OUTCOME_WITH_INTERPOLATION_BODY <%= i.dont.exist %>
+<% end %>

--- a/test/fixtures/smart_answer_flows/flow-sample/questions/question_raising_exception.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/flow-sample/questions/question_raising_exception.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  QUESTION_RAISING_EXCEPTION_TITLE
+<% end %>
+
+<% content_for :hint do %>
+  QUESTION_RAISING_EXCEPTION_HINT
+<% end %>
+
+<% content_for :body do %>
+  <% raise 'exception' %>
+<% end %>

--- a/test/integration/indexable_content_test.rb
+++ b/test/integration/indexable_content_test.rb
@@ -1,0 +1,10 @@
+require_relative '../test_helper'
+
+class IndexableContentTest < ActiveSupport::TestCase
+  should 'generate at least one keyword for each flow' do
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
+    flow_presenters.each do |flow_presenter|
+      assert flow_presenter.indexable_content.split(' ').any?
+    end
+  end
+end

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -114,6 +114,15 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
       assert_match %r{QUESTION_WITH_INTERPOLATION_BODY}, @content
       assert_match %r{OUTCOME_WITH_INTERPOLATION_BODY}, @content
     end
+
+    should "ignore any exceptions in rendering nodes" do
+      @flow.multiple_choice(:question_raising_exception)
+      @flow.outcome(:outcome_raising_exception)
+      @content = @presenter.indexable_content
+      assert_match %r{FLOW_BODY}, @content
+      assert_match %r{QUESTION_1_BODY}, @content
+      assert_match %r{OUTCOME_1_BODY}, @content
+    end
   end
 
   context "state" do

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -65,11 +65,11 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
       assert_match %r{QUESTION_2_TITLE}, @content
     end
 
-    should "not include any outcome node titles" do
+    should "include all outcome node titles" do
       @content = @presenter.indexable_content
-      assert_no_match %r{OUTCOME_1_TITLE}, @content
-      assert_no_match %r{OUTCOME_2_TITLE}, @content
-      assert_no_match %r{OUTCOME_3_TITLE}, @content
+      assert_match %r{OUTCOME_1_TITLE}, @content
+      assert_match %r{OUTCOME_2_TITLE}, @content
+      assert_match %r{OUTCOME_3_TITLE}, @content
     end
 
     should "include the flow body and question node bodies" do
@@ -79,11 +79,11 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
       assert_match %r{QUESTION_2_BODY}, @content
     end
 
-    should "not include outcome node bodies" do
+    should "include outcome node bodies" do
       @content = @presenter.indexable_content
-      assert_no_match %r{OUTCOME_1_BODY}, @content
-      assert_no_match %r{OUTCOME_2_BODY}, @content
-      assert_no_match %r{OUTCOME_3_BODY}, @content
+      assert_match %r{OUTCOME_1_BODY}, @content
+      assert_match %r{OUTCOME_2_BODY}, @content
+      assert_match %r{OUTCOME_3_BODY}, @content
     end
 
     should "include all question hints" do
@@ -106,11 +106,13 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
 
     should "ignore any interpolation errors" do
       @flow.multiple_choice(:question_with_interpolation)
+      @flow.outcome(:outcome_with_interpolation)
       @content = @presenter.indexable_content
       assert_match %r{FLOW_BODY}, @content
       assert_match %r{QUESTION_1_BODY}, @content
       assert_match %r{QUESTION_2_BODY}, @content
       assert_match %r{QUESTION_WITH_INTERPOLATION_BODY}, @content
+      assert_match %r{OUTCOME_WITH_INTERPOLATION_BODY}, @content
     end
   end
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -22,6 +22,29 @@ module SmartAnswer
       OutcomePresenter.new(outcome)
     end
 
+    test 'renderer is constructed with default helper modules' do
+      outcome_directory = Pathname.new('outcome-template-directory')
+      outcome = stub('outcome', name: :outcome_name, template_directory: outcome_directory)
+
+      SmartAnswer::ErbRenderer.expects(:new).with(has_entry(helpers: [
+        SmartAnswer::FormattingHelper,
+        SmartAnswer::OverseasPassportsHelper,
+        SmartAnswer::MarriageAbroadHelper,
+      ]))
+
+      OutcomePresenter.new(outcome)
+    end
+
+    test 'renderer is constructed with supplied helper modules' do
+      outcome_directory = Pathname.new('outcome-template-directory')
+      outcome = stub('outcome', name: :outcome_name, template_directory: outcome_directory)
+      helper = Module.new
+
+      SmartAnswer::ErbRenderer.expects(:new).with(has_entry(helpers: includes(helper)))
+
+      OutcomePresenter.new(outcome, nil, helpers: [helper])
+    end
+
     test '#title returns single line of content rendered for title block' do
       @renderer.stubs(:single_line_of_content_for).with(:title).returns('title-text')
 


### PR DESCRIPTION
### Description

Supersedes #2391.

During the transition from YAML to ERB templates this behaviour got broken and then removed in order to avoid errors. See this [Trello card][1] for details.

Now that we have `MethodMissingHelper` we can avoid errors when outcome templates include ERB interpolation.

### Notes

* I've made a small change to the `OutcomePresenter` constructor to make it possible to specify extra helper modules c.f. `QuestionPresenter`.
* I've inlined `NODE_PRESENTER_METHODS`, because it was only being used in one place.
* I've added a new outcome template fixture in order to test ERB interpolation.
* I've added a new "integration" test which builds a `FlowRegistrationPresenter` for each flow in the app and calls `indexable_content` on each. This takes about 15 seconds to run on my local machine, but I think it's worth having in order to catch problems before deployment.

### External changes

Indexable content is used rather circuitously in the `panopticon:register` rake task which I believe is still invoked during deployment. I don't think it's used in the newer & related `publishing_api:publish` rake task.

I assume the indexable content eventually makes its way to the search app (rummager?). I suspect it'll be hard to test that this change has taken effect, but you could try using the GOV.UK search box to search for an unusual word in the content of an outcome.

### Deployment

We should probably notify Richard Boulton and Tara Stockford when this is deployed (see comments on Trello card).

[1]: https://trello.com/c/nZJqFYLE