### PR TITLE
Move register_a_death context out of married_couples_allowance context

### DIFF
--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -101,36 +101,36 @@ module SmartAnswer::Calculators
             assert_equal 10000, @query.rates(Date.parse("2014-04-06")).personal_allowance
           end
         end
+      end
 
-        context 'register a death fees' do
-          context 'for 2015/16' do
-            setup do
-              @rates_query = RatesQuery.from_file('register_a_death')
-              @sixth_april_2015 = Date.parse('2015-04-06')
-            end
-
-            should 'be £105 for registering a death' do
-              assert_equal 105, @rates_query.rates(@sixth_april_2015).register_a_death
-            end
-
-            should 'be £65 for a copy of the death registration certificate' do
-              assert_equal 65, @rates_query.rates(@sixth_april_2015).copy_of_death_registration_certificate
-            end
+      context 'register a death fees' do
+        context 'for 2015/16' do
+          setup do
+            @rates_query = RatesQuery.from_file('register_a_death')
+            @sixth_april_2015 = Date.parse('2015-04-06')
           end
 
-          context 'for 2016/17' do
-            setup do
-              @rates_query = RatesQuery.from_file('register_a_death')
-              @sixth_april_2016 = Date.parse('2016-04-06')
-            end
+          should 'be £105 for registering a death' do
+            assert_equal 105, @rates_query.rates(@sixth_april_2015).register_a_death
+          end
 
-            should 'be £150 for registering a death' do
-              assert_equal 150, @rates_query.rates(@sixth_april_2016).register_a_death
-            end
+          should 'be £65 for a copy of the death registration certificate' do
+            assert_equal 65, @rates_query.rates(@sixth_april_2015).copy_of_death_registration_certificate
+          end
+        end
 
-            should 'be £50 for a copy of the death registration certificate' do
-              assert_equal 50, @rates_query.rates(@sixth_april_2016).copy_of_death_registration_certificate
-            end
+        context 'for 2016/17' do
+          setup do
+            @rates_query = RatesQuery.from_file('register_a_death')
+            @sixth_april_2016 = Date.parse('2016-04-06')
+          end
+
+          should 'be £150 for registering a death' do
+            assert_equal 150, @rates_query.rates(@sixth_april_2016).register_a_death
+          end
+
+          should 'be £50 for a copy of the death registration certificate' do
+            assert_equal 50, @rates_query.rates(@sixth_april_2016).copy_of_death_registration_certificate
           end
         end
       end


### PR DESCRIPTION
## Description

This just fixes a mistake made in 919071b5910c4c54557952ced8ec9868005e502b in which the `register_a_death` test context was accidentally added *inside* the `married_couples_allowance` test context. I don't think the mistake actually had any bad effects, but I found the test quite confusing, so I think it's worth fixing.

The diff is best viewed using the `--ignore-all-space` option.

## External changes

None. This is just an internal refactoring.