### PR TITLE
Fix constant warnings in `gds-api-adapters/lib/gds_api/json_client.rb`

### DIFF
--- a/lib/working_days.rb
+++ b/lib/working_days.rb
@@ -1,5 +1,4 @@
 require 'gds_api/base'
-require 'gds_api/json_client'
 
 class WorkingDays
   WEEKDAYS = 1..5

--- a/test/data/vat-payment-deadlines-files.yml
+++ b/test/data/vat-payment-deadlines-files.yml
@@ -13,4 +13,4 @@ lib/smart_answer_flows/vat-payment-deadlines/questions/how_do_you_want_to_pay.go
 lib/smart_answer_flows/vat-payment-deadlines/questions/when_does_your_vat_accounting_period_end.govspeak.erb: 217f9782f9f2d669080270a463b04028
 lib/smart_answer_flows/vat-payment-deadlines/vat_payment_deadlines.govspeak.erb: 3f4ae8b59119f2eb094f1ece2cb4329b
 lib/smart_answer/calculators/vat_payment_deadlines.rb: 508ec06026cd700543c551366c31a550
-lib/working_days.rb: 30905f0f493f5842b564da7d1529899f
+lib/working_days.rb: 56b303de1ac11a141db3b523b2e589cd


### PR DESCRIPTION
## Description

I recently started seeing the following two warnings for each of the three constants defined in `gds_api/json_client`:

```
.bundle/gems/gems/gds-api-adapters-25.1.0/lib/gds_api/json_client.rb:65: warning: already initialized constant GdsApi::JsonClient::DEFAULT_TIMEOUT_IN_SECONDS
.bundle-2.3.0/gems/gems/gds-api-adapters-25.1.0/lib/gds_api/json_client.rb:65: warning: previous definition of DEFAULT_TIMEOUT_IN_SECONDS was here
.bundle/gems/gems/gds-api-adapters-25.1.0/lib/gds_api/json_client.rb:66: warning: already initialized constant GdsApi::JsonClient::DEFAULT_CACHE_SIZE
.bundle-2.3.0/gems/gems/gds-api-adapters-25.1.0/lib/gds_api/json_client.rb:66: warning: previous definition of DEFAULT_CACHE_SIZE was here
.bundle/gems/gems/gds-api-adapters-25.1.0/lib/gds_api/json_client.rb:67: warning: already initialized constant GdsApi::JsonClient::DEFAULT_CACHE_TTL
.bundle-2.3.0/gems/gems/gds-api-adapters-25.1.0/lib/gds_api/json_client.rb:67: warning: previous definition of DEFAULT_CACHE_TTL was here
```

I see them when I start the Rails console and when I run the tests with `rake`.

I'd like to avoid these warnings, because if we get used to seeing them, we're less likely to spot real problems in the future.

I'm not quite sure why I've only recently started seeing these warnings, but it might be connected to the fact that I deleted all my bundled gems and re-installed them.

The fundamental reason we are seeing these warnings is that the `gds-api-adapters/lib/gds_api/json_client.rb` file is being loaded multiple times.

One place it's happening is in `lib/working_days.rb` which has the following two lines at the top:

```ruby
require 'gds_api/base'
require 'gds_api/json_client'
```

The `WorkingDays.load_bank_holidays` method should only need the second of these lines i.e. `require 'gds_api/json_client'`, so it can use `GdsApi::JsonClient`. However, it turns out that the latter also depends on `GdsApi::Base`, but does not require it. This is why we need the first of the above lines, i.e. `require 'gds_api/base'`.

To further complicate matters, it turns out that `gds_api/base` requires `gds_api/json_client`! Also all the require statements within the `gds-api-adapters` gem use `require_relative`.

So I think what's happening is:

```
require 'gds_api/base' (lib/working_days.rb)
  -> require_relative 'json_client' (gds-api-adapters/lib/gds_api/base.rb)
    -> loads 'gds-api-adapters/lib/gds_api/json_client.rb' (1st time)
require 'gds_api/json_client' (lib/working_days.rb)
  -> loads 'gds-api-adapters/lib/gds_api/json_client.rb'   (2nd time)
```

I believe that the usual `require` mechanism which prevents files being loaded twice is not working, because the paths in each underlying call to `require` are different, because of the use of `require_relative` in one case and `require` in the other.

To be fair to `gds-api-adapters`, I don't think `GdsApi::JsonClient` was intended for use outside the gem. And perhaps the "right" way to fix this is to extract a `GdsApi::BankHolidays` component from the Smart Answers app into the gem.

Another way to fix this would be to ensure that the dependency of `JsonClient` on `Base` is made explicit within the `gds-api-adapters` gem. However, since we're many versions behind the current version of this gem, it might take us a while to get a fix to the gem accepted and published and then get the app updated to use the latest version.

In the short term, in this case we can avoid the warnings by only requiring `gds_api/base` in `lib/working_days.rb` and relying on that to require `gds_api/json_client`.

I think the change in this PR should mean that we don't see the warnings any more.

## External changes

None. This is just a small tweak to production code to avoid some Ruby warnings.
