### PR TITLE
Simplify `Services.worldwide_api` method

### DIFF
--- a/doc/common-errors.md
+++ b/doc/common-errors.md
@@ -19,7 +19,7 @@ undefined method `to_html' for nil:NilClass
 Visit a specific Smart Answer, e.g. /marriage-abroad.
 
 
-## "SocketError" when viewing a Smart Answer
+## "SocketError" when viewing a Smart Answer (relating to Content API)
 
 __NOTE.__ This is specifically when the exception is raised in `SmartAnswerPresenter#artefact`.
 
@@ -29,7 +29,7 @@ You'll see this error if the Smart Answers app can't connect to the Content API.
 
 ```
 SocketError at /marriage-abroad
-getaddrinfo: nodename nor servname provided, or not known
+Failed to open TCP connection to contentapi.dev.gov.uk:80 (getaddrinfo: nodename nor servname provided, or not known)
 ```
 
 ### Resolution
@@ -39,6 +39,28 @@ There are a couple of solutions to this problem:
 1. Set the `PLEK_SERVICE_CONTENTAPI_URI` environment variable to a valid host. NOTE. This doesn't need to be hosting the Content API (although you can use "https://www.gov.uk/api" if that's what you want), it simply needs to be a host that responds to HTTP requests.
 
 2. Configure a web server (e.g. Apache) on your machine to respond to http://contentapi.dev.gov.uk. This is the default location of the Content API in development so configuring this means that you won't have to set the `PLEK_SERVICE_CONTENTAPI_URI` environment variable.
+
+
+## "SocketError" when viewing a Smart Answer (relating to Worldwide API)
+
+__NOTE.__ This is specifically when the exception is raised in methods like `WorldLocation#find`, `WorldLocation.all` or `WorldwideOrganisation.for_location` which try to access the Worldwide API.
+
+You'll see this error if the Smart Answers app can't connect to the Worldwide API.
+
+### Exception
+
+```
+SocketError at /marriage-abroad/y
+Failed to open TCP connection to whitehall-admin.dev.gov.uk:80 (getaddrinfo: nodename nor servname provided, or not known)
+```
+
+### Resolution
+
+There are a couple of solutions to this problem:
+
+1. Set the `PLEK_SERVICE_WHITEHALL_ADMIN_URI` environment variable to "https://www.gov.uk".
+
+2. Configure a web server (e.g. Apache) on your machine to respond to http://whitehall-admin.dev.gov.uk. This is the default location of the Worldwide API in development so configuring this means that you won't have to set the `PLEK_SERVICE_WHITEHALL_ADMIN_URI` environment variable.
 
 
 ## "Slimmer::CouldNotRetrieveTemplate" when viewing a Smart Answer

--- a/doc/developing-using-vm.md
+++ b/doc/developing-using-vm.md
@@ -16,14 +16,32 @@ Clone the following repositories:
 * [asset-manager](https://github.com/alphagov/asset-manager)
 * [govuk_content_api](https://github.com/alphagov/govuk_content_api)
 
+If you want to run the Whitehall app locally (to provide the server side of the Worldwide API), then you also need to clone its repository:
+
+* [whitehall](https://github.com/alphagov/whitehall)
+
 Then run `bundle install` for each application.
+
+If you're running the Whitehall app locally, you'll need to setup its database and import some suitable data. There's a data replication job that imports production data which includes Whitehall data.
 
 ## Running the application
 
-Run using bowler on VM from cd /var/govuk/development:
+### Without local Whitehall app
+
+Add `PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk` to a `.env` file in `/var/govuk/development` to point the Smart Answers app at the production instance of the Whitehall app.
+
+Run using bowler on VM from `/var/govuk/development`:
 
 ```bash
 bowl smartanswers
+```
+
+### With local Whitehall app
+
+Run using bowler on VM from ``/var/govuk/development`:
+
+```bash
+bowl smartanswers whitehall
 ```
 
 ## Viewing a Smart Answer

--- a/doc/developing-without-vm.md
+++ b/doc/developing-without-vm.md
@@ -4,10 +4,11 @@ The simplest way to get Smart Answers running locally is to run:
 
 ```bash
 $ PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api \
+PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk \
 PLEK_SERVICE_STATIC_URI=assets-origin.integration.publishing.service.gov.uk \
 rails s
 ```
 
-This tells Smart Answers to use the production Content API and the asset server from the integration environment.
+This tells Smart Answers to use the production Content API & Worldwide API, and the asset server from the integration environment.
 
-If you don't set either environment variable then the app will attempt to connect to the content API and asset server at http://contentapi.dev.gov.uk and http://static.dev.gov.uk respectively. NOTE. These are available automatically if you're [developing using the VM](developing-using-vm.md). If the app can't connect to these hosts then you'll see [errors](common-errors.md).
+If you don't set either environment variable then the app will attempt to connect to the content API, worldwide API and asset server at http://contentapi.dev.gov.uk, http://whitehall-admin.dev.gov.uk and http://static.dev.gov.uk respectively. NOTE. These are available automatically if you're [developing using the VM](developing-using-vm.md). If the app can't connect to these hosts then you'll see [errors](common-errors.md).

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -16,13 +16,7 @@ module Services
   end
 
   def self.worldwide_api
-    # In development, point at the public version of the API
-    # as we won't normally have whitehall running
-    if Rails.env.development?
-      @worldwide_api ||= GdsApi::Worldwide.new("https://www.gov.uk")
-    else
-      @worldwide_api ||= GdsApi::Worldwide.new(Plek.new.find('whitehall-admin'))
-    end
+    @worldwide_api ||= GdsApi::Worldwide.new(Plek.new.find('whitehall-admin'))
   end
 
   def self.content_api


### PR DESCRIPTION
There is already a mechanism available for overriding the URI for specific services, so there is no need to have some special code to do this. Service URI's are automatically looked up via `Plek` and they can be overridden using environment variables of the form: `PLEK_SERVICE_<service-name>_URI` (see [Plek documentation][1]).

In this case, we can set the `PLEK_SERVICE_WHITEHALL_ADMIN_URI` environment variable to "https://www.gov.uk" if we want to use the production website to supply the data for the Worldwide API.

Although I've updated the `developing-without-vm` documentation, I haven't yet updated the `developing-using-vm` documentation, because I don't use the VM myself and so am not sure how the documentation should be changed. I have, however, confirmed that it is possible to use a locally-running version of the `whitehall` app to serve the Worldwide API data.

I have also updated the `common-errors` documentation to reflect the error that occurs if the Worldwide API is not pointing at an appropriate URI.

This PR should not be merged until I've updated the `developing-using-vm` documentation. Also developers should be warned about this change so they can make the appropriate changes to their local environments.

[1]: https://github.com/alphagov/plek/blob/b1f917cd6498aea8867728dab0132d0373ca702b/README.md#for-base-urls