### PR TITLE
Refactor TranslatorLinks to handle alternate links

### DIFF
--- a/lib/data/alternative_translators_links.yml
+++ b/lib/data/alternative_translators_links.yml
@@ -1,0 +1,2 @@
+---
+spain: http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx

--- a/lib/smart_answer/calculators/translator_links.rb
+++ b/lib/smart_answer/calculators/translator_links.rb
@@ -1,13 +1,22 @@
 module SmartAnswer::Calculators
   class TranslatorLinks
-    attr_reader :links
+    attr_reader :links, :alternate_links
 
     def initialize
       @links = self.class.translator_links
+      @alternate_links = self.class.alternate_links
     end
 
     def self.translator_links
       YAML.load_file(Rails.root.join("lib", "data", "translators.yml"))
+    end
+
+    def self.alternate_links
+      YAML.load_file(Rails.root.join("lib", "data", "alternative_translators_links.yml"))
+    end
+
+    def alternate_link?(country)
+      @alternate_links.has_key?(country)
     end
   end
 end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -220,7 +220,11 @@ module SmartAnswer
         end
 
         precalculate :translator_link_url do
-          translator_query.links[country_of_birth]
+          if translator_query.alternate_link?(country_of_birth)
+            translator_query.alternate_links[country_of_birth]
+          else
+            translator_query.links[country_of_birth]
+          end
         end
       end
 

--- a/test/artefacts/register-a-birth/spain/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2006-06-30.txt
@@ -1,0 +1,17 @@
+
+
+$!You must register the birth according to the regulations in Spain.$!
+
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+
+You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
+
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on the father's [legal country of domicile](/government/publications/legitimation-and-domicile) at the time of the birth)
+- the country where the father was [legally domiciled](/government/publications/legitimation-and-domicile) at the time of the birth did not distinguish between married and unmarried parents
+
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/spain/father/no/2015-02-02/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/spain/father/yes/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/spain/mother/no/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/spain/mother/yes/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/no/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/spain/mother_and_father/yes/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘certificación literal’) - it must have both parents’ names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/spain/neither.txt
+++ b/test/artefacts/register-a-birth/spain/neither.txt
@@ -1,0 +1,6 @@
+
+
+You can’t register your child’s birth with the UK authorities. Your child must have an automatic claim to British nationality at birth to be eligible.
+
+
+

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,7 +1,7 @@
 ---
-lib/smart_answer_flows/register-a-birth.rb: 232ef65452cefa8a62711ee7a0bb4c4b
-test/data/register-a-birth-questions-and-responses.yml: c59cb1d0c11f3ad29f905b632f7c58bb
-test/data/register-a-birth-responses-and-expected-results.yml: 3ac4372034c86d8cc87665db59ff11d5
+lib/smart_answer_flows/register-a-birth.rb: aa8331ad5b974c2c76a9363c80babda1
+test/data/register-a-birth-questions-and-responses.yml: 2b592a7da9ebfba015f0aea380847b1a
+test/data/register-a-birth-responses-and-expected-results.yml: d9529fff9f57f406eb5b20b007ab5e0a
 lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb: a2bc6c611c6809b333ab42066a805f71
 lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb: a7c70e3191f23f7e747cb45587e4825f
 lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb: e07b86c2a892f42b0cab80b166af05df
@@ -26,7 +26,7 @@ lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/data/registrations.yml: 2eb5c61678f21bd9cc06af67c230279f
 lib/smart_answer/calculators/country_name_formatter.rb: 16b57a11261644a0bda0d609a60d1c62
 lib/smart_answer/calculators/registrations_data_query.rb: 6e66e8a3884f3efa3118434e2b28e876
-lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
+lib/smart_answer/calculators/translator_links.rb: f3bdbe9ef2ca8bd9efb53763d71a7b43
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029
 test/fixtures/worldwide/afghanistan_organisations.json: 17c0cf62dc952a13684d25c0374263ac
 test/fixtures/worldwide/algeria_organisations.json: 0351ae95cffe4095b3287058ca9af42e

--- a/test/data/register-a-birth-questions-and-responses.yml
+++ b/test/data/register-a-birth-questions-and-responses.yml
@@ -14,6 +14,7 @@
 - timor-leste # indonesia_british_father_paternity
 - usa # birth_registration_form_usa
 - venezuela # book_appointment_at_embassy
