### PR TITLE
Split up RatesQueryTest

### DIFF
--- a/test/unit/calculators/married_couples_allowance_rates_query_test.rb
+++ b/test/unit/calculators/married_couples_allowance_rates_query_test.rb
@@ -1,0 +1,33 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class MarriedCouplesAllowanceRatesQueryTest < ActiveSupport::TestCase
+    setup do
+      @query = RatesQuery.from_file('married_couples_allowance')
+    end
+
+    should "have all required rates defined for the current fiscal year" do
+      %w(personal_allowance over_65_allowance over_75_allowance income_limit_for_personal_allowances maximum_married_couple_allowance minimum_married_couple_allowance).each do |rate|
+        assert @query.rates.send(rate).is_a?(Numeric)
+      end
+    end
+
+    context "personal_allowance" do
+      should "be the latest known walue on 15th April 2116 (fallback)" do
+        assert @query.rates(Date.parse("2116-04-15")).personal_allowance.is_a?(Numeric)
+      end
+
+      should "be 10600 on 5th April 2016" do
+        assert_equal 10600, @query.rates(Date.parse("2016-04-05")).personal_allowance
+      end
+
+      should "be 9440 on 6th April 2013" do
+        assert_equal 9440, @query.rates(Date.parse("2013-04-06")).personal_allowance
+      end
+
+      should "be 10000 on 6th April 2014" do
+        assert_equal 10000, @query.rates(Date.parse("2014-04-06")).personal_allowance
+      end
+    end
+  end
+end

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -103,37 +103,5 @@ module SmartAnswer::Calculators
         end
       end
     end
-
-    context 'register a birth fees' do
-      context 'for 2015/16' do
-        setup do
-          @rates_query = RatesQuery.from_file('register_a_birth')
-          @sixth_april_2015 = Date.parse('2015-04-06')
-        end
-
-        should 'be £105 for registering a birth' do
-          assert_equal 105, @rates_query.rates(@sixth_april_2015).register_a_birth
-        end
-
-        should 'be £65 for a copy of the birth registration certificate' do
-          assert_equal 65, @rates_query.rates(@sixth_april_2015).copy_of_birth_registration_certificate
-        end
-      end
-
-      context 'for 2016/17' do
-        setup do
-          @rates_query = RatesQuery.from_file('register_a_birth')
-          @sixth_april_2016 = Date.parse('2016-04-06')
-        end
-
-        should 'be £150 for registering a birth' do
-          assert_equal 150, @rates_query.rates(@sixth_april_2016).register_a_birth
-        end
-
-        should 'be £50 for a copy of the birth registration certificate' do
-          assert_equal 50, @rates_query.rates(@sixth_april_2016).copy_of_birth_registration_certificate
-        end
-      end
-    end
   end
 end

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -71,37 +71,5 @@ module SmartAnswer::Calculators
         end
       end
     end
-
-    context 'register a death fees' do
-      context 'for 2015/16' do
-        setup do
-          @rates_query = RatesQuery.from_file('register_a_death')
-          @sixth_april_2015 = Date.parse('2015-04-06')
-        end
-
-        should 'be £105 for registering a death' do
-          assert_equal 105, @rates_query.rates(@sixth_april_2015).register_a_death
-        end
-
-        should 'be £65 for a copy of the death registration certificate' do
-          assert_equal 65, @rates_query.rates(@sixth_april_2015).copy_of_death_registration_certificate
-        end
-      end
-
-      context 'for 2016/17' do
-        setup do
-          @rates_query = RatesQuery.from_file('register_a_death')
-          @sixth_april_2016 = Date.parse('2016-04-06')
-        end
-
-        should 'be £150 for registering a death' do
-          assert_equal 150, @rates_query.rates(@sixth_april_2016).register_a_death
-        end
-
-        should 'be £50 for a copy of the death registration certificate' do
-          assert_equal 50, @rates_query.rates(@sixth_april_2016).copy_of_death_registration_certificate
-        end
-      end
-    end
   end
 end

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -72,36 +72,6 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "Married couples allowance" do
-      setup do
-        @query = RatesQuery.from_file('married_couples_allowance')
-      end
-
-      should "have all required rates defined for the current fiscal year" do
-        %w(personal_allowance over_65_allowance over_75_allowance income_limit_for_personal_allowances maximum_married_couple_allowance minimum_married_couple_allowance).each do |rate|
-          assert @query.rates.send(rate).is_a?(Numeric)
-        end
-      end
-
-      context "personal_allowance" do
-        should "be the latest known walue on 15th April 2116 (fallback)" do
-          assert @query.rates(Date.parse("2116-04-15")).personal_allowance.is_a?(Numeric)
-        end
-
-        should "be 10600 on 5th April 2016" do
-          assert_equal 10600, @query.rates(Date.parse("2016-04-05")).personal_allowance
-        end
-
-        should "be 9440 on 6th April 2013" do
-          assert_equal 9440, @query.rates(Date.parse("2013-04-06")).personal_allowance
-        end
-
-        should "be 10000 on 6th April 2014" do
-          assert_equal 10000, @query.rates(Date.parse("2014-04-06")).personal_allowance
-        end
-      end
-    end
-
     context 'register a death fees' do
       context 'for 2015/16' do
         setup do

