### PR TITLE
Fix responses and expected results files for regression tests

### DIFF
--- a/script/generate-responses-and-expected-results-for-smart-answer.rb
+++ b/script/generate-responses-and-expected-results-for-smart-answer.rb
@@ -1,3 +1,5 @@
+ENV['PLEK_SERVICE_WHITEHALL_ADMIN_URI'] = 'https://www.gov.uk'
+
 require 'timecop'
 
 Timecop.freeze(Date.parse('2015-01-01'))

--- a/test/artefacts/state-pension-through-partner/married/your_pension_age_after_specific_date/partner_pension_age_before_specific_date.html
+++ b/test/artefacts/state-pension-through-partner/married/your_pension_age_after_specific_date/partner_pension_age_before_specific_date.html
@@ -28,7 +28,7 @@
   </header>
 
     <div class="step current">
-      <form action="/state-pension-through-partner/y/married/your_pension_age_after_specific_date/partner_pension_age_after_specific_date" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+      <form action="/state-pension-through-partner/y/married/your_pension_age_after_specific_date/partner_pension_age_before_specific_date" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">
           <div class="question">
   <h2>
@@ -102,10 +102,10 @@
               <tr class="section">
   <td class="previous-question-title">When will (or did) your spouse or civil partner reach state pension age?</td>
     <td class="previous-question-body">
-    on or after 6 April 2016</td>
+    on or before 5 April 2016</td>
 
   <td class="link-right">
-    <a href="/state-pension-through-partner/y/married/your_pension_age_after_specific_date?previous_response=partner_pension_age_after_specific_date">
+    <a href="/state-pension-through-partner/y/married/your_pension_age_after_specific_date?previous_response=partner_pension_age_before_specific_date">
       Change<span class="visuallyhidden"> answer to "When will (or did) your spouse or civil partner reach state pension age?"</span>
 </a>  </td>
 </tr>

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1617.html
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1617.html
@@ -28,7 +28,7 @@
   </header>
 
     <div class="step current">
-      <form action="/student-finance-forms/y/uk-full-time/apply-loans-grants/year-1516" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+      <form action="/student-finance-forms/y/uk-full-time/apply-loans-grants/year-1617" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">
           <div class="question">
   <h2>
@@ -103,10 +103,10 @@
               <tr class="section">
   <td class="previous-question-title">What academic year do you want funding for?</td>
     <td class="previous-question-body">
-    2015 to 2016</td>
+    2016 to 2017</td>
 
   <td class="link-right">
-    <a href="/student-finance-forms/y/uk-full-time/apply-loans-grants?previous_response=year-1516">
+    <a href="/student-finance-forms/y/uk-full-time/apply-loans-grants?previous_response=year-1617">
       Change<span class="visuallyhidden"> answer to "What academic year do you want funding for?"</span>
 </a>  </td>
 </tr>

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/check-uk-visa.rb: 18ff6d2173bdb8d0e10ad4c986d03c96
 test/data/check-uk-visa-questions-and-responses.yml: db3081a2a7162f108baa5ff00706c9fd
-test/data/check-uk-visa-responses-and-expected-results.yml: 60d4090bdf290693442b66d5ab86102e
+test/data/check-uk-visa-responses-and-expected-results.yml: 0c16e3dad5ca56436cc8c4b14eb9b3a1
 lib/smart_answer_flows/check-uk-visa/check_uk_visa.govspeak.erb: a442b4ddd169b26a401c70d145e5b44e
 lib/smart_answer_flows/check-uk-visa/outcomes/_b1_b2_visa_exception.govspeak.erb: 410e39d565d0a5caed2d1b8c20c1ca77
 lib/smart_answer_flows/check-uk-visa/outcomes/_stateless_or_refugee.govspeak.erb: a14d7807087e4f05e9fada8ac755ee2e

--- a/test/data/check-uk-visa-responses-and-expected-results.yml
+++ b/test/data/check-uk-visa-responses-and-expected-results.yml
@@ -630,7 +630,7 @@
   - kuwait
   - work
   - six_months_or_less
-  :next_node: :outcome_work_m
+  :next_node: :outcome_work_waiver
   :outcome_node: true
 - :current_node: :staying_for_how_long?
   :responses:
@@ -650,7 +650,7 @@
   - kuwait
   - study
   - six_months_or_less
-  :next_node: :outcome_visit_waiver
+  :next_node: :outcome_study_waiver
   :outcome_node: true
 - :current_node: :staying_for_how_long?
   :responses:
@@ -695,7 +695,7 @@
   :responses:
   - kuwait
   - school
