### PR TITLE
Introduce concept of Period of Incapacity for Work into calculate-statutory-sick-pay

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -1,9 +1,9 @@
 module SmartAnswer
   module Calculators
     class StatutorySickPayCalculator
-      MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK = 4
-
       class PeriodOfIncapacityForWork < DateRange
+        MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK = 4
+
         def working_days(pattern)
           dates = begins_on..ends_on
           # create an array of all dates that would have been normal workdays

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -2,7 +2,7 @@ module SmartAnswer
   module Calculators
     class StatutorySickPayCalculator
       class PeriodOfIncapacityForWork < DateRange
-        MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK = 4
+        MINIMUM_NUMBER_OF_DAYS = 4
 
         def working_days(pattern)
           dates = begins_on..ends_on
@@ -15,7 +15,7 @@ module SmartAnswer
         end
 
         def valid?
-          number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
+          number_of_days >= MINIMUM_NUMBER_OF_DAYS
         end
       end
 

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -5,17 +5,7 @@ module SmartAnswer
 
       class PeriodOfIncapacityForWork < DateRange
         def working_days(pattern)
-          self.class.dates_matching_pattern(
-            from: begins_on,
-            to: ends_on,
-            pattern: pattern
-          )
-        end
-
-        private
-
-        def self.dates_matching_pattern(from:, to:, pattern:)
-          dates = from..to
+          dates = begins_on..ends_on
           # create an array of all dates that would have been normal workdays
           matching_dates = []
           dates.each do |d|

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -4,6 +4,13 @@ module SmartAnswer
       MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK = 4
 
       class PeriodOfIncapacityForWork < DateRange
+        def working_days(pattern)
+          StatutorySickPayCalculator.dates_matching_pattern(
+            from: begins_on,
+            to: ends_on,
+            pattern: pattern
+          )
+        end
       end
 
       include ActiveModel::Model
@@ -298,10 +305,8 @@ module SmartAnswer
       end
 
       def init_normal_workdays_missed(days_of_the_week_worked)
-        self.class.dates_matching_pattern(
-          from: @sick_start_date,
-          to: @sick_end_date,
-          pattern: days_of_the_week_worked
+        current_period_of_incapacity_for_work.working_days(
+          days_of_the_week_worked
         )
       end
 

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -35,14 +35,18 @@ module SmartAnswer
         )
       end
 
+      def linked_period_of_incapacity_for_work
+        PeriodOfIncapacityForWork.new(
+          begins_on: linked_sickness_start_date,
+          ends_on: linked_sickness_end_date
+        )
+      end
+
       def prev_sick_days
         return 0 unless has_linked_sickness
-        prev_sick_days = self.class.dates_matching_pattern(
-          from: linked_sickness_start_date,
-          to: linked_sickness_end_date,
-          pattern: days_of_the_week_worked
-        )
-        prev_sick_days.length
+        linked_period_of_incapacity_for_work.working_days(
+          days_of_the_week_worked
+        ).length
       end
 
       def waiting_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -100,7 +100,7 @@ module SmartAnswer
 
       def prior_sick_days
         return 0 unless has_linked_sickness