--- a/test/unit/calculators/register_a_birth_rates_query_test.rb
+++ b/test/unit/calculators/register_a_birth_rates_query_test.rb
@@ -1,0 +1,35 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class RegisterABirthRatesQueryTest < ActiveSupport::TestCase
+    context 'for 2015/16' do
+      setup do
+        @rates_query = RatesQuery.from_file('register_a_birth')
+        @sixth_april_2015 = Date.parse('2015-04-06')
+      end
+
+      should 'be £105 for registering a birth' do
+        assert_equal 105, @rates_query.rates(@sixth_april_2015).register_a_birth
+      end
+
+      should 'be £65 for a copy of the birth registration certificate' do
+        assert_equal 65, @rates_query.rates(@sixth_april_2015).copy_of_birth_registration_certificate
+      end
+    end
+
+    context 'for 2016/17' do
+      setup do
+        @rates_query = RatesQuery.from_file('register_a_birth')
+        @sixth_april_2016 = Date.parse('2016-04-06')
+      end
+
+      should 'be £150 for registering a birth' do
+        assert_equal 150, @rates_query.rates(@sixth_april_2016).register_a_birth
+      end
+
+      should 'be £50 for a copy of the birth registration certificate' do
+        assert_equal 50, @rates_query.rates(@sixth_april_2016).copy_of_birth_registration_certificate
+      end
+    end
+  end
+end

--- a/test/unit/calculators/register_a_birth_rates_query_test.rb
+++ b/test/unit/calculators/register_a_birth_rates_query_test.rb
@@ -2,33 +2,35 @@ require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
   class RegisterABirthRatesQueryTest < ActiveSupport::TestCase
+    setup do
+      @rates_query = RatesQuery.from_file('register_a_birth')
+    end
+
     context 'for 2015/16' do
       setup do
-        @rates_query = RatesQuery.from_file('register_a_birth')
-        @sixth_april_2015 = Date.parse('2015-04-06')
+        @rates = @rates_query.rates(Date.parse('2015-04-06'))
       end
 
       should 'be £105 for registering a birth' do
-        assert_equal 105, @rates_query.rates(@sixth_april_2015).register_a_birth
+        assert_equal 105, @rates.register_a_birth
       end
 
       should 'be £65 for a copy of the birth registration certificate' do
-        assert_equal 65, @rates_query.rates(@sixth_april_2015).copy_of_birth_registration_certificate
+        assert_equal 65, @rates.copy_of_birth_registration_certificate
       end
     end
 
     context 'for 2016/17' do
       setup do
-        @rates_query = RatesQuery.from_file('register_a_birth')
-        @sixth_april_2016 = Date.parse('2016-04-06')
+        @rates = @rates_query.rates(Date.parse('2016-04-06'))
       end
 
       should 'be £150 for registering a birth' do
