### PR TITLE
Refactor landlord-immigration-check

### DIFF
--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -18,7 +18,7 @@ module SmartAnswer::Calculators
 
     def areas_for_postcode
       response = Services.imminence_api.areas_for_postcode(postcode)
-      response.try(:code) == 200 ? response.to_hash["results"] : {}
+      response.try(:code) == 200 ? response.results : {}
     end
   end
 end

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -18,7 +18,7 @@ module SmartAnswer::Calculators
 
     def areas_for_postcode
       response = Services.imminence_api.areas_for_postcode(postcode)
-      response.code == 200 ? response.results : []
+      response.results
     end
   end
 end

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -18,7 +18,7 @@ module SmartAnswer::Calculators
 
     def areas_for_postcode
       response = Services.imminence_api.areas_for_postcode(postcode)
-      response.code == 200 ? response.results : {}
+      response.code == 200 ? response.results : []
     end
   end
 end

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -18,7 +18,7 @@ module SmartAnswer::Calculators
 
     def areas_for_postcode
       response = Services.imminence_api.areas_for_postcode(postcode)
-      response.try(:code) == 200 ? response.results : {}
+      response.code == 200 ? response.results : {}
     end
   end
 end

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -11,7 +11,7 @@ module SmartAnswer::Calculators
     end
 
     def countries_for_postcode
-      areas_for_postcode.map { |a| a['country_name'] }.uniq
+      areas_for_postcode.map(&:country_name).uniq
     end
 
     def areas_for_postcode

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -17,8 +17,7 @@ module SmartAnswer::Calculators
     end
 
     def areas_for_postcode
-      response = Services.imminence_api.areas_for_postcode(postcode)
-      response.results
+      Services.imminence_api.areas_for_postcode(postcode).results
     end
   end
 end

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -1,6 +1,6 @@
 module SmartAnswer::Calculators
   class LandlordImmigrationCheckCalculator
-    VALID_COUNTRIES = %w( England )
+    COUNTRIES_WHERE_RULES_APPLY = %w( England )
 
     attr_reader :postcode
 
@@ -9,7 +9,7 @@ module SmartAnswer::Calculators
     end
 
     def rules_apply?
-      postcode_within?(VALID_COUNTRIES, 'country_name')
+      postcode_within?(COUNTRIES_WHERE_RULES_APPLY, 'country_name')
     end
 
     def postcode_within?(included_areas, key_name)

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -1,10 +1,8 @@
 module SmartAnswer::Calculators
   class LandlordImmigrationCheckCalculator
-    attr_reader :postcode
+    include ActiveModel::Model
 
-    def initialize(postcode)
-      @postcode = postcode
-    end
+    attr_accessor :postcode
 
     def rules_apply?
       countries_for_postcode.include?('England')

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -1,7 +1,5 @@
 module SmartAnswer::Calculators
   class LandlordImmigrationCheckCalculator
-    COUNTRIES_WHERE_RULES_APPLY = %w( England )
-
     attr_reader :postcode
 
     def initialize(postcode)
@@ -9,11 +7,11 @@ module SmartAnswer::Calculators
     end
 
     def rules_apply?
-      postcode_within?(COUNTRIES_WHERE_RULES_APPLY, 'country_name')
+      countries_for_postcode.include?('England')
     end
 
-    def postcode_within?(included_areas, key_name)
-      areas_for_postcode.select { |a| included_areas.include?(a[key_name]) }.any?
+    def countries_for_postcode
+      areas_for_postcode.map { |a| a['country_name'] }.uniq
     end
 
     def areas_for_postcode

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -8,7 +8,7 @@ module SmartAnswer::Calculators
       @postcode = postcode
     end
 
-    def included_country?
+    def rules_apply?
       postcode_within?(VALID_COUNTRIES, 'country_name')
     end
 

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -12,8 +12,6 @@ module SmartAnswer::Calculators
       postcode_within?(VALID_COUNTRIES, 'country_name')
     end
 
-  private
-
     def postcode_within?(included_areas, key_name)
       areas_for_postcode.select { |a| included_areas.include?(a[key_name]) }.any?
     end

--- a/lib/smart_answer_flows/landlord-immigration-check.rb
+++ b/lib/smart_answer_flows/landlord-immigration-check.rb
@@ -12,7 +12,7 @@ module SmartAnswer
         end
 
         next_node do
