### PR TITLE
Use appropriate value of stubbed time in regression tests

### DIFF
--- a/script/generate-responses-and-expected-results-for-smart-answer.rb
+++ b/script/generate-responses-and-expected-results-for-smart-answer.rb
@@ -2,12 +2,13 @@ ENV['PLEK_SERVICE_WHITEHALL_ADMIN_URI'] = 'https://www.gov.uk'
 
 require 'timecop'
 
-Timecop.freeze(Date.parse('2015-01-01'))
-
 unless flow_name = ARGV.shift
   puts "Usage: #{__FILE__} <flow-name>"
   exit 1
 end
+
+helper = SmartAnswerTestHelper.new(flow_name)
+Timecop.freeze(helper.current_time)
 
 if ENV["TEST_COVERAGE"]
   require 'simplecov'


### PR DESCRIPTION
## Description

Since #2518, it's been possible to configure different values of current time to use in the regression tests for different flows.

This commit updates the script for generating responses and expected results to use the appropriate value of current time derived from the configurations.

There doesn't appear to be an equivalent stubbing of current time in the `generate-questions-and-responses-for-smart-answer.rb` script and so I haven't made any changes to that.

I've re-generated the `*-responses-and-expected-results.yml` files for the flows which have a different current time specified (see below), but none of them have changed.

* `additional-commodity-code`
* `benefit-cap-calculator`
* `calculate-married-couples-allowance`
* `calculate-your-child-maintenance`
* `check-uk-visa`

## External changes

None. This only affects test code - not production code.
