### PR TITLE
Remove unused `outcomes` attr_reader from Flow class

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 
 module SmartAnswer
   class Flow
-    attr_reader :nodes, :outcomes
+    attr_reader :nodes
     attr_accessor :status, :need_id
 
     def self.build


### PR DESCRIPTION
## Description

The `outcomes` method defined later in the file replaces this making it redundant. Both have been present since the [first commit][1] of this file.

## External changes

None. This is just a very minor internal refactoring.

[1]: 659b96663794d9fb8b5d6f9d032e6588a97e510f