-          if calculator.included_country?
+          if calculator.rules_apply?
             question :main_home?
           else
             outcome :outcome_check_not_needed

--- a/lib/smart_answer_flows/landlord-immigration-check.rb
+++ b/lib/smart_answer_flows/landlord-immigration-check.rb
@@ -8,7 +8,7 @@ module SmartAnswer
 
       postcode_question :property? do
         next_node_calculation :calculator do |response|
-          Calculators::LandlordImmigrationCheckCalculator.new(response)
+          Calculators::LandlordImmigrationCheckCalculator.new(postcode: response)
         end
 
         next_node do

--- a/lib/smart_answer_flows/landlord-immigration-check.rb
+++ b/lib/smart_answer_flows/landlord-immigration-check.rb
@@ -7,8 +7,9 @@ module SmartAnswer
       satisfies_need "102373"
 
       postcode_question :property? do
-        next_node_calculation :calculator do |response|
-          Calculators::LandlordImmigrationCheckCalculator.new(postcode: response)
+        on_response do |response|
+          self.calculator = Calculators::LandlordImmigrationCheckCalculator.new
+          calculator.postcode = response
         end
 
         next_node do

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/landlord-immigration-check.rb: f8848dcb9bdd7c4e16e44782bec1a5a7
+lib/smart_answer_flows/landlord-immigration-check.rb: 3ddf91421103393dde03e3bbc825d60a
 test/data/landlord-immigration-check-questions-and-responses.yml: 1915a9d0bbbdf95822d21f11ff509465
 test/data/landlord-immigration-check-responses-and-expected-results.yml: 7982d80c9851bfa7e55dbee4661e70bc
 lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: 60507bfc657cf13a750b258017453743
@@ -31,4 +31,4 @@ lib/smart_answer_flows/landlord-immigration-check/questions/right_to_abode.govsp
 lib/smart_answer_flows/landlord-immigration-check/questions/tenant_country.govspeak.erb: a28062a1e9cb019d012fb962524130ee
 lib/smart_answer_flows/landlord-immigration-check/questions/tenant_over_18.govspeak.erb: c4a270709e77da5aff8c4e50aa56e905
 lib/smart_answer_flows/landlord-immigration-check/questions/time_limited_to_remain.govspeak.erb: 05c03a6a5cc9e07c3816a446cdc1c6f3
-lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: dc307bea9cf971910715971e36d7d36f
+lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: 8f94f99690138ede5c134b870c983489

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -11,8 +11,7 @@ module SmartAnswer::Calculators
 
     context 'when postcode is unknown' do
       setup do
