### PR TITLE
Spike: Allow user to choose between 2 versions of benefit-cap-calculator

### DIFF
--- a/lib/data/benefit_cap_data.yml
+++ b/lib/data/benefit_cap_data.yml
@@ -1,66 +1,88 @@
 ---
-weekly_benefit_caps:
-  single:
-    amount: 350
-    description: "Single"
-  couple:
-    amount: 500
-    description: "Living as a couple (with or without children)"
-  parent:
-    amount: 500
-    description: "A lone parent with 1 or more dependent children"
-exempt_benefits:
-  - Attendance Allowance
-  - Disability Living Allowance
-  - Industrial Injuries Benefit
-  - Personal Independence Payment
-  - Employment and Support Allowance (support component)
-  - War Widow’s or War Widower’s Pension
-  - Armed Forces Compensation Scheme
-  - Armed Forces Independence Payment
-benefits:
-  bereavement:
-    question: :bereavement_amount?
-    description: "Bereavement Allowance"
-  carers:
-    question: :carers_amount?
-    description: "Carer's Allowance"
-  child_benefit:
-    question: :child_benefit_amount?
-    description: "Child Benefit"
-  child_tax:
-    question: :child_tax_amount?
-    description: "Child Tax Credit"
-  esa:
-    question: :esa_amount?
-    description: "Employment and Support Allowance"
-  guardian:
-    question: :guardian_amount?
-    description: "Guardian's Allowance"
-  incapacity:
-    question: :incapacity_amount?
-    description: "Incapacity Benefit"
-  income_support:
-    question: :income_support_amount?
-    description: "Income Support"
-  jsa:
-    question: :jsa_amount?
-    description: "Jobseeker’s Allowance"
-  maternity:
-    question: :maternity_amount?
-    description: "Maternity Allowance"
-  sda:
-    question: :sda_amount?
-    description: "Severe Disablement Allowance"
-  widowed_mother:
-    question: :widowed_mother_amount?
-    description: "Widowed Mother's Allowance"
-  widowed_parent:
-    question: :widowed_parent_amount?
-    description: "Widowed Parent's Allowance"
-  widow_pension:
-    question: :widow_pension_amount?
-    description: "Widow's Pension"
-  widows_aged:
-    question: :widows_aged_amount?
-    description: "Widow's Pension (age related)"
+  default:
+    weekly_benefit_caps:
+      single:
+        amount: 350
+        description: "Single"
+      couple:
+        amount: 500
+        description: "Living as a couple (with or without children)"
+      parent:
+        amount: 500
+        description: "A lone parent with 1 or more dependent children"
+    exempt_benefits:
+      - Attendance Allowance
+      - Disability Living Allowance
+      - Industrial Injuries Benefit
+      - Personal Independence Payment
+      - Employment and Support Allowance (support component)
+      - War Widow’s or War Widower’s Pension
+      - Armed Forces Compensation Scheme
+      - Armed Forces Independence Payment
+    benefits:
+      bereavement:
+        question: :bereavement_amount?
+        description: "Bereavement Allowance"
+      carers:
+        question: :carers_amount?
+        description: "Carer's Allowance"
+      child_benefit:
+        question: :child_benefit_amount?
+        description: "Child Benefit"
+      child_tax:
+        question: :child_tax_amount?
+        description: "Child Tax Credit"
+      esa:
+        question: :esa_amount?
+        description: "Employment and Support Allowance"
+      guardian:
+        question: :guardian_amount?
+        description: "Guardian's Allowance"
+      incapacity:
+        question: :incapacity_amount?
+        description: "Incapacity Benefit"
+      income_support:
+        question: :income_support_amount?
+        description: "Income Support"
+      jsa:
+        question: :jsa_amount?
+        description: "Jobseeker’s Allowance"
+      maternity:
+        question: :maternity_amount?
+        description: "Maternity Allowance"
+      sda:
+        question: :sda_amount?
+        description: "Severe Disablement Allowance"
+      widowed_mother:
+        question: :widowed_mother_amount?
+        description: "Widowed Mother's Allowance"
+      widowed_parent:
+        question: :widowed_parent_amount?
+        description: "Widowed Parent's Allowance"
+      widow_pension:
+        question: :widow_pension_amount?
+        description: "Widow's Pension"
+      widows_aged:
+        question: :widows_aged_amount?
+        description: "Widow's Pension (age related)"
+  future:
+    weekly_benefit_caps:
+      single:
+        amount: 400
+        description: "Single"
+      couple:
+        amount: 550
+        description: "Living as a couple (with or without children)"
+    exempt_benefits:
+      - Attendance Allowance
+      - Disability Living Allowance
+    benefits:
+      bereavement:
+        question: :bereavement_amount?
+        description: "Bereavement Allowance"
+      carers:
+        question: :carers_amount?
+        description: "Carer's Allowance"
+      child_benefit:
+        question: :child_benefit_amount?
+        description: "Child Benefit"

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -1,49 +1,51 @@
 module SmartAnswer::Calculators
   class BenefitCapCalculatorConfiguration
