### PR TITLE
New outcomes for letter of no trace and clarify power of attorney

### DIFF
--- a/lib/data/legalisation_documents_data.yml
+++ b/lib/data/legalisation_documents_data.yml
@@ -178,7 +178,7 @@ letter-of-invitation:
 letter-of-no-trace:
   heading: Letter of no trace
   type: letter of no trace
-  group: birth_death
+  group: letter_no_trace
 medical-report:
   heading: Medical report
   type: medical report

--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -21,6 +21,24 @@
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/general-register-office-for-northern-ireland)
 
       ^A photocopy of your document won’t be accepted.^
+
+    <% when 'letter_no_trace' %>
+      ##<%= heading %>
+      Your <%= type %> can be legalised if it is either:
+
+      - an official certified copy of the letter signed by the General Register Office (GRO) with the original seal
+      - an original letter (or original certified copy) issued by a local register office, with the original signature of the official who issued the letter
+
+      It can take longer to legalise a signature on an original letter, especially if it was issued before 1991.
+
+      It might be quicker to order a certified copy of your letter from the:
+
+      - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
+      - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+      - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/general-register-office-for-northern-ireland)
+
+      ^A photocopy of your document won’t be accepted.^  
+    
     <% when 'certificate_impediment' %>
       ##<%= heading %>
 

--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -161,7 +161,8 @@
       Your <%= type %> can only be legalised if it’s either:
 
       - an original document issued by the Office of the Public Guardian (OPG) that’s marked with the embossed seal or the ink signature of an official of the OPG
-      - an original or photocopy that’s been certified
+      - an original document that's been certified
+      - a photocopy that’s been certified
 
     <% when 'solicitors_notaries' %>
       ##<%= heading %>

--- a/test/data/legalisation-document-checker-files.yml
+++ b/test/data/legalisation-document-checker-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/legalisation-document-checker.rb: 2ceea4546b19e8acf0d44b6
 test/data/legalisation-document-checker-questions-and-responses.yml: 37c99c68ba04e459447622b01938ce0b
 test/data/legalisation-document-checker-responses-and-expected-results.yml: d55ccccc64cc1f58b648e810e5fa07e5
 lib/smart_answer_flows/legalisation-document-checker/legalisation_document_checker.govspeak.erb: 4be67b8e3aeebe4f3b99a5153b92ccdf
-lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb: 43b1eb3528a773e49eda3f2a3940a9a6
+lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb: 0576974fff2274cf82f39124bff3f47e
 lib/smart_answer_flows/legalisation-document-checker/questions/which_documents_do_you_want_legalised.govspeak.erb: 807d6bee48fd47731d066aab6ad50544
 lib/smart_answer/calculators/legalisation_documents_data_query.rb: 1506239dc7b75049361f98fcb29dde85
-lib/data/legalisation_documents_data.yml: c9e9ce969845f657824904ad03a63793
+lib/data/legalisation_documents_data.yml: 7b32249d4358d433be1dd57886555c34


### PR DESCRIPTION
Supersedes #2506 

[Trello card](https://trello.com/c/K7JiG94b/126-updated-outcomes-for-letter-of-no-trace-power-of-attorney-in-legalise-document-tool)

* New outcome for letter of no trace and clarify power of attorney 

## Factcheck
[Preview Link](https://smart-answers-pr-2543.herokuapp.com/legalisation-document-checker/y/letter-of-no-trace)
[GOV.UK](https://www.gov.uk/legalisation-document-checker/y/letter-of-no-trace)

### Expected Changes

* Another Outcome for letter of no trace and clarify power of attorney 

### Before

![screen shot 2016-05-19 at 20 16 00](https://cloud.githubusercontent.com/assets/84896/15406462/993f9b6e-1dfe-11e6-9ce9-caf105ac78db.png)

### After
![screen shot 2016-05-19 at 20 15 36](https://cloud.githubusercontent.com/assets/84896/15406459/9369dad8-1dfe-11e6-8c88-f2e05d6b3543.png)
