### PR TITLE
Change Spanish translator link for register a birth and death

### DIFF
--- a/lib/data/translators.yml
+++ b/lib/data/translators.yml
@@ -60,7 +60,7 @@ san-marino: /government/publications/italy-list-of-lawyers
 serbia: /government/publications/list-of-translators-and-interpreters-in-serbia
 slovakia: /government/publications/slovakia-list-of-lawyers
 slovenia: /government/publications/slovenia-list-of-lawyers
-spain: /government/publications/spain-list-of-lawyers
+spain: http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx
 switzerland: /government/publications/switzerland-list-of-lawyers
 the-occupied-palestinian-territories: /government/publications/the-occupied-palestinian-territories-list-of-lawyers
 united-arab-emirates: /government/publications/united-arab-emirates-list-of-lawyers

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -22,7 +22,7 @@ lib/data/rates/register_a_birth.yml: 8d678c61d06f614a67e8faa1933b0ff5
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
-lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
+lib/data/translators.yml: f51e2bb27d2e33a3ac05032988ccd573
 lib/data/registrations.yml: 2eb5c61678f21bd9cc06af67c230279f
 lib/smart_answer/calculators/country_name_formatter.rb: 16b57a11261644a0bda0d609a60d1c62
 lib/smart_answer/calculators/registrations_data_query.rb: 6e66e8a3884f3efa3118434e2b28e876

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -20,7 +20,7 @@ lib/data/rates/register_a_death.yml: f24583d68edd4b06242b5a92e08e25c3
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
-lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
+lib/data/translators.yml: f51e2bb27d2e33a3ac05032988ccd573
 test/fixtures/worldwide/italy_organisations.json: 536304a31cc5d56801162af4d056d6bd
 lib/smart_answer/calculators/registrations_data_query.rb: 6e66e8a3884f3efa3118434e2b28e876
 lib/smart_answer/calculators/country_name_formatter.rb: 16b57a11261644a0bda0d609a60d1c62

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -144,7 +144,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
             assert_state_variable :registration_country, 'spain'
             assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk/start"
             assert_current_node :oru_result
-            assert_state_variable :translator_link_url, "/government/publications/spain-list-of-lawyers"
+            assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
           end
         end
       end # married

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -201,7 +201,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         end
         should "give the embassy result and be done" do
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "/government/publications/spain-list-of-lawyers"
+          assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
           assert current_state.send(:document_return_fees).present?
         end
       end # Answer embassy
@@ -211,7 +211,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         end
         should "give the ORU result and be done" do
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "/government/publications/spain-list-of-lawyers"
+          assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
         end
       end # Answer ORU
     end # Answer Spain


### PR DESCRIPTION
This PR supersedes #2490

Trello Story: https://trello.com/c/nIdy7kh6/75-register-a-birth-abroad-spain-translators-link

* Change Spanish translator link in register a birth and death respectively

## Factcheck for Register-a-Birth

[Preview link](https://smart-answers-pr-2490.herokuapp.com/register-a-birth/y/spain/mother/yes/same_country) 
[GOV.UK](https://gov.uk/register-a-birth/y/spain/mother/yes/same_country) 

### Expected changes
* The link should change from:
https://www.gov.uk/government/publications/spain-list-of-lawyers to http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx

### Before
![screen shot 2016-04-26 at 14 58 42](https://cloud.githubusercontent.com/assets/84896/14820823/2baf2074-0bc0-11e6-9a1f-3ce17afab24c.png)


### After
 
![screen shot 2016-04-26 at 14 59 22](https://cloud.githubusercontent.com/assets/84896/14820831/310d1a26-0bc0-11e6-9978-055ca4a08f8a.png)


## Factcheck for Register-a-Death

[Preview link](https://smart-answers-pr-2490.herokuapp.com/register-a-death/y/overseas/spain/same_country) 
[GOV.UK](https://gov.uk/register-a-death/y/overseas/spain/same_country) 

### Expected changes
* The link should change from:
https://www.gov.uk/government/publications/spain-list-of-lawyers to http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx

### Before
![screen shot 2016-04-27 at 12 31 53](https://cloud.githubusercontent.com/assets/84896/14850901/1159e772-0c74-11e6-8a87-9177a91210b1.png)



### After
 
![screen shot 2016-04-27 at 12 31 23](https://cloud.githubusercontent.com/assets/84896/14850905/175b70dc-0c74-11e6-9ffb-1441c6fe484a.png)