-  :next_node: :outcome_visit_waiver
+  :next_node: :outcome_school_waiver
   :outcome_node: true
 - :current_node: :purpose_of_visit?
   :responses:

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/landlord-immigration-check.rb: f8848dcb9bdd7c4e16e44782bec1a5a7
-test/data/landlord-immigration-check-questions-and-responses.yml: d4b485131540c40211b26a50e071032d
+test/data/landlord-immigration-check-questions-and-responses.yml: 1915a9d0bbbdf95822d21f11ff509465
 test/data/landlord-immigration-check-responses-and-expected-results.yml: 7982d80c9851bfa7e55dbee4661e70bc
 lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: 60507bfc657cf13a750b258017453743
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_landlord_code_of_practice.govspeak.erb: cfb1261ac17c7aa40445173406459290

--- a/test/data/landlord-immigration-check-questions-and-responses.yml
+++ b/test/data/landlord-immigration-check-questions-and-responses.yml
@@ -1,7 +1,6 @@
 ---
 :property?:
 - B1 1PW
-- WC2B 6SE
 - PA3 2SW
 :main_home?:
 - 'yes'

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/overseas-passports.rb: 6d3c353334c76e2fc60e6bbd2c9e63b5
 test/data/overseas-passports-questions-and-responses.yml: 4c6749fcf0a37deb135fc8c94fa52bc7
-test/data/overseas-passports-responses-and-expected-results.yml: aca0c7e72dfbf84606a47cb7d6d7f758
+test/data/overseas-passports-responses-and-expected-results.yml: 41f97e3e2501d5e03046aff45a3c614d
 lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb: 548eee239b4195e500d106f6b72f26ce
 lib/smart_answer_flows/overseas-passports/outcomes/_getting_your_passport.govspeak.erb: 0517a359ec39699de24009ff2a5fef18
 lib/smart_answer_flows/overseas-passports/outcomes/_how_long.govspeak.erb: 4534bc621bd3d7af0ef7edf2fa50d6a1

--- a/test/data/overseas-passports-responses-and-expected-results.yml
+++ b/test/data/overseas-passports-responses-and-expected-results.yml
@@ -752,7 +752,7 @@
 - :current_node: :which_country_are_you_in?
   :responses:
   - yemen
-  :next_node: :cannot_apply
+  :next_node: :apply_in_neighbouring_country
   :outcome_node: true
 - :current_node: :which_country_are_you_in?
   :responses:

--- a/test/data/simplified-expenses-checker-files.yml
+++ b/test/data/simplified-expenses-checker-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/simplified-expenses-checker.rb: 941d9c6680006c79e44275f8f8b73ee3
-test/data/simplified-expenses-checker-questions-and-responses.yml: de8747e3d768e4095264a214cdb58d0b
+test/data/simplified-expenses-checker-questions-and-responses.yml: 426882edc239d4078c5d7d957a01cbce
 test/data/simplified-expenses-checker-responses-and-expected-results.yml: 239e9c4e6fda064faecff3403fc3033d
 lib/smart_answer_flows/simplified-expenses-checker/outcomes/capital_allowance_result.govspeak.erb: 0f738efb15d8d63ebb9f824eb4010744
 lib/smart_answer_flows/simplified-expenses-checker/outcomes/you_can_use_result.govspeak.erb: c688eef5f6cc7fdfee645d1198a3ee7f

--- a/test/data/simplified-expenses-checker-questions-and-responses.yml
+++ b/test/data/simplified-expenses-checker-questions-and-responses.yml
@@ -45,7 +45,7 @@
 :deduct_from_premises?:
 - '789' # :deduct_from_premises? -> :people_live_on_premises?
 :people_live_on_premises?:
--- '0' # simple_business_costs == 0
--- '1' # simple_business_costs == 4200
--- '2' # simple_business_costs == 6000
--- '5' # simple_business_costs == 7800
+- '0' # simple_business_costs == 0
+- '1' # simple_business_costs == 4200
+- '2' # simple_business_costs == 6000
+- '5' # simple_business_costs == 7800

--- a/test/data/state-pension-through-partner-files.yml
+++ b/test/data/state-pension-through-partner-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/state-pension-through-partner.rb: e76214e2bbdfcf23514354ec870a4cfd
 test/data/state-pension-through-partner-questions-and-responses.yml: 743b0b6dc9a8d33502d402c4da8220af
-test/data/state-pension-through-partner-responses-and-expected-results.yml: 930b237cf1f76ad3f85dd2f58f5b539a
+test/data/state-pension-through-partner-responses-and-expected-results.yml: 3f0949246808bddc383a063183273c14
 lib/smart_answer_flows/state-pension-through-partner/outcomes/_increase_retirement_income.govspeak.erb: 2391bf6e80d1aa4d0d4258030b4f4e00
 lib/smart_answer_flows/state-pension-through-partner/outcomes/age_dependent_pension_outcome.govspeak.erb: e701cd1a337d4bf36e3228449a037a31
 ? lib/smart_answer_flows/state-pension-through-partner/outcomes/current_rules_national_insurance_no_state_pension_outcome.govspeak.erb

