### PR TITLE
Add content_api to Services module and use it from FlowPresenter

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -1,8 +1,6 @@
 require 'node_presenter'
-require 'gds_api/helpers'
 
 class FlowPresenter
-  include GdsApi::Helpers
   extend Forwardable
   include Rails.application.routes.url_helpers
 
@@ -18,7 +16,7 @@ class FlowPresenter
   end
 
   def artefact
-    @artefact ||= content_api.artefact(@flow.name.to_s)
+    @artefact ||= Services.content_api.artefact(@flow.name.to_s)
   rescue GdsApi::HTTPErrorResponse
     {}
   end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,6 +1,7 @@
 require 'gds_api/publishing_api_v2'
 require 'gds_api/imminence'
 require 'gds_api/worldwide'
+require 'gds_api/content_api'
 
 module Services
   def self.publishing_api
@@ -22,5 +23,9 @@ module Services
     else
       @worldwide_api ||= GdsApi::Worldwide.new(Plek.new.find('whitehall-admin'))
     end
+  end
+
+  def self.content_api
+    @content_api ||= GdsApi::ContentApi.new(Plek.new.find("contentapi"))
   end
 end


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/YAhS8i8Y

@tijmenb introduced a `Service` module in [this commit][1] to make the `publishing_api` available. Since then we've gradually been moving `GdsApi` services into this module for consistency.

As well as making the code more consistent, this change also makes it more explicit that we're calling an external service and should make it easier to stub that service at a higher level.

The implementation of the new `Services.content_api` method was copied from `GdsApi::Helper#content_api`, but modified slightly to be consistent with the existing methods in `Services` i.e. using `Plek.new` vs `Plek.current` (the former being the preferred style according to the comment on the method definition in `Plek`).

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/commit/34f8f7f4b169c8f10471edc630c7c1088cc205aa