### PR TITLE
Fix stubbing of current time in regression tests

### DIFF
--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -61,8 +61,9 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
     context "Smart Answer: #{flow_name}" do
       setup do
-        next if self.class.setup_has_run? && !self.class.teardown_hooks_installed?
         Timecop.freeze(smart_answer_helper.current_time)
+
+        next if self.class.setup_has_run? && !self.class.teardown_hooks_installed?
         stub_content_api_default_artefact
         WebMock.stub_request(:get, WorkingDays::BANK_HOLIDAYS_URL).to_return(body: File.open(fixture_file('bank_holidays.json')))
 


### PR DESCRIPTION
Since #2518 was merged, when multiple regression tests were run the call to `Timecop.freeze` in the `setup` block was only being made the first time the `setup` block was executed. This is because of the optimisation introduced in [this commit][1].

It so happens that #2518 changed the stubbed value of current time in the first flow, `additional-commodity-code`, to `2016-05-05` i.e. different from the value used to generate the artefacts for the majority of the flows. So when running all the regression tests, the stubbed value of current time was set to the value for `additional-commodity-code` and never changed. This caused the full regression test suite to fail on the `govuk_smart_answers_regressions` CI server.

This commit moves the call to `Timecop.freeze` before the condition which skips the `setup` on subsequent tests. This means that it is now executed for every test and the appropriate values of current time should be used for each flow.

I didn't spot this sooner, because I didn't run all the regression tests before merging #2518. This was because having run the regression tests for a number of the flows individually, I mistakenly convinced myself that running all of them wasn't necessary.

[1]: c86ba038821012a70cb5d8ee3c462fd6f9c5e53c