### PR TITLE
Add test to ensure all flows are visualisable

### DIFF
--- a/test/integration/flow_visualisation_test.rb
+++ b/test/integration/flow_visualisation_test.rb
@@ -1,0 +1,12 @@
+require_relative '../integration_test_helper'
+
+class FlowVisualisationTest < ActionDispatch::IntegrationTest
+  SmartAnswer::FlowRegistry.instance.flows.each do |flow|
+    should "be able to visualise #{flow.name}" do
+      presenter = GraphPresenter.new(flow)
+      assertion_message = "The #{flow.name} Smart Answers isn't visualisable"
+
+      assert presenter.visualisable?, assertion_message
+    end
+  end
+end


### PR DESCRIPTION
We've gone to quite some effort to ensure that the graph visualisation
continues to work while we've been refactoring Smart Answers. I'm adding this
test to ensure that we don't undo that work in future.

This was highlighted by a proposed refactoring of benefit-cap-calculator (see
PR #2452) that results in the flow not being visualisable.

Assuming this commit, and the proposed benefit-cap-calculator refactoring make
it into master, we'll have to work out how to handle the broken visualisation.