+- spain
 :who_has_british_nationality?:
 - mother
 - father

--- a/test/data/register-a-birth-responses-and-expected-results.yml
+++ b/test/data/register-a-birth-responses-and-expected-results.yml
@@ -9137,3 +9137,787 @@
   - neither
   :next_node: :no_registration_result
   :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - spain
+  :next_node: :who_has_british_nationality?
+  :outcome_node: false
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - spain
+  - mother
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother
+  - 'no'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - spain
+  - father
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - father
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  :next_node: :childs_date_of_birth?
+  :outcome_node: false
+- :current_node: :childs_date_of_birth?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2006-06-30'
+  :next_node: :homeoffice_result
+  :outcome_node: true
+- :current_node: :childs_date_of_birth?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - father
+  - 'no'
+  - '2015-02-02'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - spain
+  - mother_and_father
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - spain
+  - mother_and_father
+  - 'no'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - spain
+  - neither
+  :next_node: :no_registration_result
+  :outcome_node: true

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -24,7 +24,7 @@ lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 test/fixtures/worldwide/italy_organisations.json: 536304a31cc5d56801162af4d056d6bd
 lib/smart_answer/calculators/registrations_data_query.rb: 6e66e8a3884f3efa3118434e2b28e876
 lib/smart_answer/calculators/country_name_formatter.rb: 16b57a11261644a0bda0d609a60d1c62
-lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
+lib/smart_answer/calculators/translator_links.rb: f3bdbe9ef2ca8bd9efb53763d71a7b43
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029
 test/fixtures/worldwide/algeria_organisations.json: 0351ae95cffe4095b3287058ca9af42e
 test/fixtures/worldwide/australia_organisations.json: e1f694483eaf4fb50808f688db0ff9c5

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -144,7 +144,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
             assert_state_variable :registration_country, 'spain'
             assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk/start"
             assert_current_node :oru_result
-            assert_state_variable :translator_link_url, "/government/publications/spain-list-of-lawyers"
+            assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
           end
         end
       end # married

--- a/test/unit/calculators/translator_links_test.rb
+++ b/test/unit/calculators/translator_links_test.rb
@@ -40,6 +40,34 @@ module SmartAnswer::Calculators
           refute @data.links['pitcairn']
         end
       end
+
+      context "alternate links" do
+        setup do
+          YAML.stubs(:load_file).returns(
+            'spain' =>
+              'http://gob.es/path/to/spanish/translator/page',
+          )
+          @translator_links = TranslatorLinks.new
+        end
+
+        should "return true for a defined country(spain)" do
+          assert_equal true, @translator_links.alternate_link?('spain')
+        end
+
+        should "return false for an undefined country (belguim)" do
+          assert_equal false, @translator_links.alternate_link?('belgium')
+        end
+
+        should "return alternative link for spain" do
+          assert_equal 'http://gob.es/path/to/spanish/translator/page',
+            @translator_links.alternate_links['spain']
+        end
+
+        should "return nil for belgium" do
+          assert_equal nil,
+            @translator_links.alternate_links['belgium']
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Trello Story: https://trello.com/c/nIdy7kh6/75-register-a-birth-abroad-spain-translators-link

* Change Spanish translator link 

## Factcheck

[Preview link](https://smart-answers-pr-2484.herokuapp.com/register-a-birth/y/spain/mother/yes/same_country) 
[GOV.UK](https://gov.uk/register-a-birth/y/spain/mother/yes/same_country) 

### Expected changes
* Under the "Check your documents" header, the first para has a link to approved translators. The link should change from:
https://www.gov.uk/government/publications/spain-list-of-lawyers to http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx

### Before
![screen shot 2016-04-26 at 14 58 42](https://cloud.githubusercontent.com/assets/84896/14820823/2baf2074-0bc0-11e6-9a1f-3ce17afab24c.png)


### After
 
![screen shot 2016-04-26 at 14 59 22](https://cloud.githubusercontent.com/assets/84896/14820831/310d1a26-0bc0-11e6-9978-055ca4a08f8a.png)
