### PR TITLE
Render notification message for soon to be pensioners

### DIFF
--- a/lib/smart_answer/calculators/state_pension_age_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_age_calculator.rb
@@ -16,6 +16,10 @@ module SmartAnswer::Calculators
       StatePensionDateQuery.state_pension_date(dob, gender)
     end
 
+    def can_apply?
+      Date.today >= earliest_application_date
+    end
+
     def state_pension_age
       if birthday_on_feb_29?
         friendly_time_diff(dob, state_pension_date - 1.day)
@@ -50,6 +54,12 @@ module SmartAnswer::Calculators
 
     def over_16_years_old?
       dob < 16.years.ago
+    end
+
+  private
+
+    def earliest_application_date
+      state_pension_date - 4.months - 4.days
     end
   end
 end

--- a/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb
@@ -6,6 +6,12 @@
 <% content_for :body do %>
   Your State Pension age is <%= calculator.state_pension_age %>.
 
+  <% if calculator.can_apply? %>
+    You can [claim your State Pension](/state-pension/how-to-claim) now. Your payments will start after you reach State Pension age.
+
+    Alternatively, you can [delay (defer) claiming](/deferring-state-pension).
+  <% end %>
+
   ##Pension Credit
   You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 

--- a/test/artefacts/state-pension-age/age/1950-02-01/male.txt
+++ b/test/artefacts/state-pension-age/age/1950-02-01/male.txt
@@ -2,6 +2,10 @@ You’ll reach State Pension age on  1 February 2015.
 
 Your State Pension age is 65 years.
 
+You can [claim your State Pension](/state-pension/how-to-claim) now. Your payments will start after you reach State Pension age.
+
+Alternatively, you can [delay (defer) claiming](/deferring-state-pension).
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 

--- a/test/data/state-pension-age-files.yml
+++ b/test/data/state-pension-age-files.yml
@@ -4,7 +4,7 @@ test/data/state-pension-age-questions-and-responses.yml: 6cf2d7052e044c4367b9430
 test/data/state-pension-age-responses-and-expected-results.yml: 54283e77f05bd42775d6d3d1f1fc4380
 lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb: dcd8e4132b25e8dd46b82f096837b974
 lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age.govspeak.erb: 021cb8dfc6b4200ae09ea36642b13084
-lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb: 6640ca59fbe0be642649ce6cd03c9e20
+lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb: 844a4099a9b8cea4d8df84da5558a4d0
 lib/smart_answer_flows/state-pension-age/questions/dob_age.govspeak.erb: 336a91fc32e8fc66011a9ae504111ae0
 lib/smart_answer_flows/state-pension-age/questions/gender.govspeak.erb: 4624dfdac5be156a8573cbc21245e36d
 lib/smart_answer_flows/state-pension-age/questions/which_calculation.govspeak.erb: 047d48d2d752d7b53c0b78f0eaedac3f

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -206,5 +206,45 @@ module SmartAnswer::Calculators
         end
       end
     end
+
+    context "#can_apply?" do
+      context "for women" do
+        setup do
+          @answers = { gender: "female" }
+          @calculator = StatePensionAgeCalculator.new(@answers)
+        end
+        should "return true for someone is approaching pension age in 4 months and 4 days time" do
+          Timecop.freeze(Date.parse('2020-01-11')) do
+            @calculator.stubs(dob: Date.parse("1954-06-06"))
+            assert @calculator.can_apply?
+          end
+        end
+
+        should "return false for someone is approaching pension age in more than  4 months and 4 days time" do
+          Timecop.freeze(Date.parse('2020-03-11')) do
+            @calculator.stubs(dob: Date.parse("1954-12-06"))
+            refute @calculator.can_apply?
+          end
+        end
+      end
+
+      context "for men" do
+        setup do
+          @answers = { gender: "male" }
+          @calculator = StatePensionAgeCalculator.new(@answers.merge(dob: Date.parse("1951-12-06")))
+        end
+        should "return true for someone is approaching pension age in 4 months and 4 days time" do
+          Timecop.freeze(Date.parse('2016-09-11')) do
+            assert @calculator.can_apply?
+          end
+        end
+
+        should "return false for someone is approaching pension age in more than 4 months and 4 days time" do
+          Timecop.freeze(Date.parse('2016-03-11')) do
+            refute @calculator.can_apply?
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello Story](https://trello.com/c/t08jEsHK/114-sp-age-smart-answer-new-content-for-users-within-4-months-and-4-days-of-state-pension-age) 

* Show notification message to soon to be pensioners who are 4months and 4 days from receiving State Pension (SP) age can apply to get their State Pension. (i.e. advising them that they don't have to wait till their Sate Pension age before doing this.)


## Factcheck
[Preview Link](https://smart-answers-pr-2521.herokuapp.com/state-pension-age/y/)
[GOVU.UK](https://gov.uk/state-pension-age/y/)


### Expected changes
*  Display notification to only soon to be pensioners who are 4months and 4 days from recieving State Pension (SP)

### Before

![screen shot 2016-05-19 at 10 38 33](https://cloud.githubusercontent.com/assets/84896/15389256/e438ef36-1dad-11e6-9205-f7ea46f1d42d.png)

### After
 
![screen shot 2016-05-19 at 10 39 25](https://cloud.githubusercontent.com/assets/84896/15389283/fe9f2cbe-1dad-11e6-9185-2a079056890a.png)