-        stub_request(:get, %r{\A#{Plek.new.find('imminence')}/areas/E15\.json}).
-          to_return(body: { _response_info: { status: 404 }, total: 0, results: [] }.to_json)
+        imminence_has_areas_for_postcode("E15", [])
         @calculator.postcode = "E15"
       end
 

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -6,6 +6,8 @@ module SmartAnswer::Calculators
     include GdsApi::TestHelpers::Imminence
 
     setup do
+      @calculator = LandlordImmigrationCheckCalculator.new
+
       # Excluded countries
       imminence_has_areas_for_postcode("PA3%202SW",   [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
       imminence_has_areas_for_postcode("SA2%207JU",   [{ slug: 'swansea-council', country_name: 'Wales' }])
@@ -19,33 +21,33 @@ module SmartAnswer::Calculators
       stub_request(:get, %r{\A#{Plek.new.find('imminence')}/areas/E15\.json}).
         to_return(body: { _response_info: { status: 404 }, total: 0, results: [] }.to_json)
 
-      calculator = LandlordImmigrationCheckCalculator.new(postcode: "E15")
+      @calculator.postcode = "E15"
 
-      assert_equal [], calculator.areas_for_postcode
+      assert_equal [], @calculator.areas_for_postcode
     end
 
     test "with a postcode in Scotland" do
-      calculator = LandlordImmigrationCheckCalculator.new(postcode: "PA3 2SW")
+      @calculator.postcode = "PA3 2SW"
 
-      refute calculator.rules_apply?
+      refute @calculator.rules_apply?
     end
 
     test "with a postcode in Wales" do
-      calculator = LandlordImmigrationCheckCalculator.new(postcode: "SA2 7JU")
+      @calculator.postcode = "SA2 7JU"
 
-      refute calculator.rules_apply?
+      refute @calculator.rules_apply?
     end
 
     test "with a postcode in Northern Ireland" do
-      calculator = LandlordImmigrationCheckCalculator.new(postcode: "BT29 4AB")
+      @calculator.postcode = "BT29 4AB"
 
-      refute calculator.rules_apply?
+      refute @calculator.rules_apply?
     end
 
     test "with a postcode in England" do
-      calculator = LandlordImmigrationCheckCalculator.new(postcode: "RH6 0NP")
+      @calculator.postcode = "RH6 0NP"
 
-      assert calculator.rules_apply?
+      assert @calculator.rules_apply?
     end
   end
 end

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -19,11 +19,9 @@ module SmartAnswer::Calculators
       stub_request(:get, %r{\A#{Plek.new.find('imminence')}/areas/E15\.json}).
         to_return(body: { _response_info: { status: 404 }, total: 0, results: [] }.to_json)
 
-      response = Services.imminence_api.areas_for_postcode("E15")
+      calculator = LandlordImmigrationCheckCalculator.new("E15")
 
-      assert_equal 404, response["_response_info"]["status"]
-      assert_equal 0, response["total"]
-      assert_empty response["results"]
+      assert_equal [], calculator.areas_for_postcode
     end
 
     test "with a valid postcode in Scotland" do

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -31,6 +31,42 @@ module SmartAnswer::Calculators
       end
     end
 
+    context 'when postcode has multiple areas all in England' do
+      setup do
+        imminence_has_areas_for_postcode("RH6 0NP", [
+          { slug: 'crawley-borough-council', country_name: 'England' },
+          { slug: 'west-sussex-county-council', country_name: 'England' },
+        ])
+        @calculator.postcode = "RH6 0NP"
+      end
+
+      should 'return single country for postcode' do
+        assert_equal ['England'], @calculator.countries_for_postcode
+      end
+
+      should 'determine that the rules do apply' do
+        assert @calculator.rules_apply?
+      end
+    end
+
+    context 'when postcode has multiple areas some in England and some not' do
+      setup do
+        imminence_has_areas_for_postcode("XY1 0AB", [
+          { slug: 'xy-borough-council', country_name: 'England' },
+          { slug: 'xy-county-council', country_name: 'Scotland' },
+        ])
+        @calculator.postcode = "XY1 0AB"
+      end
+
+      should 'return all countries for postcode' do
+        assert_equal %w(England Scotland), @calculator.countries_for_postcode
+      end
+
+      should 'determine that the rules do apply' do
+        assert @calculator.rules_apply?
+      end
+    end
+
     context 'when postcode is unknown' do
       setup do
         imminence_has_areas_for_postcode("E15", [])

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -10,8 +10,6 @@ module SmartAnswer::Calculators
 
       # Excluded countries
       imminence_has_areas_for_postcode("PA3%202SW",   [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
-      imminence_has_areas_for_postcode("SA2%207JU",   [{ slug: 'swansea-council', country_name: 'Wales' }])
-      imminence_has_areas_for_postcode("BT29%204AB",  [{ slug: 'antrim-south-east', country_name: 'Northern Ireland' }])
 
       # Included country
       imminence_has_areas_for_postcode("RH6%200NP",   [{ slug: 'crawley-borough-council', country_name: 'England' }])
@@ -26,20 +24,8 @@ module SmartAnswer::Calculators
       assert_equal [], @calculator.areas_for_postcode
     end
 
-    test "with a postcode in Scotland" do
+    test "with a postcode outside England" do
       @calculator.postcode = "PA3 2SW"
-
-      refute @calculator.rules_apply?
-    end
-
-    test "with a postcode in Wales" do
-      @calculator.postcode = "SA2 7JU"
-
-      refute @calculator.rules_apply?
-    end
-
-    test "with a postcode in Northern Ireland" do
-      @calculator.postcode = "BT29 4AB"
 
       refute @calculator.rules_apply?
     end

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -27,7 +27,7 @@ module SmartAnswer::Calculators
 
     context 'when postcode is outside England' do
       setup do
-        imminence_has_areas_for_postcode("PA3%202SW", [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
+        imminence_has_areas_for_postcode("PA3 2SW", [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
         @calculator.postcode = "PA3 2SW"
       end
 
@@ -38,7 +38,7 @@ module SmartAnswer::Calculators
 
     context 'when postcode is in England' do
       setup do
-        imminence_has_areas_for_postcode("RH6%200NP", [{ slug: 'crawley-borough-council', country_name: 'England' }])
+        imminence_has_areas_for_postcode("RH6 0NP", [{ slug: 'crawley-borough-council', country_name: 'England' }])
         @calculator.postcode = "RH6 0NP"
       end
 

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -7,33 +7,44 @@ module SmartAnswer::Calculators
 
     setup do
       @calculator = LandlordImmigrationCheckCalculator.new
-
-      # Excluded countries
-      imminence_has_areas_for_postcode("PA3%202SW",   [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
-
-      # Included country
-      imminence_has_areas_for_postcode("RH6%200NP",   [{ slug: 'crawley-borough-council', country_name: 'England' }])
     end
 
-    test "with an unknown postcode" do
-      stub_request(:get, %r{\A#{Plek.new.find('imminence')}/areas/E15\.json}).
-        to_return(body: { _response_info: { status: 404 }, total: 0, results: [] }.to_json)
+    context 'when postcode is unknown' do
+      setup do
+        stub_request(:get, %r{\A#{Plek.new.find('imminence')}/areas/E15\.json}).
+          to_return(body: { _response_info: { status: 404 }, total: 0, results: [] }.to_json)
+        @calculator.postcode = "E15"
+      end
 
-      @calculator.postcode = "E15"
+      should 'return no areas for postcode' do
+        assert_equal [], @calculator.areas_for_postcode
+      end
 
-      assert_equal [], @calculator.areas_for_postcode
+      should 'determine that the rules do not apply' do
+        refute @calculator.rules_apply?
+      end
     end
 
-    test "with a postcode outside England" do
-      @calculator.postcode = "PA3 2SW"
+    context 'when postcode is outside England' do
+      setup do
+        imminence_has_areas_for_postcode("PA3%202SW", [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
+        @calculator.postcode = "PA3 2SW"
+      end
 
-      refute @calculator.rules_apply?
+      should 'determine that the rules do not apply' do
+        refute @calculator.rules_apply?
+      end
     end
 
-    test "with a postcode in England" do
-      @calculator.postcode = "RH6 0NP"
+    context 'when postcode is in England' do
+      setup do
+        imminence_has_areas_for_postcode("RH6%200NP", [{ slug: 'crawley-borough-council', country_name: 'England' }])
+        @calculator.postcode = "RH6 0NP"
+      end
 
-      assert @calculator.rules_apply?
+      should 'determine that the rules do not apply' do
+        assert @calculator.rules_apply?
+      end
     end
   end
 end

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -15,7 +15,7 @@ module SmartAnswer::Calculators
       imminence_has_areas_for_postcode("RH6%200NP",   [{ slug: 'crawley-borough-council', country_name: 'England' }])
     end
 
-    test "with an invalid postcode" do
+    test "with an unknown postcode" do
       stub_request(:get, %r{\A#{Plek.new.find('imminence')}/areas/E15\.json}).
         to_return(body: { _response_info: { status: 404 }, total: 0, results: [] }.to_json)
 
@@ -24,25 +24,25 @@ module SmartAnswer::Calculators
       assert_equal [], calculator.areas_for_postcode
     end
 
-    test "with a valid postcode in Scotland" do
+    test "with a postcode in Scotland" do
       calculator = LandlordImmigrationCheckCalculator.new("PA3 2SW")
 
       refute calculator.included_country?
     end
 
-    test "with a valid postcode in Wales" do
+    test "with a postcode in Wales" do
       calculator = LandlordImmigrationCheckCalculator.new("SA2 7JU")
 
       refute calculator.included_country?
     end
 
-    test "with a valid postcode in Northern Ireland" do
+    test "with a postcode in Northern Ireland" do
       calculator = LandlordImmigrationCheckCalculator.new("BT29 4AB")
 
       refute calculator.included_country?
     end
 
-    test "with a valid postcode in England" do
+    test "with a postcode in England" do
       calculator = LandlordImmigrationCheckCalculator.new("RH6 0NP")
 
       assert calculator.included_country?

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -27,25 +27,25 @@ module SmartAnswer::Calculators
     test "with a postcode in Scotland" do
       calculator = LandlordImmigrationCheckCalculator.new("PA3 2SW")
 
-      refute calculator.included_country?
+      refute calculator.rules_apply?
     end
 
     test "with a postcode in Wales" do
       calculator = LandlordImmigrationCheckCalculator.new("SA2 7JU")
 
-      refute calculator.included_country?
+      refute calculator.rules_apply?
     end
 
     test "with a postcode in Northern Ireland" do
       calculator = LandlordImmigrationCheckCalculator.new("BT29 4AB")
 
-      refute calculator.included_country?
+      refute calculator.rules_apply?
     end
 
     test "with a postcode in England" do
       calculator = LandlordImmigrationCheckCalculator.new("RH6 0NP")
 
-      assert calculator.included_country?
+      assert calculator.rules_apply?
     end
   end
 end

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -9,18 +9,14 @@ module SmartAnswer::Calculators
       @calculator = LandlordImmigrationCheckCalculator.new
     end
 
-    context 'when postcode is unknown' do
+    context 'when postcode is in England' do
       setup do
-        imminence_has_areas_for_postcode("E15", [])
-        @calculator.postcode = "E15"
-      end
-
-      should 'return no areas for postcode' do
-        assert_equal [], @calculator.areas_for_postcode
+        imminence_has_areas_for_postcode("RH6 0NP", [{ slug: 'crawley-borough-council', country_name: 'England' }])
+        @calculator.postcode = "RH6 0NP"
       end
 
       should 'determine that the rules do not apply' do
-        refute @calculator.rules_apply?
+        assert @calculator.rules_apply?
       end
     end
 
@@ -35,14 +31,18 @@ module SmartAnswer::Calculators
       end
     end
 
-    context 'when postcode is in England' do
+    context 'when postcode is unknown' do
       setup do
-        imminence_has_areas_for_postcode("RH6 0NP", [{ slug: 'crawley-borough-council', country_name: 'England' }])
-        @calculator.postcode = "RH6 0NP"
+        imminence_has_areas_for_postcode("E15", [])
+        @calculator.postcode = "E15"
+      end
+
+      should 'return no areas for postcode' do
+        assert_equal [], @calculator.areas_for_postcode
       end
 
       should 'determine that the rules do not apply' do
-        assert @calculator.rules_apply?
+        refute @calculator.rules_apply?
       end
     end
   end

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -19,31 +19,31 @@ module SmartAnswer::Calculators
       stub_request(:get, %r{\A#{Plek.new.find('imminence')}/areas/E15\.json}).
         to_return(body: { _response_info: { status: 404 }, total: 0, results: [] }.to_json)
 
-      calculator = LandlordImmigrationCheckCalculator.new("E15")
+      calculator = LandlordImmigrationCheckCalculator.new(postcode: "E15")
 
       assert_equal [], calculator.areas_for_postcode
     end
 
     test "with a postcode in Scotland" do
-      calculator = LandlordImmigrationCheckCalculator.new("PA3 2SW")
+      calculator = LandlordImmigrationCheckCalculator.new(postcode: "PA3 2SW")
 
       refute calculator.rules_apply?
     end
 
     test "with a postcode in Wales" do
-      calculator = LandlordImmigrationCheckCalculator.new("SA2 7JU")
+      calculator = LandlordImmigrationCheckCalculator.new(postcode: "SA2 7JU")
 
       refute calculator.rules_apply?
     end
 
     test "with a postcode in Northern Ireland" do
-      calculator = LandlordImmigrationCheckCalculator.new("BT29 4AB")
+      calculator = LandlordImmigrationCheckCalculator.new(postcode: "BT29 4AB")
 
       refute calculator.rules_apply?
     end
 
     test "with a postcode in England" do
-      calculator = LandlordImmigrationCheckCalculator.new("RH6 0NP")
+      calculator = LandlordImmigrationCheckCalculator.new(postcode: "RH6 0NP")
 
       assert calculator.rules_apply?
     end


### PR DESCRIPTION
## Description

I started work on this with the aim of reducing the duplication in the postcode lookups in `LandlordImmigrationCheckCalculator` and `BenefitCapCalculatorConfiguration` as per [this Trello card][1]. However, as a pre-cursor to that I've ended up refactoring the code towards the [new-style][2] and simplifying the `LandlordImmigrationCheckCalculator` considerably.

## External changes

None. This is just an internal refactoring.

[1]: https://trello.com/c/PvoeTNco
[2]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md