### PR TITLE
Remove unnecessary explicit namespace qualifications

### DIFF
--- a/lib/smart_answer/calculators/married_couples_allowance_calculator.rb
+++ b/lib/smart_answer/calculators/married_couples_allowance_calculator.rb
@@ -62,7 +62,7 @@ module SmartAnswer::Calculators
     end
 
     def rates
-      @rates ||= SmartAnswer::Calculators::RatesQuery.from_file('married_couples_allowance').rates
+      @rates ||= RatesQuery.from_file('married_couples_allowance').rates
     end
   end
 end

--- a/lib/smart_answer/calculators/registrations_data_query.rb
+++ b/lib/smart_answer/calculators/registrations_data_query.rb
@@ -80,7 +80,7 @@ module SmartAnswer::Calculators
     end
 
     def document_return_fees
-      SmartAnswer::Calculators::RatesQuery.from_file('births_and_deaths_document_return_fees').rates
+      RatesQuery.from_file('births_and_deaths_document_return_fees').rates
     end
 
     def register_a_birth_fees

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -160,7 +160,7 @@ module SmartAnswer
 
       # define as static so we don't have to instantiate the calculator too early in the flow
       def self.lower_earning_limit_on(date)
-        SmartAnswer::Calculators::RatesQuery.from_file('statutory_sick_pay').rates(date).lower_earning_limit_rate
+        RatesQuery.from_file('statutory_sick_pay').rates(date).lower_earning_limit_rate
       end
 
       def self.months_between(start_date, end_date)
@@ -256,7 +256,7 @@ module SmartAnswer
     private
 
       def weekly_rate_on(date)
-        SmartAnswer::Calculators::RatesQuery.from_file('statutory_sick_pay').rates(date).ssp_weekly_rate
+        RatesQuery.from_file('statutory_sick_pay').rates(date).ssp_weekly_rate
       end
 
       def max_days_that_can_be_paid

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -21,7 +21,7 @@ module SmartAnswer
         end
 
         calculate :age_related_allowance_chooser do