-        prev_sick_days = Calculators::StatutorySickPayCalculator.dates_matching_pattern(
+        prev_sick_days = self.class.dates_matching_pattern(
           from: linked_sickness_start_date,
           to: linked_sickness_end_date,
           pattern: days_of_the_week_worked

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -29,7 +29,13 @@ module SmartAnswer
       end
 
       def prev_sick_days
-        prior_sick_days
+        return 0 unless has_linked_sickness
+        prev_sick_days = self.class.dates_matching_pattern(
+          from: linked_sickness_start_date,
+          to: linked_sickness_end_date,
+          pattern: days_of_the_week_worked
+        )
+        prev_sick_days.length
       end
 
       def waiting_days
@@ -105,16 +111,6 @@ module SmartAnswer
 
       def sick_end_date_for_awe
         linked_sickness_end_date || sick_end_date
-      end
-
-      def prior_sick_days
-        return 0 unless has_linked_sickness
-        prev_sick_days = self.class.dates_matching_pattern(
-          from: linked_sickness_start_date,
-          to: linked_sickness_end_date,
-          pattern: days_of_the_week_worked
-        )
-        prev_sick_days.length
       end
 
       def pay_day_offset
@@ -223,7 +219,7 @@ module SmartAnswer
       end
 
       def maximum_entitlement_reached?
-        prior_sick_days >= (days_of_the_week_worked.size * 28 + 3)
+        prev_sick_days >= (days_of_the_week_worked.size * 28 + 3)
       end
 
       def maximum_entitlement_reached_v2?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -274,12 +274,12 @@ module SmartAnswer
       end
 
       def sick_pay_weekly_dates
-        if @sick_end_date.sunday?
-          ssp_week_end = @sick_end_date + 6
+        if sick_end_date.sunday?
+          ssp_week_end = sick_end_date + 6
         else
-          ssp_week_end = @sick_end_date.end_of_week - 1
+          ssp_week_end = sick_end_date.end_of_week - 1
         end
-        (@sick_start_date..ssp_week_end).select { |day| day.wday == 6 }
+        (sick_start_date..ssp_week_end).select { |day| day.wday == 6 }
       end
 
       def weekly_payment(week_start_date)

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -5,11 +5,23 @@ module SmartAnswer
 
       class PeriodOfIncapacityForWork < DateRange
         def working_days(pattern)
-          StatutorySickPayCalculator.dates_matching_pattern(
+          self.class.dates_matching_pattern(
             from: begins_on,
             to: ends_on,
             pattern: pattern
           )
+        end
+
+        private
+
+        def self.dates_matching_pattern(from:, to:, pattern:)
+          dates = from..to
+          # create an array of all dates that would have been normal workdays
+          matching_dates = []
+          dates.each do |d|
+            matching_dates << d if pattern.include?(d.wday.to_s)
+          end
+          matching_dates
         end
       end
 
@@ -251,16 +263,6 @@ module SmartAnswer
         else
           (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
         end
-      end
-
-      def self.dates_matching_pattern(from:, to:, pattern:)
-        dates = from..to
-        # create an array of all dates that would have been normal workdays
-        matching_dates = []
-        dates.each do |d|
-          matching_dates << d if pattern.include?(d.wday.to_s)
-        end
-        matching_dates
       end
 
       def weekly_payments

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -58,11 +58,11 @@ module SmartAnswer
       end
 
       def pattern_days
-        @days_of_the_week_worked.length
+        days_of_the_week_worked.length
       end
 
       def normal_workdays_missed
-        @normal_workdays_missed ||= current_piw.qualifying_days(@days_of_the_week_worked)
+        @normal_workdays_missed ||= current_piw.qualifying_days(days_of_the_week_worked)
       end
 
       def normal_workdays

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -95,7 +95,8 @@ module SmartAnswer
       end
 
       def at_least_1_day_before_first_sick_day?
-        linked_sickness_end_date < sick_start_date - 1
+        gap = linked_piw.gap_between(current_piw)
+        !gap.empty?
       end
 
       def valid_period_of_incapacity_for_work?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -82,8 +82,7 @@ module SmartAnswer
       end
 
       def valid_last_sick_day?
-        period = DateRange.new(begins_on: sick_start_date, ends_on: sick_end_date)
-        period.number_of_days >= 1
+        current_piw.number_of_days >= 1
       end
 
       def valid_linked_sickness_start_date?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -90,8 +90,8 @@ module SmartAnswer
       end
 
       def within_eight_weeks_of_current_sickness_period?
-        earliest_allowed_date = sick_start_date - 8.weeks - 1.day
-        linked_sickness_end_date >= earliest_allowed_date
+        gap = linked_piw.gap_between(current_piw)
+        gap.number_of_days.days <= 8.weeks
       end
 
       def at_least_1_day_before_first_sick_day?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -77,10 +77,6 @@ module SmartAnswer
         (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).none?
       end
 
-      def days_sick
-        current_piw.number_of_days
-      end
-
       def valid_last_sick_day?
         !current_piw.empty?
       end
@@ -100,7 +96,7 @@ module SmartAnswer
       end
 
       def valid_period_of_incapacity_for_work?
-        days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
+        current_piw.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
       end
 
       def valid_linked_period_of_incapacity_for_work?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -2,6 +2,7 @@ module SmartAnswer
   module Calculators
     class StatutorySickPayCalculator
       class PeriodOfIncapacityForWork < DateRange
+        MAXIMUM_NUMBER_OF_WAITING_DAYS = 3
         MINIMUM_NUMBER_OF_DAYS = 4
 
         def qualifying_days(pattern)
@@ -54,11 +55,11 @@ module SmartAnswer
       end
 
       def number_of_waiting_days_in_linked_piw
-        [prev_sick_days, 3].min
+        [prev_sick_days, PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS].min
       end
 
       def number_of_waiting_days_not_in_linked_piw
-        3 - number_of_waiting_days_in_linked_piw
+        PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS - number_of_waiting_days_in_linked_piw
       end
 
       def pattern_days
@@ -233,7 +234,7 @@ module SmartAnswer
       end
 
       def maximum_entitlement_reached?
-        prev_sick_days >= (days_of_the_week_worked.length * 28 + 3)
+        prev_sick_days >= (days_of_the_week_worked.length * 28 + PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS)
       end
 
       def maximum_entitlement_reached_v2?
@@ -294,7 +295,7 @@ module SmartAnswer
       end
 
       def days_paid_in_linked_period
-        [prev_sick_days - 3, 0].max
+        [prev_sick_days - PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS, 0].max
       end
 
       def init_payable_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -294,11 +294,7 @@ module SmartAnswer
       end
 
       def days_paid_in_linked_period
-        if prev_sick_days > 3
-          prev_sick_days - 3
-        else
-          0
-        end
+        [prev_sick_days - 3, 0].max
       end
 
       def init_payable_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -13,6 +13,10 @@ module SmartAnswer
           end
           matching_dates
         end
+
+        def valid?
+          number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
+        end
       end
 
       include ActiveModel::Model
@@ -96,11 +100,11 @@ module SmartAnswer
       end
 
       def valid_period_of_incapacity_for_work?
-        current_piw.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
+        current_piw.valid?
       end
 
       def valid_linked_period_of_incapacity_for_work?
-        linked_piw.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
+        linked_piw.valid?
       end
 
       def valid_last_payday_before_sickness?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -229,7 +229,7 @@ module SmartAnswer
       end
 
       def maximum_entitlement_reached?
-        prev_sick_days >= (days_of_the_week_worked.size * 28 + 3)
+        prev_sick_days >= (days_of_the_week_worked.length * 28 + 3)
       end
 
       def maximum_entitlement_reached_v2?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -53,8 +53,12 @@ module SmartAnswer
         linked_piw.qualifying_days(days_of_the_week_worked).length
       end
 
+      def number_of_waiting_days_in_linked_piw
+        prev_sick_days < 3 ? prev_sick_days : 3
+      end
+
       def number_of_waiting_days_not_in_linked_piw
-        prev_sick_days >= 3 ? 0 : 3 - prev_sick_days
+        3 - number_of_waiting_days_in_linked_piw
       end
 
       def pattern_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -54,7 +54,7 @@ module SmartAnswer
       end
 
       def number_of_waiting_days_in_linked_piw
-        prev_sick_days < 3 ? prev_sick_days : 3
+        [prev_sick_days, 3].min
       end
 
       def number_of_waiting_days_not_in_linked_piw

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -100,8 +100,7 @@ module SmartAnswer
       end
 
       def valid_linked_period_of_incapacity_for_work?
-        period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: linked_sickness_end_date)
-        period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
+        linked_piw.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
       end
 
       def valid_last_payday_before_sickness?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -3,6 +3,9 @@ module SmartAnswer
     class StatutorySickPayCalculator
       MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK = 4
 
+      class PeriodOfIncapacityForWork < DateRange
+      end
+
       include ActiveModel::Model
 
       attr_accessor :sick_start_date, :sick_end_date, :days_of_the_week_worked
@@ -17,6 +20,13 @@ module SmartAnswer
       attr_accessor :total_employee_earnings
       attr_accessor :contractual_days_covered_by_earnings
       attr_accessor :days_covered_by_earnings
+
+      def current_period_of_incapacity_for_work
+        PeriodOfIncapacityForWork.new(
+          begins_on: sick_start_date,
+          ends_on: sick_end_date
+        )
+      end
 
       def prev_sick_days
         prior_sick_days
@@ -51,8 +61,7 @@ module SmartAnswer
       end
 
       def days_sick
-        period = DateRange.new(begins_on: sick_start_date, ends_on: sick_end_date)
-        period.number_of_days
+        current_period_of_incapacity_for_work.number_of_days
       end
 
       def valid_last_sick_day?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -62,7 +62,7 @@ module SmartAnswer
       end
 
       def normal_workdays_missed
-        @normal_workdays_missed ||= init_normal_workdays_missed(@days_of_the_week_worked)
+        @normal_workdays_missed ||= current_piw.qualifying_days(@days_of_the_week_worked)
       end
 
       def normal_workdays
@@ -295,10 +295,6 @@ module SmartAnswer
         else
           0
         end
-      end
-
-      def init_normal_workdays_missed(days_of_the_week_worked)
-        current_piw.qualifying_days(days_of_the_week_worked)
       end
 
       def init_payable_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -86,7 +86,7 @@ module SmartAnswer
       end
 
       def valid_linked_sickness_start_date?
-        sick_start_date > linked_sickness_start_date
+        linked_piw.begins_before?(current_piw)
       end
 
       def within_eight_weeks_of_current_sickness_period?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -82,7 +82,7 @@ module SmartAnswer
       end
 
       def valid_last_sick_day?
-        current_piw.number_of_days >= 1
+        !current_piw.empty?
       end
 
       def valid_linked_sickness_start_date?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -1,7 +1,7 @@
 module SmartAnswer
   module Calculators
     class StatutorySickPayCalculator
-      MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK = 4
+      MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK = 4
 
       include ActiveModel::Model
 
@@ -74,12 +74,12 @@ module SmartAnswer
       end
 
       def valid_period_of_incapacity_for_work?
-        days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
+        days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
       end
 
       def valid_linked_period_of_incapacity_for_work?
         period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: linked_sickness_end_date)
-        period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
+        period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_FOR_WORK
       end
 
       def valid_last_payday_before_sickness?

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -53,7 +53,7 @@ module SmartAnswer
         linked_piw.qualifying_days(days_of_the_week_worked).length
       end
 
-      def waiting_days
+      def number_of_waiting_days_not_in_linked_piw
         prev_sick_days >= 3 ? 0 : 3 - prev_sick_days
       end
 
@@ -301,7 +301,7 @@ module SmartAnswer
         # copy not to modify the instance variable we need to keep
         payable_days_temp = normal_workdays_missed.dup
         ## 1. remove up to 3 first dates from the array if there are waiting days in this period
-        payable_days_temp.shift(waiting_days)
+        payable_days_temp.shift(number_of_waiting_days_not_in_linked_piw)
         ## 2. return only the first days_that_can_be_paid_for_this_period
         payable_days_temp.shift(days_that_can_be_paid_for_this_period)
       end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -30,14 +30,14 @@ module SmartAnswer
       attr_accessor :contractual_days_covered_by_earnings
       attr_accessor :days_covered_by_earnings
 
-      def current_period_of_incapacity_for_work
+      def current_piw
         PeriodOfIncapacityForWork.new(
           begins_on: sick_start_date,
           ends_on: sick_end_date
         )
       end
 
-      def linked_period_of_incapacity_for_work
+      def linked_piw
         PeriodOfIncapacityForWork.new(
           begins_on: linked_sickness_start_date,
           ends_on: linked_sickness_end_date
@@ -46,9 +46,7 @@ module SmartAnswer
 
       def prev_sick_days
         return 0 unless has_linked_sickness
-        linked_period_of_incapacity_for_work.working_days(
-          days_of_the_week_worked
-        ).length
+        linked_piw.working_days(days_of_the_week_worked).length
       end
 
       def waiting_days
@@ -80,7 +78,7 @@ module SmartAnswer
       end
 
       def days_sick
-        current_period_of_incapacity_for_work.number_of_days
+        current_piw.number_of_days
       end
 
       def valid_last_sick_day?
@@ -301,9 +299,7 @@ module SmartAnswer
       end
 
       def init_normal_workdays_missed(days_of_the_week_worked)
-        current_period_of_incapacity_for_work.working_days(
-          days_of_the_week_worked
-        )
+        current_piw.working_days(days_of_the_week_worked)
       end
 
       def init_payable_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -4,7 +4,7 @@ module SmartAnswer
       class PeriodOfIncapacityForWork < DateRange
         MINIMUM_NUMBER_OF_DAYS = 4
 
-        def working_days(pattern)
+        def qualifying_days(pattern)
           dates = begins_on..ends_on
           # create an array of all dates that would have been normal workdays
           matching_dates = []
@@ -50,7 +50,7 @@ module SmartAnswer
 
       def prev_sick_days
         return 0 unless has_linked_sickness
-        linked_piw.working_days(days_of_the_week_worked).length
+        linked_piw.qualifying_days(days_of_the_week_worked).length
       end
 
       def waiting_days
@@ -298,7 +298,7 @@ module SmartAnswer
       end
 
       def init_normal_workdays_missed(days_of_the_week_worked)
-        current_piw.working_days(days_of_the_week_worked)
+        current_piw.qualifying_days(days_of_the_week_worked)
       end
 
       def init_payable_days

--- a/lib/smart_answer/date_range.rb
+++ b/lib/smart_answer/date_range.rb
@@ -60,5 +60,9 @@ module SmartAnswer
     def empty?
       number_of_days == 0
     end
+
+    def begins_before?(other)
+      ComparableDate.new(begins_on) < ComparableDate.new(other.begins_on)
+    end
   end
 end

--- a/lib/smart_answer/date_range.rb
+++ b/lib/smart_answer/date_range.rb
@@ -64,5 +64,12 @@ module SmartAnswer
     def begins_before?(other)
       ComparableDate.new(begins_on) < ComparableDate.new(other.begins_on)
     end
+
+    def gap_between(other)
+      self.class.new(
+        begins_on: [ComparableDate.new(ends_on), ComparableDate.new(other.ends_on)].min.date + 1,
+        ends_on: [ComparableDate.new(begins_on), ComparableDate.new(other.begins_on)].max.date - 1
+      )
+    end
   end
 end

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -29,5 +29,5 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/pay_amount_if_not_
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.govspeak.erb: 46ce81328d55d2bef88bb1047cf047cd
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 6d88363ba1319f8b2a6a63d75c626183
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 48289bfc2406d317c688d9e0206c31dd
 lib/data/rates/statutory_sick_pay.yml: b275311f2ec89fc707e6b9cfefec1179

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -4,14 +4,14 @@ module SmartAnswer
   module Calculators
     class StatutorySickPayCalculatorTest < ActiveSupport::TestCase
       context "period of incapacity for work" do
-        context "working_days" do
+        context "qualifying_days" do
           should "return dates matching working days pattern" do
             pattern = %w(Sunday Tuesday Thursday).map { |d| Date::DAYNAMES.index(d).to_s }
             piw = StatutorySickPayCalculator::PeriodOfIncapacityForWork.new(
               begins_on: Date.parse("Sun, 04 Jan 2015"),
               ends_on:   Date.parse("Wed, 14 Jan 2015"),
             )
-            dates = piw.working_days(pattern)
+            dates = piw.qualifying_days(pattern)
             assert_equal [
               Date.parse("Sun, 04 Jan 2015"), Date.parse("Tue, 06 Jan 2015"), Date.parse("Thu, 08 Jan 2015"),
               Date.parse("Sun, 11 Jan 2015"), Date.parse("Tue, 13 Jan 2015")

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -3,18 +3,20 @@ require_relative "../../test_helper"
 module SmartAnswer
   module Calculators
     class StatutorySickPayCalculatorTest < ActiveSupport::TestCase
-      context ".dates_matching_pattern" do
-        should "return dates maching working days pattern" do
-          working_days = %w(Sunday Tuesday Thursday).map { |d| Date::DAYNAMES.index(d).to_s }
-          dates = StatutorySickPayCalculator::PeriodOfIncapacityForWork.dates_matching_pattern(
-            from: Date.parse("Sun, 04 Jan 2015"),
-            to:   Date.parse("Wed, 14 Jan 2015"),
-            pattern: working_days
-          )
-          assert_equal [
-            Date.parse("Sun, 04 Jan 2015"), Date.parse("Tue, 06 Jan 2015"), Date.parse("Thu, 08 Jan 2015"),
-            Date.parse("Sun, 11 Jan 2015"), Date.parse("Tue, 13 Jan 2015")
-          ], dates
+      context "period of incapacity for work" do
+        context "working_days" do
+          should "return dates matching working days pattern" do
+            pattern = %w(Sunday Tuesday Thursday).map { |d| Date::DAYNAMES.index(d).to_s }
+            piw = StatutorySickPayCalculator::PeriodOfIncapacityForWork.new(
+              begins_on: Date.parse("Sun, 04 Jan 2015"),
+              ends_on:   Date.parse("Wed, 14 Jan 2015"),
+            )
+            dates = piw.working_days(pattern)
+            assert_equal [
+              Date.parse("Sun, 04 Jan 2015"), Date.parse("Tue, 06 Jan 2015"), Date.parse("Thu, 08 Jan 2015"),
+              Date.parse("Sun, 11 Jan 2015"), Date.parse("Tue, 13 Jan 2015")
+            ], dates
+          end
         end
       end
 

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -6,7 +6,7 @@ module SmartAnswer
       context ".dates_matching_pattern" do
         should "return dates maching working days pattern" do
           working_days = %w(Sunday Tuesday Thursday).map { |d| Date::DAYNAMES.index(d).to_s }
-          dates = StatutorySickPayCalculator.dates_matching_pattern(
+          dates = StatutorySickPayCalculator::PeriodOfIncapacityForWork.dates_matching_pattern(
             from: Date.parse("Sun, 04 Jan 2015"),
             to:   Date.parse("Wed, 14 Jan 2015"),
             pattern: working_days

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -236,8 +236,8 @@ module SmartAnswer
           assert_equal @calculator.prev_sick_days, 5
         end
 
-        should "return waiting_days of 0" do
-          assert_equal @calculator.waiting_days, 0
+        should "return number_of_waiting_days_not_in_linked_piw of 0" do
+          assert_equal @calculator.number_of_waiting_days_not_in_linked_piw, 0
         end
 
         should "return daily rate of 17.1700" do
@@ -344,8 +344,8 @@ module SmartAnswer
           assert_equal @calculator.prev_sick_days, 2
         end
 
-        should "return waiting_days of 1" do
-          assert_equal @calculator.waiting_days, 1
+        should "return number_of_waiting_days_not_in_linked_piw of 1" do
+          assert_equal @calculator.number_of_waiting_days_not_in_linked_piw, 1
         end
       end
 
@@ -362,8 +362,8 @@ module SmartAnswer
           assert_equal @calculator.prev_sick_days, 1
         end
 
-        should "return waiting_days of 2" do
-          assert_equal @calculator.waiting_days, 2
+        should "return number_of_waiting_days_not_in_linked_piw of 2" do
+          assert_equal @calculator.number_of_waiting_days_not_in_linked_piw, 2
           assert_equal @calculator.normal_workdays, 5
           assert_equal @calculator.send(:days_to_pay), 3
         end
@@ -380,8 +380,8 @@ module SmartAnswer
           assert_equal @calculator.prev_sick_days, 0
         end
 
-        should "return waiting_days of 3, ssp payment of 0" do
-          assert_equal @calculator.waiting_days, 3
+        should "return number_of_waiting_days_not_in_linked_piw of 3, ssp payment of 0" do
+          assert_equal @calculator.number_of_waiting_days_not_in_linked_piw, 3
           assert_equal @calculator.send(:days_to_pay), 0
           assert_equal @calculator.normal_workdays, 3
           assert_equal @calculator.ssp_payment, 0.00
@@ -458,7 +458,7 @@ module SmartAnswer
         end
 
         should "give correct ssp calculation" do # 15 days with 3 waiting days, so 6 days at lower weekly rate, 6 days at higher rate
-          assert_equal @calculator.waiting_days, 3
+          assert_equal @calculator.number_of_waiting_days_not_in_linked_piw, 3
           assert_equal @calculator.send(:days_to_pay), 12
           assert_equal @calculator.normal_workdays, 15
           assert_equal @calculator.ssp_payment, 200.94
@@ -557,7 +557,7 @@ module SmartAnswer
         end
 
         should "give correct ssp calculation" do # 12 days with 3 waiting days, all at 2012-13 daily rate
-          assert_equal @calculator.waiting_days, 3
+          assert_equal @calculator.number_of_waiting_days_not_in_linked_piw, 3
           assert_equal @calculator.send(:days_to_pay), 9
           assert_equal @calculator.normal_workdays, 12
           assert_equal @calculator.ssp_payment, 386.33
@@ -617,7 +617,7 @@ module SmartAnswer
 
         should "give correct ssp calculation" do # there should be 3 normal workdays to pay
           assert_equal @calculator.send(:days_to_pay), 3
-          assert_equal @calculator.waiting_days, 3
+          assert_equal @calculator.number_of_waiting_days_not_in_linked_piw, 3
           assert_equal @calculator.ssp_payment, 257.55
         end
       end

--- a/test/unit/date_range_test.rb
+++ b/test/unit/date_range_test.rb
@@ -294,5 +294,60 @@ module SmartAnswer
         refute @date_range.begins_before?(does_not_start_after)
       end
     end
+
+    context 'between' do
+      context 'two overlapping date ranges' do
+        setup do
+          @date_range = DateRange.new(begins_on: Date.parse('2000-01-01'), ends_on: Date.parse('2000-12-31'))
+          @overlapping = DateRange.new(begins_on: Date.parse('2000-06-01'), ends_on: Date.parse('2001-05-31'))
+        end
+
+        should 'return an empty date range, because there is no gap' do
+          gap = @date_range.gap_between(@overlapping)
+          assert gap.empty?
+        end
+      end
+
+      context 'two infinite overlapping date ranges' do
+        setup do
+          @date_range = DateRange.new(ends_on: Date.parse('2000-12-31'))
+          @overlapping = DateRange.new(begins_on: Date.parse('2000-06-01'))
+        end
+
+        should 'return an empty date range, because there is no gap' do
+          gap = @date_range.gap_between(@overlapping)
+          assert gap.empty?
+        end
+      end
+
+      context 'two non-overlapping date ranges' do
+        setup do
+          @date_range = DateRange.new(begins_on: Date.parse('2000-01-01'), ends_on: Date.parse('2000-12-31'))
+          @non_overlapping = DateRange.new(begins_on: Date.parse('2002-01-01'), ends_on: Date.parse('2002-12-31'))
+        end
+
+        should 'return the gap between the two date ranges' do
+          gap = @date_range.gap_between(@non_overlapping)
+          assert_equal DateRange.new(begins_on: Date.parse('2001-01-01'), ends_on: Date.parse('2001-12-31')), gap
+        end
+
+        should 'be commutative' do
+          gap = @non_overlapping.gap_between(@date_range)
+          assert_equal DateRange.new(begins_on: Date.parse('2001-01-01'), ends_on: Date.parse('2001-12-31')), gap
+        end
+      end
+
+      context 'two non-overlapping infinite date ranges' do
+        setup do
+          @date_range = DateRange.new(ends_on: Date.parse('2000-12-31'))
+          @non_overlapping = DateRange.new(begins_on: Date.parse('2002-01-01'))
+        end
+
+        should 'return the gap between the two date ranges' do
+          gap = @date_range.gap_between(@non_overlapping)
+          assert_equal DateRange.new(begins_on: Date.parse('2001-01-01'), ends_on: Date.parse('2001-12-31')), gap
+        end
+      end
+    end
   end
 end

--- a/test/unit/date_range_test.rb
+++ b/test/unit/date_range_test.rb
@@ -268,5 +268,31 @@ module SmartAnswer
         end
       end
     end
+
+    context 'begins_before?' do
+      setup do
+        @date_range = DateRange.new(begins_on: Date.parse('2000-01-02'))
+      end
+
+      should 'be true if date range starts before specified date range' do
+        starts_before = DateRange.new(begins_on: Date.parse('2000-01-01'))
+        assert starts_before.begins_before?(@date_range)
+      end
+
+      should 'be true if date range starts infinitely before specified date range' do
+        starts_before = DateRange.new(begins_on: nil)
+        assert starts_before.begins_before?(@date_range)
+      end
+
+      should 'be false if date range starts on same day as specified date range' do
+        does_not_start_before = @date_range.dup
+        refute does_not_start_before.begins_before?(@date_range)
+      end
+
+      should 'be false if date range starts after specified infinite date range' do
+        does_not_start_after = DateRange.new(begins_on: nil)
+        refute @date_range.begins_before?(does_not_start_after)
+      end
+    end
   end
 end

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -13,6 +13,10 @@ module SmartAnswer
     end
 
     context 'when answering last_sick_day? question' do
+      setup do
+        @calculator.sick_start_date = Date.parse('2015-01-01')
+      end
+
       context 'and sickness period is valid period of incapacity for work' do
         setup do
           @calculator.stubs(valid_period_of_incapacity_for_work?: true)


### PR DESCRIPTION
## Description

Supersedes: #2280

Trello card: https://trello.com/c/uu0HeZee

When I was fixing problems with `calculate-statutory-sick-pay` at the end of last year, I realised that there was at least one missing concept in the code - namely the  [Period of Incapacity for Work][1] (PIW).

This PR introduces that concept as an inner class within the SSP calculator. I think this reduces duplication and significantly improves the readability and testability of the code.

There's a lot more that could be done to improve the SSP calculator code, but I think this represents a decent step forward and I'd like to get it merged.

## External changes

There should be no externally observable changes in behaviour as this is just a refactoring.

[1]: http://www.hmrc.gov.uk/manuals/spmmanual/spm110500.htm