-        assert_equal 150, @rates_query.rates(@sixth_april_2016).register_a_birth
+        assert_equal 150, @rates.register_a_birth
       end
 
       should 'be £50 for a copy of the birth registration certificate' do
-        assert_equal 50, @rates_query.rates(@sixth_april_2016).copy_of_birth_registration_certificate
+        assert_equal 50, @rates.copy_of_birth_registration_certificate
       end
     end
   end

--- a/test/unit/calculators/register_a_death_rates_query_test.rb
+++ b/test/unit/calculators/register_a_death_rates_query_test.rb
@@ -1,0 +1,35 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class RegisterADeathRatesQueryTest < ActiveSupport::TestCase
+    context 'for 2015/16' do
+      setup do
+        @rates_query = RatesQuery.from_file('register_a_death')
+        @sixth_april_2015 = Date.parse('2015-04-06')
+      end
+
+      should 'be £105 for registering a death' do
+        assert_equal 105, @rates_query.rates(@sixth_april_2015).register_a_death
+      end
+
+      should 'be £65 for a copy of the death registration certificate' do
+        assert_equal 65, @rates_query.rates(@sixth_april_2015).copy_of_death_registration_certificate
+      end
+    end
+
+    context 'for 2016/17' do
+      setup do
+        @rates_query = RatesQuery.from_file('register_a_death')
+        @sixth_april_2016 = Date.parse('2016-04-06')
+      end
+
+      should 'be £150 for registering a death' do
+        assert_equal 150, @rates_query.rates(@sixth_april_2016).register_a_death
+      end
+
+      should 'be £50 for a copy of the death registration certificate' do
+        assert_equal 50, @rates_query.rates(@sixth_april_2016).copy_of_death_registration_certificate
+      end
+    end
+  end
+end

--- a/test/unit/calculators/register_a_death_rates_query_test.rb
+++ b/test/unit/calculators/register_a_death_rates_query_test.rb
@@ -2,33 +2,35 @@ require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
   class RegisterADeathRatesQueryTest < ActiveSupport::TestCase
+    setup do
+      @rates_query = RatesQuery.from_file('register_a_death')
+    end
+
     context 'for 2015/16' do
       setup do
-        @rates_query = RatesQuery.from_file('register_a_death')
-        @sixth_april_2015 = Date.parse('2015-04-06')
+        @rates = @rates_query.rates(Date.parse('2015-04-06'))
       end
 
       should 'be £105 for registering a death' do
-        assert_equal 105, @rates_query.rates(@sixth_april_2015).register_a_death
+        assert_equal 105, @rates.register_a_death
       end
 
       should 'be £65 for a copy of the death registration certificate' do
-        assert_equal 65, @rates_query.rates(@sixth_april_2015).copy_of_death_registration_certificate
+        assert_equal 65, @rates.copy_of_death_registration_certificate
       end
     end
 
     context 'for 2016/17' do
       setup do
-        @rates_query = RatesQuery.from_file('register_a_death')
-        @sixth_april_2016 = Date.parse('2016-04-06')
+        @rates = @rates_query.rates(Date.parse('2016-04-06'))
       end
 
       should 'be £150 for registering a death' do
-        assert_equal 150, @rates_query.rates(@sixth_april_2016).register_a_death
+        assert_equal 150, @rates.register_a_death
       end
 
       should 'be £50 for a copy of the death registration certificate' do
-        assert_equal 50, @rates_query.rates(@sixth_april_2016).copy_of_death_registration_certificate
+        assert_equal 50, @rates.copy_of_death_registration_certificate
       end
     end
   end


### PR DESCRIPTION
## Description

The focus of a number of these tests is actually testing the underlying data in the YAML files rather than the functionality of the `DataQuery` class itself. As such I think it's better that these tests are split off into separate test cases. This also has the benefit of making the `DataQueryTest` a more manageable size.

In preparation for splitting the tests out into separate files, I removed the unnecessary top-level context in `DataQueryTest`.

After splitting the tests out into separate files, I noticed a bunch of duplication which I decided to remove, even though this wasn't strictly necessary as part of this PR.

## External changes

None. This is purely an internal refactoring and in any case only affects test code.
