### PR TITLE
Avoid raising InvalidResponse exception in calculators

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -72,7 +72,11 @@ module SmartAnswer::Calculators
     end
 
     def world_location
-      WorldLocation.find(ceremony_country) || raise(SmartAnswer::InvalidResponse)
+      WorldLocation.find(ceremony_country)
+    end
+
+    def valid_ceremony_country?
+      world_location.present?
     end
 
     def ceremony_country_name

--- a/lib/smart_answer/calculators/married_couples_allowance_calculator.rb
+++ b/lib/smart_answer/calculators/married_couples_allowance_calculator.rb
@@ -1,17 +1,10 @@
 module SmartAnswer::Calculators
   class MarriedCouplesAllowanceCalculator
-    attr_accessor :validate_income
-
-    def initialize(validate_income: true)
-      @validate_income = validate_income
-    end
-
     def calculate_adjusted_net_income(income, gross_pension_contributions, net_pension_contributions, gift_aided_donations)
       income - gross_pension_contributions - (net_pension_contributions * 1.25) - (gift_aided_donations * 1.25)
     end
 
     def calculate_allowance(age_related_allowance, income)
-      validate(income) if validate_income
       income = 1 if income < 1
 
       mca_entitlement = maximum_mca
@@ -39,10 +32,6 @@ module SmartAnswer::Calculators
 
       mca = mca_entitlement * 0.1
       SmartAnswer::Money.new(mca)
-    end
-
-    def validate(income)
-      raise SmartAnswer::InvalidResponse if income < 1
     end
 
     def maximum_mca

--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -26,8 +26,6 @@ module SmartAnswer::Calculators
         date_of_birth > FEMALE_YOUNGEST_DOB
       when 'male'
         date_of_birth > MALE_YOUNGEST_DOB
-      else
-        raise SmartAnswer::InvalidResponse
       end
     end
 

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -30,7 +30,7 @@ module SmartAnswer
         end
 
         calculate :calculator do
-          Calculators::MarriedCouplesAllowanceCalculator.new(validate_income: false)
+          Calculators::MarriedCouplesAllowanceCalculator.new
         end
 
         next_node do |response|

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -24,6 +24,10 @@ module SmartAnswer
           calculator.ceremony_country = response
         end
 
+        validate do
+          calculator.valid_ceremony_country?
+        end
+
         next_node do
           if calculator.ceremony_country == 'ireland'
             question :partner_opposite_or_same_sex?

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-married-couples-allowance.rb: 2f2006fce32a89da526fda3ad51bdc07
+lib/smart_answer_flows/calculate-married-couples-allowance.rb: 26e5b73a363f0083644daa025e6312a3
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 3cdcbf373de49fa6383b7dcb1967eb80
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3a6d219be3fceda5e5e091520ab5227f
 lib/smart_answer_flows/calculate-married-couples-allowance/calculate_married_couples_allowance.govspeak.erb: 2a107c5f5eccf492a1bbb055fb87ee2c
@@ -22,4 +22,4 @@ lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_h
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_husbands_date_of_birth.govspeak.erb: e4fc026bed0343ef3a2727da6c8ed30a
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_husbands_income.govspeak.erb: dd71c9678c1f2b9eba3471151b2ba839
 lib/data/rates/married_couples_allowance.yml: 4963b39377d58a433c033b657f595810
-lib/smart_answer/calculators/married_couples_allowance_calculator.rb: c8c647584dda5e9192282b8ee20561b2
+lib/smart_answer/calculators/married_couples_allowance_calculator.rb: da03eb7f2e9058aff0bd4ef8fb34f7c2

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 2d74e9acd7911ed675bc9313327cc433
+lib/smart_answer_flows/marriage-abroad.rb: 021ab7c796f9f88896a579d285ad72c8
 test/data/marriage-abroad-questions-and-responses.yml: 2debf4d9c0e525b5fe3b44ca701e36e0
 test/data/marriage-abroad-responses-and-expected-results.yml: 036c68d4bd7329533da81902fa1c6ac4
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027
@@ -146,7 +146,7 @@ lib/smart_answer_flows/marriage-abroad/questions/partner_opposite_or_same_sex.go
 lib/smart_answer_flows/marriage-abroad/questions/what_is_your_partners_nationality.govspeak.erb: 80e04f36c75c232bede1a244d621471e
 lib/data/rates/marriage_abroad_consular_fees.yml: db466bd97c7ee1b9a275dec70590d61f
 lib/data/marriage_abroad_services.yml: 2715735cb6045f54c6c45dc91ae63c4e
