### PR TITLE
Fix no method error undefined method transition on outcome

### DIFF
--- a/lib/smart_answer/outcome.rb
+++ b/lib/smart_answer/outcome.rb
@@ -3,5 +3,9 @@ module SmartAnswer
     def outcome?
       true
     end
+
+    def transition(*_args)
+      raise InvalidNode
+    end
   end
 end

--- a/test/integration/smart_answers_controller_error_handling_test.rb
+++ b/test/integration/smart_answers_controller_error_handling_test.rb
@@ -1,0 +1,37 @@
+require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/content_api'
+
+class SmartAnswersControllerErrorHandlingTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::ContentApi
+
+  setup do
+    @flow_registry = stub('flow-registry')
+    SmartAnswer::FlowRegistry.stubs(:instance).returns(@flow_registry)
+    stub_content_api_default_artefact
+  end
+
+  context 'when SmartAnswer::InvalidNode raised' do
+    setup do
+      flow = stub('flow', name: 'flow-name')
+      flow.stubs(:process).raises(SmartAnswer::InvalidNode)
+      @flow_registry.stubs(:find).returns(flow)
+    end
+
+    should 'set response status code to 404' do
+      get '/flow-name'
+      assert_response 404
+    end
+  end
+
+  context 'when SmartAnswer::InvalidNode raised' do
+    setup do
+      flow = stub('flow', name: 'flow-name')
+      @flow_registry.stubs(:find).raises(SmartAnswer::FlowRegistry::NotFound)
+    end
+
+    should 'set response status code to 404' do
+      get '/flow-name'
+      assert_response 404
+    end
+  end
+end

--- a/test/unit/outcome_test.rb
+++ b/test/unit/outcome_test.rb
@@ -1,0 +1,17 @@
+require_relative '../test_helper'
+
+module SmartAnswer
+  class OutcomeTest < ActiveSupport::TestCase
+    setup do
+      @outcome = Outcome.new(nil, 'node-name')
+    end
+
+    context '#transition' do
+      should 'raise InvalidNode exception so app responds with 404 Not Found' do
+        assert_raises(InvalidNode) do
+          @outcome.transition
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This reverts commit 0929036ffa0c92dbea372c2d570fe6f25a087e29.

It was a mistake to remove the `Outcome#transition` method which raised a `SmartAnswer::InvalidNode` exception. I hadn't noticed that [this exception is rescued and the app responds with a 404 Not Found][1]. The latter seems like sensible behaviour and so I'm restoring the previous implementation in this PR. This should prevent [exceptions like this one][2] from appearing in Errbit.

This PR also adds test coverage to hopefully avoid the same mistake happening again.

## External changes

Adding extra responses to the path of an outcome page should result in a `404 No Found` error instead of a `5XX` error and no exception should be recorded in Errbit.

### Before

https://www.gov.uk/overseas-passports/y/australia/renewing_new/adult/born-in-uk-pre-1983 -> "Sorry, we are experiencing technical difficulties"`

### After

https://www.gov.uk/overseas-passports/y/australia/renewing_new/adult/born-in-uk-pre-1983 -> "Page not found"

[1]: https://github.com/alphagov/smart-answers/blob/bf77a584737d8dbfee5694b64d5ad8870ebe0445/app/controllers/smart_answers_controller.rb#L7
[2]: https://errbit.publishing.service.gov.uk/apps/533c35ae0da1159384044f5f/problems/572087f96578631e0c660b00