-          rates = SmartAnswer::Calculators::RatesQuery.from_file('married_couples_allowance').rates
+          rates = Calculators::RatesQuery.from_file('married_couples_allowance').rates
           AgeRelatedAllowanceChooser.new(
             personal_allowance: rates.personal_allowance,
             over_65_allowance: rates.over_65_allowance,

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -105,7 +105,7 @@ module SmartAnswer
       #Q6
       money_question :how_much_12_months_1? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
+          Calculators::ChildcareCostCalculator.weekly_cost(response)
         end
         next_node do
           outcome :weekly_costs_are_x #O4
@@ -115,7 +115,7 @@ module SmartAnswer
       #Q7
       money_question :how_much_52_weeks_1? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
+          Calculators::ChildcareCostCalculator.weekly_cost(response)
         end
         next_node do
           outcome :weekly_costs_are_x #O4
@@ -125,7 +125,7 @@ module SmartAnswer
       #Q8
       money_question :how_much_52_weeks_2? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
+          Calculators::ChildcareCostCalculator.weekly_cost(response)
         end
 
         next_node do |response|
@@ -137,7 +137,7 @@ module SmartAnswer
       #Q9
       money_question :how_much_12_months_2? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
+          Calculators::ChildcareCostCalculator.weekly_cost(response)
         end
 
         next_node do |response|
@@ -149,7 +149,7 @@ module SmartAnswer
       #Q10
       money_question :how_much_each_month? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(response)
+          Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(response)
         end
         next_node do
           outcome :weekly_costs_are_x #O4
@@ -202,7 +202,7 @@ module SmartAnswer
       #Q13
       money_question :how_much_fortnightly? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_fortnightly(response)
+          Calculators::ChildcareCostCalculator.weekly_cost_from_fortnightly(response)
         end
 
         next_node do
@@ -213,7 +213,7 @@ module SmartAnswer
       #Q14
       money_question :how_much_4_weeks? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_four_weekly(response)
+          Calculators::ChildcareCostCalculator.weekly_cost_from_four_weekly(response)
         end
         next_node do
           outcome :weekly_costs_are_x #04
@@ -223,7 +223,7 @@ module SmartAnswer
       #Q15
       money_question :how_much_yearly? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
+          Calculators::ChildcareCostCalculator.weekly_cost(response)
         end
         next_node do
           outcome :weekly_costs_are_x #O4
@@ -233,7 +233,7 @@ module SmartAnswer
       #Q16
       money_question :how_much_spent_last_12_months? do
         calculate :weekly_cost do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
+          Calculators::ChildcareCostCalculator.weekly_cost(response)
         end
         next_node do
           outcome :weekly_costs_are_x #O4
@@ -261,7 +261,7 @@ module SmartAnswer
         end
 
         calculate :weekly_difference do
-          SmartAnswer::Calculators::ChildcareCostCalculator.cost_change(weekly_cost, old_weekly_cost)
+          Calculators::ChildcareCostCalculator.cost_change(weekly_cost, old_weekly_cost)
         end
 
         calculate :weekly_difference_abs do
@@ -276,7 +276,7 @@ module SmartAnswer
       #Q19
       money_question :new_monthly_cost? do
         calculate :new_weekly_costs do |response|
-          SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(response)
+          Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(response)
         end
 
         next_node do |response|
@@ -292,7 +292,7 @@ module SmartAnswer
         end
 
         calculate :weekly_difference do
-          SmartAnswer::Calculators::ChildcareCostCalculator.cost_change(new_weekly_costs, old_weekly_costs)
+          Calculators::ChildcareCostCalculator.cost_change(new_weekly_costs, old_weekly_costs)
         end
 
         calculate :weekly_difference_abs do
@@ -313,7 +313,7 @@ module SmartAnswer
         end
 
         calculate :weekly_difference do
-          SmartAnswer::Calculators::ChildcareCostCalculator.cost_change(new_weekly_costs, old_weekly_costs)
+          Calculators::ChildcareCostCalculator.cost_change(new_weekly_costs, old_weekly_costs)
         end
 
         calculate :weekly_difference_abs do

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
@@ -6,7 +6,7 @@ module SmartAnswer
       status :published
       satisfies_need "100220"
 
-      arrested_calc = SmartAnswer::Calculators::ArrestedAbroad.new
+      arrested_calc = Calculators::ArrestedAbroad.new
       prisoner_packs = arrested_calc.data
       exclude_countries = %w(holy-see british-antarctic-territory)
 

--- a/lib/smart_answer_flows/legalisation-document-checker.rb
+++ b/lib/smart_answer_flows/legalisation-document-checker.rb
@@ -82,7 +82,7 @@ module SmartAnswer
 
       outcome :outcome_results do
         precalculate :data_query do
-          SmartAnswer::Calculators::LegalisationDocumentsDataQuery.new
+          Calculators::LegalisationDocumentsDataQuery.new
         end
 
         precalculate :groups_selected do

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -6,9 +6,9 @@ module SmartAnswer
       status :published
       satisfies_need "101003"
 
-      country_name_query = SmartAnswer::Calculators::CountryNameFormatter.new
-      reg_data_query = SmartAnswer::Calculators::RegistrationsDataQuery.new
-      translator_query = SmartAnswer::Calculators::TranslatorLinks.new
+      country_name_query = Calculators::CountryNameFormatter.new
+      reg_data_query = Calculators::RegistrationsDataQuery.new
+      translator_query = Calculators::TranslatorLinks.new
       exclude_countries = %w(holy-see british-antarctic-territory)
 
       # Q1

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -6,9 +6,9 @@ module SmartAnswer
       status :published
       satisfies_need "101006"
 
-      country_name_query = SmartAnswer::Calculators::CountryNameFormatter.new
-      reg_data_query = SmartAnswer::Calculators::RegistrationsDataQuery.new
-      translator_query = SmartAnswer::Calculators::TranslatorLinks.new
+      country_name_query = Calculators::CountryNameFormatter.new
+      reg_data_query = Calculators::RegistrationsDataQuery.new
+      translator_query = Calculators::TranslatorLinks.new
       exclude_countries = %w(holy-see british-antarctic-territory)
 
       # Q1
@@ -157,7 +157,7 @@ module SmartAnswer
         end
 
         precalculate :reg_data_query do
-          SmartAnswer::Calculators::RegistrationsDataQuery.new
+          Calculators::RegistrationsDataQuery.new
         end
 
         precalculate :document_return_fees do
@@ -167,7 +167,7 @@ module SmartAnswer
 
       outcome :north_korea_result do
         precalculate :reg_data_query do
-          SmartAnswer::Calculators::RegistrationsDataQuery.new
+          Calculators::RegistrationsDataQuery.new
         end
 
         precalculate :overseas_passports_embassies do

--- a/lib/smart_answer_flows/state-pension-through-partner.rb
+++ b/lib/smart_answer_flows/state-pension-through-partner.rb
@@ -26,11 +26,11 @@ module SmartAnswer
         end
 
         calculate :lower_basic_state_pension_rate do
-          rate = SmartAnswer::Calculators::RatesQuery.from_file('state_pension').rates.lower_weekly_rate
+          rate = Calculators::RatesQuery.from_file('state_pension').rates.lower_weekly_rate
           "£#{'%.2f' % rate}"
         end
         calculate :higher_basic_state_pension_rate do
-          rate = SmartAnswer::Calculators::RatesQuery.from_file('state_pension').rates.weekly_rate
+          rate = Calculators::RatesQuery.from_file('state_pension').rates.weekly_rate
           "£#{'%.2f' % rate}"
         end
 

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -67,7 +67,7 @@ module SmartAnswer
       #Q5
       money_question :whats_your_household_income? do
         calculate :calculator do |response|
-          SmartAnswer::Calculators::StudentFinanceCalculator.new(
+          Calculators::StudentFinanceCalculator.new(
             course_start: start_date,
             household_income: response,
             residence: where_living

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-married-couples-allowance.rb: f9bf8da3b4b9e2966fabf91f6f2142cd
+lib/smart_answer_flows/calculate-married-couples-allowance.rb: 2f2006fce32a89da526fda3ad51bdc07
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 3cdcbf373de49fa6383b7dcb1967eb80
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3a6d219be3fceda5e5e091520ab5227f
 lib/smart_answer_flows/calculate-married-couples-allowance/calculate_married_couples_allowance.govspeak.erb: 2a107c5f5eccf492a1bbb055fb87ee2c
@@ -22,4 +22,4 @@ lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_h
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_husbands_date_of_birth.govspeak.erb: e4fc026bed0343ef3a2727da6c8ed30a
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_husbands_income.govspeak.erb: dd71c9678c1f2b9eba3471151b2ba839
 lib/data/rates/married_couples_allowance.yml: 4963b39377d58a433c033b657f595810
-lib/smart_answer/calculators/married_couples_allowance_calculator.rb: 5933b68549cee3305ea4c9c589b37f29
+lib/smart_answer/calculators/married_couples_allowance_calculator.rb: c8c647584dda5e9192282b8ee20561b2

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -29,5 +29,5 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/pay_amount_if_not_
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.govspeak.erb: 46ce81328d55d2bef88bb1047cf047cd
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 90c89eabd2e47837ffe538ae27706552
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 6d88363ba1319f8b2a6a63d75c626183
 lib/data/rates/statutory_sick_pay.yml: b275311f2ec89fc707e6b9cfefec1179

--- a/test/data/childcare-costs-for-tax-credits-files.yml
+++ b/test/data/childcare-costs-for-tax-credits-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: ba9df96d0584e74dfbb63c0b031d293c
+lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: 1a504104abba53f3b39b7893076db03d
 test/data/childcare-costs-for-tax-credits-questions-and-responses.yml: 626012bfcc3d89170729eb2140fc1aa4
 test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml: 37aa1c49681770c252fd9ca273d1ba07
 lib/smart_answer_flows/childcare-costs-for-tax-credits/childcare_costs_for_tax_credits.govspeak.erb: b9067a0397fac45150cfc4b5a3174b25

--- a/test/data/help-if-you-are-arrested-abroad-files.yml
+++ b/test/data/help-if-you-are-arrested-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: 25abce7dd7e68b2050123947143c3de3
+lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: c106f1d1ff22a0805eb59a710cf6d74b
 test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml: c007b0dd259d1c09ccc2dd3163fa1e56
 test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml: 3e3aeca8a1af7c147b8f62af365f650d
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/help_if_you_are_arrested_abroad.govspeak.erb: cb923645274b287ba93af8c7118d7f88

--- a/test/data/legalisation-document-checker-files.yml
+++ b/test/data/legalisation-document-checker-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/legalisation-document-checker.rb: 67b37fc748fc37f930d2fdfdafe4fe55
+lib/smart_answer_flows/legalisation-document-checker.rb: 2ceea4546b19e8acf0d44b694bfac409
 test/data/legalisation-document-checker-questions-and-responses.yml: 37c99c68ba04e459447622b01938ce0b
 test/data/legalisation-document-checker-responses-and-expected-results.yml: d55ccccc64cc1f58b648e810e5fa07e5
 lib/smart_answer_flows/legalisation-document-checker/legalisation_document_checker.govspeak.erb: 4be67b8e3aeebe4f3b99a5153b92ccdf

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -149,4 +149,4 @@ lib/smart_answer/calculators/marriage_abroad_calculator.rb: 4cb4e31a2f91a8559525
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: abae964cf47d9f1ecbad30f9a4e2ed0b
 lib/smart_answer/calculators/country_name_formatter.rb: 16b57a11261644a0bda0d609a60d1c62
-lib/smart_answer/calculators/registrations_data_query.rb: c63ecdace15fda23a06d14909a246873
+lib/smart_answer/calculators/registrations_data_query.rb: 6e66e8a3884f3efa3118434e2b28e876

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/register-a-birth.rb: 2fc88098ac8bdbdda35222aa10de5050
+lib/smart_answer_flows/register-a-birth.rb: 232ef65452cefa8a62711ee7a0bb4c4b
 test/data/register-a-birth-questions-and-responses.yml: c59cb1d0c11f3ad29f905b632f7c58bb
 test/data/register-a-birth-responses-and-expected-results.yml: 3ac4372034c86d8cc87665db59ff11d5
 lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb: a2bc6c611c6809b333ab42066a805f71
@@ -25,7 +25,7 @@ lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b5
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/data/registrations.yml: 2eb5c61678f21bd9cc06af67c230279f
 lib/smart_answer/calculators/country_name_formatter.rb: 16b57a11261644a0bda0d609a60d1c62
-lib/smart_answer/calculators/registrations_data_query.rb: c63ecdace15fda23a06d14909a246873
+lib/smart_answer/calculators/registrations_data_query.rb: 6e66e8a3884f3efa3118434e2b28e876
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029
 test/fixtures/worldwide/afghanistan_organisations.json: 17c0cf62dc952a13684d25c0374263ac

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/register-a-death.rb: a2ec281c741736119b14cdcfef9965de
+lib/smart_answer_flows/register-a-death.rb: a8b8e0245c02c2eece40ca005476ef4b
 test/data/register-a-death-questions-and-responses.yml: bae21b0a8be1bbaa2dd6febd505382d6
 test/data/register-a-death-responses-and-expected-results.yml: a69c595900ab2d85208c0ac92f186ae8
 lib/smart_answer_flows/register-a-death/outcomes/_fees.govspeak.erb: ea6d04bee0f4148fc2fa587df3cc8363
@@ -22,7 +22,7 @@ lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.er
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 test/fixtures/worldwide/italy_organisations.json: 536304a31cc5d56801162af4d056d6bd
-lib/smart_answer/calculators/registrations_data_query.rb: c63ecdace15fda23a06d14909a246873
+lib/smart_answer/calculators/registrations_data_query.rb: 6e66e8a3884f3efa3118434e2b28e876
 lib/smart_answer/calculators/country_name_formatter.rb: 16b57a11261644a0bda0d609a60d1c62
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029

--- a/test/data/state-pension-through-partner-files.yml
+++ b/test/data/state-pension-through-partner-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/state-pension-through-partner.rb: e5658034ac6801cc61a87d9a365c0cc3
+lib/smart_answer_flows/state-pension-through-partner.rb: e76214e2bbdfcf23514354ec870a4cfd
 test/data/state-pension-through-partner-questions-and-responses.yml: 743b0b6dc9a8d33502d402c4da8220af
 test/data/state-pension-through-partner-responses-and-expected-results.yml: 930b237cf1f76ad3f85dd2f58f5b539a
 lib/smart_answer_flows/state-pension-through-partner/outcomes/_increase_retirement_income.govspeak.erb: 2391bf6e80d1aa4d0d4258030b4f4e00

--- a/test/data/student-finance-calculator-files.yml
+++ b/test/data/student-finance-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/student-finance-calculator.rb: 3a50872a3c26ec70418b9b2c9d4bef39
+lib/smart_answer_flows/student-finance-calculator.rb: 28e904e26baeee25d8b91c2f1064bff8
 test/data/student-finance-calculator-questions-and-responses.yml: 8f68ec47644191cd01864ba288acf7ec
 test/data/student-finance-calculator-responses-and-expected-results.yml: 4d17ae39630843d360460ef2131c5980
 lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_eu_students.govspeak.erb: b74eb38ff2a8534fb5fc8b0175fabf68

--- a/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
+++ b/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
@@ -5,7 +5,7 @@ module SmartAnswer
     class PayLeaveForParentsCalculatorTest < ActiveSupport::TestCase
       setup do
         @due_date = Date.parse('2015-1-1')
-        @calculator = SmartAnswer::Calculators::PayLeaveForParentsCalculator.new
+        @calculator = PayLeaveForParentsCalculator.new
       end
 
       test "continuity_start_date" do
@@ -61,7 +61,7 @@ module SmartAnswer
       context "due date in 2013-2014 range" do
         setup do
           @date = Date.parse("2014-1-1")
-          @calculator = SmartAnswer::Calculators::PayLeaveForParentsCalculator.new
+          @calculator = PayLeaveForParentsCalculator.new
         end
 
         should "be in 2013-2014 range" do
@@ -76,7 +76,7 @@ module SmartAnswer
       context "due date in 2014-2015 range" do
         setup do
           @date = Date.parse("2015-1-1")
-          @calculator = SmartAnswer::Calculators::PayLeaveForParentsCalculator.new
+          @calculator = PayLeaveForParentsCalculator.new
         end
 
         should "be in 2013-2014 range" do
@@ -91,7 +91,7 @@ module SmartAnswer
       context "due date in 2015-2016 range" do
         setup do
           @date = Date.parse("2016-1-1")
-          @calculator = SmartAnswer::Calculators::PayLeaveForParentsCalculator.new
+          @calculator = PayLeaveForParentsCalculator.new
         end
 
         should "be in 2015-2016 range" do
@@ -106,7 +106,7 @@ module SmartAnswer
       context "due date outside all ranges" do
         setup do
           @date = Date.parse("2022-1-1")
-          @calculator = SmartAnswer::Calculators::PayLeaveForParentsCalculator.new
+          @calculator = PayLeaveForParentsCalculator.new
         end
 
         should "return the latest_pat_leave known lower_earnings_amount" do

--- a/test/unit/calculators/registrations_data_query_test.rb
+++ b/test/unit/calculators/registrations_data_query_test.rb
@@ -4,7 +4,7 @@ module SmartAnswer::Calculators
   class RegistrationsDataQueryTest < ActiveSupport::TestCase
     context RegistrationsDataQuery do
       setup do
-        @described_class = SmartAnswer::Calculators::RegistrationsDataQuery
+        @described_class = RegistrationsDataQuery
         @query = @described_class.new
       end
       context "registration_data method" do

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -4,7 +4,7 @@ module SmartAnswer::Calculators
   class StatePensionAgeCalculatorTest < ActiveSupport::TestCase
     context '#state_pension_date' do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new(
+        @calculator = StatePensionAgeCalculator.new(
           gender: "male", dob: Date.parse("28 February 1961"))
       end
 
@@ -16,7 +16,7 @@ module SmartAnswer::Calculators
 
     context "#state_pension_age" do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new(
+        @calculator = StatePensionAgeCalculator.new(
           gender: "male", dob: Date.parse("28 February 1961"))
       end
 
@@ -64,13 +64,13 @@ module SmartAnswer::Calculators
 
     context "#birthday_on_feb_29??" do
       should "be true for a date that is a the 29th of feb" do
-        @calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new(
+        @calculator = StatePensionAgeCalculator.new(
           gender: "male", dob: Date.parse("29 February 1976"))
         assert_equal true, @calculator.birthday_on_feb_29?
       end
 
       should "be false for a date that is not the 29th of feb" do
-        @calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new(
+        @calculator = StatePensionAgeCalculator.new(
           gender: "male", dob: Date.parse("7 June 1960"))
         assert_equal false, @calculator.birthday_on_feb_29?
       end
@@ -78,7 +78,7 @@ module SmartAnswer::Calculators
 
     context '#before_state_pension_date?' do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new({})
+        @calculator = StatePensionAgeCalculator.new({})
       end
 
       should 'return true for someone yet to reach their state pension date' do
@@ -105,7 +105,7 @@ module SmartAnswer::Calculators
 
     context '#before_state_pension_date?(days: 30)' do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new({})
+        @calculator = StatePensionAgeCalculator.new({})
       end
 
       should 'return true for someone just over 30 days away from their pension_credit_date' do
@@ -132,7 +132,7 @@ module SmartAnswer::Calculators
 
     context '#before_pension_credit_date?' do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new({})
+        @calculator = StatePensionAgeCalculator.new({})
       end
 
       should 'return true for someone yet to reach their pension credit date' do
@@ -159,7 +159,7 @@ module SmartAnswer::Calculators
 
     context '#old_state_pension?' do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new({})
+        @calculator = StatePensionAgeCalculator.new({})
       end
 
       should 'return true when the state_pension_date falls before 6 April 2016' do
@@ -183,7 +183,7 @@ module SmartAnswer::Calculators
         Timecop.freeze do
           date_of_birth = (16.years + 1.minute).ago
 
-          calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new(dob: date_of_birth)
+          calculator = StatePensionAgeCalculator.new(dob: date_of_birth)
           assert calculator.over_16_years_old?
         end
       end
@@ -192,7 +192,7 @@ module SmartAnswer::Calculators
         Timecop.freeze do
           date_of_birth = 16.years.ago
 
-          calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new(dob: date_of_birth)
+          calculator = StatePensionAgeCalculator.new(dob: date_of_birth)
           assert_not calculator.over_16_years_old?
         end
       end
@@ -201,7 +201,7 @@ module SmartAnswer::Calculators
         Timecop.freeze do
           date_of_birth = (16.years - 1.minute).ago
 
-          calculator = SmartAnswer::Calculators::StatePensionAgeCalculator.new(dob: date_of_birth)
+          calculator = StatePensionAgeCalculator.new(dob: date_of_birth)
           assert_not calculator.over_16_years_old?
         end
       end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -4,7 +4,7 @@ module SmartAnswer::Calculators
   class StatePensionTopupCalculatorTest < ActiveSupport::TestCase
     context "checking lump sum amount" do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionTopupCalculator.new
+        @calculator = StatePensionTopupCalculator.new
       end
 
       should "be 8010 for age of 69" do
@@ -23,7 +23,7 @@ module SmartAnswer::Calculators
 
     context "check lump sum amount and age" do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionTopupCalculator.new
+        @calculator = StatePensionTopupCalculator.new
       end
 
       should "Show age of 64" do
@@ -37,7 +37,7 @@ module SmartAnswer::Calculators
 
     context "check return value for lump sum amount and age male" do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionTopupCalculator.new
+        @calculator = StatePensionTopupCalculator.new
       end
 
       should "Show 2 rates for ages 85 and 86" do
@@ -47,7 +47,7 @@ module SmartAnswer::Calculators
 
     context "check return value for lump sum amount and age" do
       setup do
-        @calculator = SmartAnswer::Calculators::StatePensionTopupCalculator.new
+        @calculator = StatePensionTopupCalculator.new
       end
 
       should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do

--- a/test/unit/calculators/state_pension_topup_data_query_test.rb
+++ b/test/unit/calculators/state_pension_topup_data_query_test.rb
@@ -3,10 +3,10 @@ require_relative "../../test_helper"
 module SmartAnswer::Calculators
   class StatePensionTopupDataQueryTest < ActiveSupport::TestCase
     setup do
-      SmartAnswer::Calculators::StatePensionTopupDataQuery
+      StatePensionTopupDataQuery
         .stubs(:age_and_rates_data)
         .returns('age_and_rates' => { 100 => 127, 99 => 137 })
-      @query = SmartAnswer::Calculators::StatePensionTopupDataQuery.new
+      @query = StatePensionTopupDataQuery.new
     end
 
     should "use the rate for the maximum provided age for people who are older" do

--- a/test/unit/calculators/translator_links_test.rb
+++ b/test/unit/calculators/translator_links_test.rb
@@ -10,7 +10,7 @@ module SmartAnswer::Calculators
           'andorra' => '/government/publications/spain-list-of-lawyers',
           'san-marino' => '/government/publications/italy-list-of-lawyers'
         )
-        @data = SmartAnswer::Calculators::TranslatorLinks.new
+        @data = TranslatorLinks.new
       end
 
       should "allow access to Hash" do


### PR DESCRIPTION
These classes were already within the scope of the relevant namespace.

Removing the explicit namespace qualifications makes the code terser and easier to read.