-lib/smart_answer/calculators/marriage_abroad_calculator.rb: 4cb4e31a2f91a8559525598321328111
+lib/smart_answer/calculators/marriage_abroad_calculator.rb: 339e2a32b5f2e8d1ecd58292f0e7fd87
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: abae964cf47d9f1ecbad30f9a4e2ed0b
 lib/smart_answer/calculators/country_name_formatter.rb: 16b57a11261644a0bda0d609a60d1c62

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -9,6 +9,6 @@ lib/smart_answer_flows/state-pension-topup/questions/dob_age.govspeak.erb: a98e1
 lib/smart_answer_flows/state-pension-topup/questions/gender.govspeak.erb: f388163b3d7abb9c78bfe8265b2f2856
 lib/smart_answer_flows/state-pension-topup/questions/how_much_extra_per_week.govspeak.erb: fcbf62d8db40dde727445b1742e7b958
 lib/smart_answer_flows/state-pension-topup/state_pension_topup.govspeak.erb: 4abd6d43b9288c4da91ace7460d09132
-lib/smart_answer/calculators/state_pension_topup_calculator.rb: 8c7fd0813d54ce07b02b0bee27019121
+lib/smart_answer/calculators/state_pension_topup_calculator.rb: 9ff8cf2d08e8f49f618f2ac12e6df880
 lib/smart_answer/calculators/state_pension_topup_data_query.rb: 62717af09ad451e49dbb9e1a4d5422bc
 lib/data/pension_top_up_data.yml: 8fb3111dcf367687e4035e1dcc8d003b

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -238,13 +238,23 @@ module SmartAnswer
 
           assert_equal 'world-location', @calculator.world_location
         end
+      end
 
-        should 'raise an InvalidResponse exception if the world location cannot be found for the ceremony country' do
-          WorldLocation.stubs(:find).with('ceremony-country').returns(nil)
+      context '#valid_ceremony_country?' do
+        setup do
+          @calculator = MarriageAbroadCalculator.new
+        end
 
-          assert_raise(InvalidResponse) do
-            @calculator.world_location
-          end
+        should 'return true if the world location can be found' do
+          @calculator.stubs(:world_location).returns(stub('world-location'))
+
+          assert @calculator.valid_ceremony_country?
+        end
+
+        should 'return false if the world location cannot be found' do
+          @calculator.stubs(:world_location).returns(nil)
+
+          refute @calculator.valid_ceremony_country?
         end
       end
 

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -49,15 +49,7 @@ module SmartAnswer::Calculators
       assert_equal SmartAnswer::Money.new("721"), result
     end
 
-    # backwards compatibility with version 1
-    test "don't allow an income less than 1 by default" do
-      assert_raises SmartAnswer::InvalidResponse do
-        default_calculator.calculate_allowance(@age_related_allowance, 0)
-      end
-    end
-
-    test "allow an income less than 1 when income validation is false" do
-      default_calculator.validate_income = false
+    test "allow an income less than 1" do
       result = default_calculator.calculate_allowance(@age_related_allowance, 0)
       assert_equal SmartAnswer::Money.new("802"), result
     end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -84,5 +84,39 @@ module SmartAnswer::Calculators
         assert_equal [], @calculator.lump_sum_and_age(Date.parse('1951-04-06'), 1, 'male')
       end
     end
+
+    context '#too_young?' do
+      setup do
+        @calculator = StatePensionTopupCalculator.new
+      end
+
+      context 'when gender is female' do
+        setup do
+          @threshold_date = StatePensionTopupCalculator::FEMALE_YOUNGEST_DOB
+        end
+
+        should 'be true if date of birth is after threshold date' do
+          assert @calculator.too_young?(@threshold_date + 1, 'female')
+        end
+
+        should 'be false if date of birth is on threshold date' do
+          refute @calculator.too_young?(@threshold_date, 'female')
+        end
+      end
+
+      context 'when gender is male' do
+        setup do
+          @threshold_date = StatePensionTopupCalculator::MALE_YOUNGEST_DOB
+        end
+
+        should 'be true if date of birth is after threshold date' do
+          assert @calculator.too_young?(@threshold_date + 1, 'male')
+        end
+
+        should 'be false if date of birth is on threshold date' do
+          refute @calculator.too_young?(@threshold_date, 'male')
+        end
+      end
+    end
   end
 end

--- a/test/unit/smart_answer_flows/marriage_abroad_flow_test.rb
+++ b/test/unit/smart_answer_flows/marriage_abroad_flow_test.rb
@@ -35,6 +35,20 @@ module SmartAnswer
       should 'store parsed response on calculator as ceremony_country' do
         assert_equal 'afghanistan', @calculator.ceremony_country
       end
+
+      context 'responding with an invalid ceremony country' do
+        setup do
+          @calculator.stubs(:valid_ceremony_country?).returns(false)
+        end
+
+        should 'raise an exception' do
+          assert_raise(SmartAnswer::InvalidResponse) do
+            setup_states_for_question(:country_of_ceremony?,
+              responding_with: 'unknown-country',
+              initial_state: { calculator: @calculator })
+          end
+        end
+      end
     end
 
     context 'when answering legal_residency? question' do


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/aPkzlCZb

Avoid raising a `SmartAnswer::InvalidResponse` exception from within any calculators. It's better to have all of these exceptions raised from the same level of abstraction (i.e. within the flow itself) and ideally using a `validate` block. The following calculators for the following flows are affected:

* `marriage-abroad`
* `calculate-married-couples-allowance`
* `state-pension-topup`

## External changes

None. This is just an internal refactoring.