### PR TITLE
Fail fast in regression test if response is not success

### DIFF
--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -99,6 +99,7 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
       should "render and save the landing page" do
         get :show, id: flow_name, format: 'txt'
+        assert_response :success
 
         artefact_path = smart_answer_helper.save_output([flow_name], response)
         assert_no_output_diff artefact_path if ENV['ASSERT_EACH_ARTEFACT'].present?
@@ -106,6 +107,7 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
       should "render and save the first question page" do
         get :show, id: flow_name, started: 'y', format: 'html'
+        assert_response :success
 
         artefact_path = smart_answer_helper.save_output(['y'], response, extension: 'html')
         assert_no_output_diff artefact_path if ENV['ASSERT_EACH_ARTEFACT'].present?
@@ -122,6 +124,7 @@ class SmartAnswersRegressionTest < ActionController::TestCase
           should "render and save output for responses: #{responses.join(', ')}" do
             format = outcome_node ? 'txt' : 'html'
             get :show, id: flow_name, started: 'y', responses: responses.join('/'), format: format
+            assert_response :success
 
             artefact_path = smart_answer_helper.save_output(responses, response, extension: format)
 


### PR DESCRIPTION
## Description

When generating regression test artefacts for the first time, we should never store a response with a non-success status code - this would be a sign that we've chosen the wrong questions & responses.

When running regression tests on subsequent occasions, it's more useful to see an assertion failure specifically about the non-success response, rather than an assertion about the response body diff not matching.

I did consider avoiding the duplication by putting the assertion inside `SmartAnswerTestHelper#save_output`, but I wanted to use [`ActionDispatch::Assertions::ResponseAssertions#assert_response`][1] which checks for status codes in the range 200-299 and that would've been awkward to do outside the `SmartAnswersRegressionTest` class.

## External changes

None. This only affects test code.

[1]: http://api.rubyonrails.org/classes/ActionDispatch/Assertions/ResponseAssertions.html#method-i-assert_response