-    def weekly_benefit_caps
-      @weekly_benefit_caps ||= data.fetch("weekly_benefit_caps").with_indifferent_access
+    def weekly_benefit_caps(version)
+      data(version).fetch("weekly_benefit_caps").with_indifferent_access
     end
 
-    def weekly_benefit_cap_descriptions
-      @weekly_benefit_cap_descriptions ||=
-        weekly_benefit_caps.inject(HashWithIndifferentAccess.new) do |weekly_benefit_cap_description, (key, value)|
-          weekly_benefit_cap_description[key] = value.fetch("description")
-          weekly_benefit_cap_description
-        end
+    def weekly_benefit_cap_descriptions(version)
+      weekly_benefit_caps(version).inject(HashWithIndifferentAccess.new) do |weekly_benefit_cap_description, (key, value)|
+        weekly_benefit_cap_description[key] = value.fetch("description")
+        weekly_benefit_cap_description
+      end
     end
 
-    def weekly_benefit_cap_amount(family_type)
-      weekly_benefit_caps.fetch(family_type)["amount"]
+    def weekly_benefit_cap_amount(version, family_type)
+      weekly_benefit_caps(version).fetch(family_type)["amount"]
     end
 
-    def benefits
-      @benefits ||= data.fetch("benefits").with_indifferent_access
+    def benefits(version)
+      data(version).fetch("benefits").with_indifferent_access
     end
 
-    def exempt_benefits
-      @exempt_benefits ||= data.fetch("exempt_benefits")
+    def exempt_benefits(version)
+      data(version).fetch("exempt_benefits")
     end
 
-    def questions
-      @questions ||=
-        benefits.inject(HashWithIndifferentAccess.new) do |benefits_and_questions, (key, value)|
-          benefits_and_questions[key] = value.fetch("question")
-          benefits_and_questions
-        end
+    def questions(version)
+      benefits(version).inject(HashWithIndifferentAccess.new) do |benefits_and_questions, (key, value)|
+        benefits_and_questions[key] = value.fetch("question")
+        benefits_and_questions
+      end
     end
 
-    def descriptions
-      @descriptions ||=
-        benefits.inject(HashWithIndifferentAccess.new) do |benefits_and_descriptions, (key, value)|
-          benefits_and_descriptions[key] = value.fetch("description")
-          benefits_and_descriptions
-        end
+    def all_questions
+      questions('default').merge(questions('future'))
+    end
+
+    def descriptions(version)
+      benefits(version).inject(HashWithIndifferentAccess.new) do |benefits_and_descriptions, (key, value)|
+        benefits_and_descriptions[key] = value.fetch("description")
+        benefits_and_descriptions
+      end
     end
 
   private
 
-    def data
-      @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
+    def data(version)
+      hash = YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml'))
+      hash.fetch(version)
     end
   end
 end

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/choose_cap_to_calculate.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/choose_cap_to_calculate.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Choose the benefit cap to calculate?
+<% end %>
+
+<% options(
+  "default": "Default",
+  "future": "Future"
+) %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits_future.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits_future.govspeak.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+  Do you or someone in your household get any of the following benefits?
+<% end %>
+
+<% options(benefit_options) %>
+
+<% content_for :hint do %>
+  If you do not receive any of these click 'Next step'.
+<% end %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent_future.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent_future.govspeak.erb
@@ -1,0 +1,5 @@
+<% content_for :title do %>
+  Are you:
+<% end %>
+
+<% options(weekly_benefit_cap_descriptions) %>


### PR DESCRIPTION
This is a really hack-y spike to demonstrate what I meant by option 1 in my email earlier today [1].

There's lots not to like about this approach. In particular, the duplication of Q4 and Q6 and their templates. Although this could almost certainly be improved, because I did a very naive copy and paste of these two questions.

Note that I had to duplicate these two questions, because they were the only two places which needed the value of `chosen_cap` at flow-definition time as opposed to at request-time. In my email I hadn't appreciated that Q6 needed it too, which is why I only suggested duplicating Q4.

Note that I've removed the memoisation in `BenefitCapCalculatorConfiguration`, because I suspected it would be problematic once I added a `version` argument to the `data` method. I'm not convinced the memoisation is really necessary anyway.

For demo purposes I moved the existing YAML data under a new `default` key and copied the same data under a `future` key. I then removed a bunch of the benefits and changed some of the other values.

Note that I have not updated any of the tests and I have only tested the solution very briefly - I may well have overlooked something.

I'm still not convinced that this is the best approach, but hopefully this is enough to explain what I meant.

[1]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!topic/content-team-developers/2cCz7vvMXp8