--- a/test/data/state-pension-through-partner-responses-and-expected-results.yml
+++ b/test/data/state-pension-through-partner-responses-and-expected-results.yml
@@ -10,30 +10,6 @@
   - your_pension_age_before_specific_date
   :next_node: :when_will_your_partner_reach_pension_age?
   :outcome_node: false
-- :current_node: :when_will_you_reach_pension_age?
-  :responses:
-  - married
-  - your_pension_age_after_specific_date
-  :next_node: :when_will_your_partner_reach_pension_age?
-  :outcome_node: false
-- :current_node: :when_will_your_partner_reach_pension_age?
-  :responses:
-  - married
-  - your_pension_age_after_specific_date
-  - partner_pension_age_after_specific_date
-  :next_node: :what_is_your_gender?
-  :outcome_node: false
-- :current_node: :what_is_your_marital_status?
-  :responses:
-  - married
-  :next_node: :when_will_you_reach_pension_age?
-  :outcome_node: false
-- :current_node: :when_will_you_reach_pension_age?
-  :responses:
-  - married
-  - your_pension_age_before_specific_date
-  :next_node: :when_will_your_partner_reach_pension_age?
-  :outcome_node: false
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses:
   - married

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/student-finance-forms.rb: d359d46a211b2aff4e0acc0062b6142d
 test/data/student-finance-forms-questions-and-responses.yml: 59efd7bff0de61c0a9e707415cca4608
-test/data/student-finance-forms-responses-and-expected-results.yml: 9e1a5b712cf384edb874d8902debe279
+test/data/student-finance-forms-responses-and-expected-results.yml: e49c08e5e6d4dc8d1cd6afa13f4ee1da
 lib/smart_answer_flows/student-finance-forms/outcomes/_circumstances_changed_co2_form.govspeak.erb: 236d81f3660a1958bb0dd3a8f229baf4
 lib/smart_answer_flows/student-finance-forms/outcomes/_when_you_can_apply.govspeak.erb: c3459b01f8733370279520306716f895
 lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_non_uk.govspeak.erb: 7cc0f616b4df674cd314ba6ffc0a675b

--- a/test/data/student-finance-forms-responses-and-expected-results.yml
+++ b/test/data/student-finance-forms-responses-and-expected-results.yml
@@ -14,29 +14,6 @@
   :responses:
   - uk-full-time
   - apply-loans-grants
-  - year-1516
-  :next_node: :continuing_student?
-  :outcome_node: false
-- :current_node: :continuing_student?
-  :responses:
-  - uk-full-time
-  - apply-loans-grants
-  - year-1516
-  - continuing-student
-  :next_node: :outcome_uk_ft_1516_continuing
-  :outcome_node: true
-- :current_node: :continuing_student?
-  :responses:
-  - uk-full-time
-  - apply-loans-grants
-  - year-1516
-  - new-student
-  :next_node: :outcome_uk_ft_1516_new
-  :outcome_node: true
-- :current_node: :what_year_full_time?
-  :responses:
-  - uk-full-time
-  - apply-loans-grants
   - year-1617
   :next_node: :continuing_student?
   :outcome_node: false
@@ -56,19 +33,35 @@
   - new-student
   :next_node: :outcome_uk_ft_1617_new
   :outcome_node: true
+- :current_node: :what_year_full_time?
+  :responses:
+  - uk-full-time
+  - apply-loans-grants
+  - year-1516
+  :next_node: :continuing_student?
+  :outcome_node: false
+- :current_node: :continuing_student?
+  :responses:
+  - uk-full-time
+  - apply-loans-grants
+  - year-1516
+  - continuing-student
+  :next_node: :outcome_uk_ft_1516_continuing
+  :outcome_node: true
+- :current_node: :continuing_student?
+  :responses:
+  - uk-full-time
+  - apply-loans-grants
+  - year-1516
+  - new-student
+  :next_node: :outcome_uk_ft_1516_new
+  :outcome_node: true
 - :current_node: :form_needed_for_1?
   :responses:
   - uk-full-time
   - proof-identity
   :next_node: :what_year_full_time?
   :outcome_node: false
-- :current_node: :what_year_full_time?
-  :responses:
-  - uk-full-time
-  - proof-identity
-  - year-1516
-  :next_node: :outcome_proof_identity_1516
-  :outcome_node: true
 - :current_node: :what_year_full_time?
   :responses:
   - uk-full-time
@@ -76,19 +69,19 @@
   - year-1617
   :next_node: :outcome_proof_identity_1617
   :outcome_node: true
+- :current_node: :what_year_full_time?
+  :responses:
+  - uk-full-time
+  - proof-identity
+  - year-1516
+  :next_node: :outcome_proof_identity_1516
+  :outcome_node: true
 - :current_node: :form_needed_for_1?
   :responses:
   - uk-full-time
   - income-details
   :next_node: :what_year_full_time?
   :outcome_node: false
