### PR TITLE
Fix FlowContentItem#payload to validate against latest schemas

### DIFF
--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -9,6 +9,7 @@ class FlowContentItem
     {
       base_path: base_path,
       title: flow_presenter.title,
+      details: {},
       format: 'placeholder_smart_answer',
       publishing_app: 'smartanswers',
       rendering_app: 'smartanswers',


### PR DESCRIPTION
With the latest version of `govuk-content-schemas`, I was seeing the following test failure:

```
SmartAnswer::FlowContentItemTest#test_#payload_returns_a_valid_content-item [/home/jenkins/workspace/govuk_smartanswers_branches/test/unit/flow_content_item_test.rb:18]:
JSON not valid against placeholder schema:

The schema specific errors were:

- oneOf #0:
    - The property '#/' did not contain a required property of 'details'
- oneOf #1:
    - The property '#/' contains additional properties ["format"] outside of the schema when none are allowed
    - The property '#/' did not contain a required property of 'details'
    - The property '#/' did not contain a required property of 'schema_name'
    - The property '#/' did not contain a required property of 'document_type'
```

I first saw the test failure in [this CI build][1] rather than my local build, because my local version of `govuk-content-schemas` was not up-to-date.

@boffbowsh suggested that all I needed to do was add a `details` property set to an empty `Hash`, so that what I've done.

[1]: https://ci.dev.publishing.service.gov.uk/job/govuk_smartanswers_branches/5159/console