### PR TITLE
Fix YearRange#ends_on for year beginning on leap day (29 Feb) - rebased version

### DIFF
--- a/lib/smart_answer/year_range.rb
+++ b/lib/smart_answer/year_range.rb
@@ -1,7 +1,8 @@
 module SmartAnswer
   class YearRange < DateRange
     def initialize(begins_on:)
-      super(begins_on: begins_on, ends_on: begins_on.to_date + 1.year - 1)
+      ends_on = begins_on - 1 + 1.year
+      super(begins_on: begins_on, ends_on: ends_on)
     end
   end
 end

--- a/lib/smart_answer/year_range.rb
+++ b/lib/smart_answer/year_range.rb
@@ -2,6 +2,9 @@ module SmartAnswer
   class YearRange < DateRange
     def initialize(begins_on:)
       ends_on = begins_on - 1 + 1.year
+      if ends_on.month == 2 && ends_on.day == 28 && ends_on.leap?
+        ends_on += 1
+      end
       super(begins_on: begins_on, ends_on: ends_on)
     end
   end

--- a/test/unit/year_range_test.rb
+++ b/test/unit/year_range_test.rb
@@ -2,16 +2,50 @@ require_relative '../test_helper'
 
 module SmartAnswer
   class YearRangeTest < ActiveSupport::TestCase
-    setup do
-      @year_range = YearRange.new(begins_on: Date.parse('2000-02-01'))
+    context 'not including the 29th Feb of a leap year' do
+      setup do
+        @year_range = YearRange.new(begins_on: Date.parse('2000-03-01'))
+      end
+
+      should 'begin on begins_on date' do
+        assert_equal Date.parse('2000-03-01'), @year_range.begins_on
+      end
+
+      should 'end a day before a year after the begins_on date' do
+        assert_equal Date.parse('2001-02-28'), @year_range.ends_on
+      end
+
+      should 'be 365 days long, because it does not include 29th Feb' do
+        assert_equal 365, @year_range.number_of_days
+      end
     end
 
-    should 'begin on begins_on date' do
-      assert_equal Date.parse('2000-02-01'), @year_range.begins_on
+    context 'including the 29th Feb of a leap year' do
+      setup do
+        @year_range = YearRange.new(begins_on: Date.parse('2000-02-01'))
+      end
+
+      should 'end a day before a year after the begins_on date' do
+        assert_equal Date.parse('2001-01-31'), @year_range.ends_on
+      end
+
+      should 'be 366 days long, because it does include 29th Feb' do
+        assert_equal 366, @year_range.number_of_days
+      end
     end
 
-    should 'end a day before a year after the begins_on date' do
-      assert_equal Date.parse('2001-01-31'), @year_range.ends_on
+    context 'beginning on 29th February of a leap year' do
+      setup do
+        @year_range = YearRange.new(begins_on: Date.parse('2000-02-29'))
+      end
+
+      should 'end a day before a year after the begins_on date' do
+        assert_equal Date.parse('2001-02-28'), @year_range.ends_on
+      end
+
+      should 'be 366 days long, because it does include 29th Feb' do
+        assert_equal 366, @year_range.number_of_days
+      end
     end
   end
 end

--- a/test/unit/year_range_test.rb
+++ b/test/unit/year_range_test.rb
@@ -47,5 +47,19 @@ module SmartAnswer
         assert_equal 366, @year_range.number_of_days
       end
     end
+
+    context 'ending on 29th February of a leap year' do
+      setup do
+        @year_range = YearRange.new(begins_on: Date.parse('1999-03-01'))
+      end
+
+      should 'end a day before a year after the begins_on date' do
+        assert_equal Date.parse('2000-02-29'), @year_range.ends_on
+      end
+
+      should 'be 366 days long, because it does include 29th Feb' do
+        assert_equal 366, @year_range.number_of_days
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

Supersedes #2485.

In this [Trello card][1], @erikse pointed out that a year range beginning on 29th February should end on 28th February the following year and not 27th February as in the previous implementation. Also a year range should always include either 365 or 366 days depending on whether it includes a leap day.

In working on this I realised that there was a related problem with a year beginning on 1st March in the year before a leap year. Intuitively I think that this should end on 29th February in the leap year.

However, for both of the identified problems I can see reasons why you might not want to include the leap day (29th Feb). For now always including the leap day seems like the most unsurprising behaviour, so that what's I've gone with.

It's possible that this behaviour might need to be policy/legislation-specific, so we should bear that in mind when making use of the `YearRange` class elsewhere in the code.

This commit adds more test coverage to highlight the problems as well as fixing the implementation.

Although as far as we know this inconsistency/bug hasn't resulted in any user-facing problems, it's good to get it fixed before we roll out the use of `YearRange` to other flows.

## External changes

The `YearRange` class is only currently used within the `part-year-profit-tax-credits` flow. Although it's possible that the external behaviour of this flow has changed in some very specific circumstances, I couldn't immediately come up with such a scenario.

[1]: https://trello.com/c/M17mqlSN