-- :current_node: :what_year_full_time?
-  :responses:
-  - uk-full-time
-  - income-details
-  - year-1516
-  :next_node: :outcome_parent_partner_1516
-  :outcome_node: true
 - :current_node: :what_year_full_time?
   :responses:
   - uk-full-time
@@ -96,6 +89,13 @@
   - year-1617
   :next_node: :outcome_parent_partner_1617
   :outcome_node: true
+- :current_node: :what_year_full_time?
+  :responses:
+  - uk-full-time
+  - income-details
+  - year-1516
+  :next_node: :outcome_parent_partner_1516
+  :outcome_node: true
 - :current_node: :form_needed_for_1?
   :responses:
   - uk-full-time
@@ -106,15 +106,15 @@
   :responses:
   - uk-full-time
   - apply-dsa
-  - year-1516
-  :next_node: :outcome_dsa_1516
+  - year-1617
+  :next_node: :outcome_dsa_1617
   :outcome_node: true
 - :current_node: :what_year_full_time?
   :responses:
   - uk-full-time
   - apply-dsa
-  - year-1617
-  :next_node: :outcome_dsa_1617
+  - year-1516
+  :next_node: :outcome_dsa_1516
   :outcome_node: true
 - :current_node: :form_needed_for_1?
   :responses:
@@ -132,15 +132,15 @@
   :responses:
   - uk-full-time
   - apply-ccg
-  - year-1516
-  :next_node: :outcome_ccg_1516
+  - year-1617
+  :next_node: :outcome_ccg_1617
   :outcome_node: true
 - :current_node: :what_year_full_time?
   :responses:
   - uk-full-time
   - apply-ccg
-  - year-1617
-  :next_node: :outcome_ccg_1617
+  - year-1516
+  :next_node: :outcome_ccg_1516
   :outcome_node: true
 - :current_node: :form_needed_for_1?
   :responses:
@@ -337,26 +337,6 @@
 - :current_node: :what_year_full_time?
   :responses:
   - eu-full-time
-  - year-1516
-  :next_node: :continuing_student?
-  :outcome_node: false
-- :current_node: :continuing_student?
-  :responses:
-  - eu-full-time
-  - year-1516
-  - continuing-student
-  :next_node: :outcome_eu_ft_1516_continuing
-  :outcome_node: true
-- :current_node: :continuing_student?
-  :responses:
-  - eu-full-time
-  - year-1516
-  - new-student
-  :next_node: :outcome_eu_ft_1516_new
-  :outcome_node: true
-- :current_node: :what_year_full_time?
-  :responses:
-  - eu-full-time
   - year-1617
   :next_node: :continuing_student?
   :outcome_node: false
@@ -373,6 +353,26 @@
   - year-1617
   - new-student
   :next_node: :outcome_eu_ft_1617_new
+  :outcome_node: true
+- :current_node: :what_year_full_time?
+  :responses:
+  - eu-full-time
+  - year-1516
+  :next_node: :continuing_student?
+  :outcome_node: false
+- :current_node: :continuing_student?
+  :responses:
+  - eu-full-time
+  - year-1516
+  - continuing-student
+  :next_node: :outcome_eu_ft_1516_continuing
+  :outcome_node: true
+- :current_node: :continuing_student?
+  :responses:
+  - eu-full-time
+  - year-1516
+  - new-student
+  :next_node: :outcome_eu_ft_1516_new
   :outcome_node: true
 - :current_node: :type_of_student?
   :responses:


### PR DESCRIPTION
## Description

While looking into something else, I noticed that the `*-responses-and-expected-results.yml` files for a number of flows were out-of-date:

* `check-uk-visa`
* `student-finance-forms`
* `state-pension-through-partner`
* `overseas-passports`

This PR updates those files and identifies the PR in which they should have been updated in the first place. I haven't done any checking that these changes are sensible, but I plan to ask the authors of the relevant PRs to check for me, because they will have more context.

While fixing the above, I also came across a few other problems:

* The changes in #2498 meant that the scripts for generating both the "questions & responses" and "responses & expected results" files were trying to use a local instance of the Whitehall app rather than the production instance.
* The questions & responses file for `simplified-expenses-checker` contained some invalid YAML.
* The questions & responses file for `landlord-immigration-check` was not up-to-date with the stubbed imminence lookups in the regression test nor its responses & expected results file.

I've fixed all of the above and it would be good to get this merged as soon as possible.

Note that I've also noticed that the script for generating the responses & expected results is using the wrong stubbed value of current time for some flows. I plan to address that in a separate PR, but that PR will rely on this one.

## External changes

None. These changes only affect test code - no changes to production code.
