### PR TITLE
Check uk visa: Update visa checker for short term work

### DIFF
--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_n.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_n.govspeak.erb
@@ -1,24 +1,47 @@
 <% content_for :title do %>
-  You may need a visa to work, do business or academic research in the UK.
+  You don't need a visa for some business and academic visits, but you must get a visa to work in the UK.
 <% end %>
 
 <% content_for :body do %>
-  Whether you need a visa depends on your circumstances.
+  You may be able to come to the UK without a visa if you:
 
-  ## Business visits
-
-  You don't need a visa if you're coming to the UK for activities allowed under the following visas:
-
-  - a [Standard Visitor visa](/standard-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
-  - a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
-
-  However, you should bring [supporting documents](/government/publications/visitor-visa-guide-to-supporting-documents) to show at the border.
+  - are invited as an expert in your profession
+  - come for other business or academic activities
 
   %You may want to [apply for a visa](/browse/visas-immigration/short-visit-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
 
-  ## Temporary workers
+  ## If you’re invited as an expert
+  You can stay in the UK for up to 1 month without a visa, but you can only be paid to do certain things, eg:
 
-  You will need a temporary worker visa if you want to work in the UK for a short time:
+  - give guest lectures at a higher education institution
+  - provide advocacy in legal proceedings
+  - take part in arts, entertainment or sporting activities
+
+  Check the full list of what you can be paid to do - it’s the same as [what you can do on a Permitted Paid Engagement visa](/permitted-paid-engagement-visa).
+
+  ### Documents you need
+  You must show officers at the UK border that you’re eligible for a Permitted Paid Engagement visa, even if you don’t need one.
+
+  Check which [documents you must bring](/permitted-paid-engagement-visa/documents-you-must-provide).
+
+  ## If you come for other business or academic activities
+  You can stay in the UK for up to 6 months without a visa, but you can only do certain academic or business-related activities, eg:
+
+  - go to a conference, meeting or training
+  - take part in a specific sports-related event
+  - perform as an artist, entertainer or musician
+  - do academic research or accompany students on a study abroad programme
+
+  Check the full list of what you can do - it’s the same as [what you can do on a Standard Visitor visa](/standard-visitor-visa).
+
+  ### Documents you need
+  You must show officers at the UK border that you’re eligible for a Standard Visitor visa, even if you don’t need one.
+
+  Check which [documents you must bring](/standard-visitor-visa/documents-you-must-provide).
+
+  ## If you want to work in the UK
+
+  Apply for a temporary worker visa if you want to work in the UK for a short time:
 
   - in [sports](/tier-5-temporary-worker-creative-and-sporting-visa)
   - in [arts or entertainment](/tier-5-temporary-worker-creative-and-sporting-visa)
@@ -27,10 +50,12 @@
   - for a [charity](/tier-5-temporary-worker-charity-worker-visa)
   - for a [religious organisation](/tier-5-religious)
   - as a [domestic worker in a private household](/domestic-workers-in-a-private-household-visa)
-  - in a [role in your overseas employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
+  - on a [transfer to your employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
   - in a [skilled job](/tier-2-general)
+  - in [work covered by international law](/tier-5-international-agreement), eg for a foreign government or as a private servant in a diplomatic household
 
-  You can also apply for an [international agreement visa](/tier-5-international-agreement) if you'll be doing work covered by international law while in the UK (eg working for a foreign government or as a private servant in a diplomatic household).
+  ### If your stay is less than 3 months
+  You don't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months.
 
-  ^ You won't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months. You must bring a certificate of sponsorship and evidence of £900 savings as described in [section 3 of the visa guide](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide), to show officers at the border.
+  You must bring a [certificate of sponsorship](/tier-5-temporary-worker-creative-and-sporting-visa/eligibility) and [evidence of savings](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide) to show officers at the UK border.
 <% end %>

--- a/test/artefacts/check-uk-visa/andorra/work/six_months_or_less.txt
+++ b/test/artefacts/check-uk-visa/andorra/work/six_months_or_less.txt
@@ -1,21 +1,44 @@
-You may need a visa to work, do business or academic research in the UK.
+You don't need a visa for some business and academic visits, but you must get a visa to work in the UK.
 
-Whether you need a visa depends on your circumstances.
+You may be able to come to the UK without a visa if you:
 
-## Business visits
-
-You don't need a visa if you're coming to the UK for activities allowed under the following visas:
-
-- a [Standard Visitor visa](/standard-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
-- a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
-
-However, you should bring [supporting documents](/government/publications/visitor-visa-guide-to-supporting-documents) to show at the border.
+- are invited as an expert in your profession
+- come for other business or academic activities
 
 %You may want to [apply for a visa](/browse/visas-immigration/short-visit-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
 
-## Temporary workers
+## If you’re invited as an expert
+You can stay in the UK for up to 1 month without a visa, but you can only be paid to do certain things, eg:
 
-You will need a temporary worker visa if you want to work in the UK for a short time:
+- give guest lectures at a higher education institution
+- provide advocacy in legal proceedings
+- take part in arts, entertainment or sporting activities
+
+Check the full list of what you can be paid to do - it’s the same as [what you can do on a Permitted Paid Engagement visa](/permitted-paid-engagement-visa).
+
+### Documents you need
+You must show officers at the UK border that you’re eligible for a Permitted Paid Engagement visa, even if you don’t need one.
+
+Check which [documents you must bring](/permitted-paid-engagement-visa/documents-you-must-provide).
+
+## If you come for other business or academic activities
+You can stay in the UK for up to 6 months without a visa, but you can only do certain academic or business-related activities, eg:
+
+- go to a conference, meeting or training
+- take part in a specific sports-related event
+- perform as an artist, entertainer or musician
+- do academic research or accompany students on a study abroad programme
+
+Check the full list of what you can do - it’s the same as [what you can do on a Standard Visitor visa](/standard-visitor-visa).
+
+### Documents you need
+You must show officers at the UK border that you’re eligible for a Standard Visitor visa, even if you don’t need one.
+
+Check which [documents you must bring](/standard-visitor-visa/documents-you-must-provide).
+
+## If you want to work in the UK
+
+Apply for a temporary worker visa if you want to work in the UK for a short time:
 
 - in [sports](/tier-5-temporary-worker-creative-and-sporting-visa)
 - in [arts or entertainment](/tier-5-temporary-worker-creative-and-sporting-visa)
@@ -24,12 +47,14 @@ You will need a temporary worker visa if you want to work in the UK for a short 
 - for a [charity](/tier-5-temporary-worker-charity-worker-visa)
 - for a [religious organisation](/tier-5-religious)
 - as a [domestic worker in a private household](/domestic-workers-in-a-private-household-visa)
-- in a [role in your overseas employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
+- on a [transfer to your employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
 - in a [skilled job](/tier-2-general)
+- in [work covered by international law](/tier-5-international-agreement), eg for a foreign government or as a private servant in a diplomatic household
 
-You can also apply for an [international agreement visa](/tier-5-international-agreement) if you'll be doing work covered by international law while in the UK (eg working for a foreign government or as a private servant in a diplomatic household).
+### If your stay is less than 3 months
+You don't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months.
 
-^ You won't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months. You must bring a certificate of sponsorship and evidence of £900 savings as described in [section 3 of the visa guide](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide), to show officers at the border.
+You must bring a [certificate of sponsorship](/tier-5-temporary-worker-creative-and-sporting-visa/eligibility) and [evidence of savings](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide) to show officers at the UK border.
 
 
 

--- a/test/artefacts/check-uk-visa/anguilla/work/six_months_or_less.txt
+++ b/test/artefacts/check-uk-visa/anguilla/work/six_months_or_less.txt
@@ -1,21 +1,44 @@
-You may need a visa to work, do business or academic research in the UK.
+You don't need a visa for some business and academic visits, but you must get a visa to work in the UK.
 
-Whether you need a visa depends on your circumstances.
+You may be able to come to the UK without a visa if you:
 
-## Business visits
-
-You don't need a visa if you're coming to the UK for activities allowed under the following visas:
-
-- a [Standard Visitor visa](/standard-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
-- a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
-
-However, you should bring [supporting documents](/government/publications/visitor-visa-guide-to-supporting-documents) to show at the border.
+- are invited as an expert in your profession
+- come for other business or academic activities
 
 %You may want to [apply for a visa](/browse/visas-immigration/short-visit-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
 
-## Temporary workers
+## If you’re invited as an expert
+You can stay in the UK for up to 1 month without a visa, but you can only be paid to do certain things, eg:
 
-You will need a temporary worker visa if you want to work in the UK for a short time:
+- give guest lectures at a higher education institution
+- provide advocacy in legal proceedings
+- take part in arts, entertainment or sporting activities
+
+Check the full list of what you can be paid to do - it’s the same as [what you can do on a Permitted Paid Engagement visa](/permitted-paid-engagement-visa).
+
+### Documents you need
+You must show officers at the UK border that you’re eligible for a Permitted Paid Engagement visa, even if you don’t need one.
+
+Check which [documents you must bring](/permitted-paid-engagement-visa/documents-you-must-provide).
+
+## If you come for other business or academic activities
+You can stay in the UK for up to 6 months without a visa, but you can only do certain academic or business-related activities, eg:
+
+- go to a conference, meeting or training
+- take part in a specific sports-related event
+- perform as an artist, entertainer or musician
+- do academic research or accompany students on a study abroad programme
+
+Check the full list of what you can do - it’s the same as [what you can do on a Standard Visitor visa](/standard-visitor-visa).
+
+### Documents you need
+You must show officers at the UK border that you’re eligible for a Standard Visitor visa, even if you don’t need one.
+
+Check which [documents you must bring](/standard-visitor-visa/documents-you-must-provide).
+
+## If you want to work in the UK
+
+Apply for a temporary worker visa if you want to work in the UK for a short time:
 
 - in [sports](/tier-5-temporary-worker-creative-and-sporting-visa)
 - in [arts or entertainment](/tier-5-temporary-worker-creative-and-sporting-visa)
@@ -24,12 +47,14 @@ You will need a temporary worker visa if you want to work in the UK for a short 
 - for a [charity](/tier-5-temporary-worker-charity-worker-visa)
 - for a [religious organisation](/tier-5-religious)
 - as a [domestic worker in a private household](/domestic-workers-in-a-private-household-visa)
-- in a [role in your overseas employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
+- on a [transfer to your employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
 - in a [skilled job](/tier-2-general)
+- in [work covered by international law](/tier-5-international-agreement), eg for a foreign government or as a private servant in a diplomatic household
 
-You can also apply for an [international agreement visa](/tier-5-international-agreement) if you'll be doing work covered by international law while in the UK (eg working for a foreign government or as a private servant in a diplomatic household).
+### If your stay is less than 3 months
+You don't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months.
 
-^ You won't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months. You must bring a certificate of sponsorship and evidence of £900 savings as described in [section 3 of the visa guide](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide), to show officers at the border.
+You must bring a [certificate of sponsorship](/tier-5-temporary-worker-creative-and-sporting-visa/eligibility) and [evidence of savings](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide) to show officers at the UK border.
 
 
 

--- a/test/artefacts/check-uk-visa/israel/full-passport/work/six_months_or_less.txt
+++ b/test/artefacts/check-uk-visa/israel/full-passport/work/six_months_or_less.txt
@@ -1,21 +1,44 @@
-You may need a visa to work, do business or academic research in the UK.
+You don't need a visa for some business and academic visits, but you must get a visa to work in the UK.
 
-Whether you need a visa depends on your circumstances.
+You may be able to come to the UK without a visa if you:
 
-## Business visits
-
-You don't need a visa if you're coming to the UK for activities allowed under the following visas:
-
-- a [Standard Visitor visa](/standard-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
-- a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
-
-However, you should bring [supporting documents](/government/publications/visitor-visa-guide-to-supporting-documents) to show at the border.
+- are invited as an expert in your profession
+- come for other business or academic activities
 
 %You may want to [apply for a visa](/browse/visas-immigration/short-visit-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
 
-## Temporary workers
+## If you’re invited as an expert
+You can stay in the UK for up to 1 month without a visa, but you can only be paid to do certain things, eg:
 
-You will need a temporary worker visa if you want to work in the UK for a short time:
+- give guest lectures at a higher education institution
+- provide advocacy in legal proceedings
+- take part in arts, entertainment or sporting activities
+
+Check the full list of what you can be paid to do - it’s the same as [what you can do on a Permitted Paid Engagement visa](/permitted-paid-engagement-visa).
+
+### Documents you need
+You must show officers at the UK border that you’re eligible for a Permitted Paid Engagement visa, even if you don’t need one.
+
+Check which [documents you must bring](/permitted-paid-engagement-visa/documents-you-must-provide).
+
+## If you come for other business or academic activities
+You can stay in the UK for up to 6 months without a visa, but you can only do certain academic or business-related activities, eg:
+
+- go to a conference, meeting or training
+- take part in a specific sports-related event
+- perform as an artist, entertainer or musician
+- do academic research or accompany students on a study abroad programme
+
+Check the full list of what you can do - it’s the same as [what you can do on a Standard Visitor visa](/standard-visitor-visa).
+
+### Documents you need
+You must show officers at the UK border that you’re eligible for a Standard Visitor visa, even if you don’t need one.
+
+Check which [documents you must bring](/standard-visitor-visa/documents-you-must-provide).
+
+## If you want to work in the UK
+
+Apply for a temporary worker visa if you want to work in the UK for a short time:
 
 - in [sports](/tier-5-temporary-worker-creative-and-sporting-visa)
 - in [arts or entertainment](/tier-5-temporary-worker-creative-and-sporting-visa)
@@ -24,12 +47,14 @@ You will need a temporary worker visa if you want to work in the UK for a short 
 - for a [charity](/tier-5-temporary-worker-charity-worker-visa)
 - for a [religious organisation](/tier-5-religious)
 - as a [domestic worker in a private household](/domestic-workers-in-a-private-household-visa)
-- in a [role in your overseas employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
+- on a [transfer to your employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
 - in a [skilled job](/tier-2-general)
+- in [work covered by international law](/tier-5-international-agreement), eg for a foreign government or as a private servant in a diplomatic household
 
-You can also apply for an [international agreement visa](/tier-5-international-agreement) if you'll be doing work covered by international law while in the UK (eg working for a foreign government or as a private servant in a diplomatic household).
+### If your stay is less than 3 months
+You don't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months.
 
-^ You won't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months. You must bring a certificate of sponsorship and evidence of £900 savings as described in [section 3 of the visa guide](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide), to show officers at the border.
+You must bring a [certificate of sponsorship](/tier-5-temporary-worker-creative-and-sporting-visa/eligibility) and [evidence of savings](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide) to show officers at the UK border.
 
 
 

--- a/test/artefacts/check-uk-visa/taiwan/work/six_months_or_less.txt
+++ b/test/artefacts/check-uk-visa/taiwan/work/six_months_or_less.txt
@@ -1,21 +1,44 @@
-You may need a visa to work, do business or academic research in the UK.
+You don't need a visa for some business and academic visits, but you must get a visa to work in the UK.
 
-Whether you need a visa depends on your circumstances.
+You may be able to come to the UK without a visa if you:
 
-## Business visits
-
-You don't need a visa if you're coming to the UK for activities allowed under the following visas:
-
-- a [Standard Visitor visa](/standard-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
-- a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
-
-However, you should bring [supporting documents](/government/publications/visitor-visa-guide-to-supporting-documents) to show at the border.
+- are invited as an expert in your profession
+- come for other business or academic activities
 
 %You may want to [apply for a visa](/browse/visas-immigration/short-visit-visas) if you have a criminal record or you’ve previously been refused entry into the UK.%
 
-## Temporary workers
+## If you’re invited as an expert
+You can stay in the UK for up to 1 month without a visa, but you can only be paid to do certain things, eg:
 
-You will need a temporary worker visa if you want to work in the UK for a short time:
+- give guest lectures at a higher education institution
+- provide advocacy in legal proceedings
+- take part in arts, entertainment or sporting activities
+
+Check the full list of what you can be paid to do - it’s the same as [what you can do on a Permitted Paid Engagement visa](/permitted-paid-engagement-visa).
+
+### Documents you need
+You must show officers at the UK border that you’re eligible for a Permitted Paid Engagement visa, even if you don’t need one.
+
+Check which [documents you must bring](/permitted-paid-engagement-visa/documents-you-must-provide).
+
+## If you come for other business or academic activities
+You can stay in the UK for up to 6 months without a visa, but you can only do certain academic or business-related activities, eg:
+
+- go to a conference, meeting or training
+- take part in a specific sports-related event
+- perform as an artist, entertainer or musician
+- do academic research or accompany students on a study abroad programme
+
+Check the full list of what you can do - it’s the same as [what you can do on a Standard Visitor visa](/standard-visitor-visa).
+
+### Documents you need
+You must show officers at the UK border that you’re eligible for a Standard Visitor visa, even if you don’t need one.
+
+Check which [documents you must bring](/standard-visitor-visa/documents-you-must-provide).
+
+## If you want to work in the UK
+
+Apply for a temporary worker visa if you want to work in the UK for a short time:
 
 - in [sports](/tier-5-temporary-worker-creative-and-sporting-visa)
 - in [arts or entertainment](/tier-5-temporary-worker-creative-and-sporting-visa)
@@ -24,12 +47,14 @@ You will need a temporary worker visa if you want to work in the UK for a short 
 - for a [charity](/tier-5-temporary-worker-charity-worker-visa)
 - for a [religious organisation](/tier-5-religious)
 - as a [domestic worker in a private household](/domestic-workers-in-a-private-household-visa)
-- in a [role in your overseas employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
+- on a [transfer to your employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
 - in a [skilled job](/tier-2-general)
+- in [work covered by international law](/tier-5-international-agreement), eg for a foreign government or as a private servant in a diplomatic household
 
-You can also apply for an [international agreement visa](/tier-5-international-agreement) if you'll be doing work covered by international law while in the UK (eg working for a foreign government or as a private servant in a diplomatic household).
+### If your stay is less than 3 months
+You don't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months.
 
-^ You won't need a visa for [qualifying work](/tier-5-temporary-worker-creative-and-sporting-visa/overview) in sports, arts or entertainment if you're coming to the UK for less than 3 months. You must bring a certificate of sponsorship and evidence of £900 savings as described in [section 3 of the visa guide](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide), to show officers at the border.
+You must bring a [certificate of sponsorship](/tier-5-temporary-worker-creative-and-sporting-visa/eligibility) and [evidence of savings](/tier-5-temporary-worker-creative-and-sporting-visa/documents-you-must-provide) to show officers at the UK border.
 
 
 

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -30,7 +30,7 @@ lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_bor
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_venezuela.govspeak.erb: bae2c1566964317ca3d92b5b1d8a21f3
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver.govspeak.erb: 02d5c593f767fe5201de2afe81e65963
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_m.govspeak.erb: 7502173e6c4f65cb85ca5559c7ebb2e6
-lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_n.govspeak.erb: da229fbf8796faffab862bee3ed2b9a0
+lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_n.govspeak.erb: 8167c4997d0feeb1d9ae8833ea1af258
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_waiver.govspeak.erb: 916d5d06e4f6958d2dc287f128fd0bc9
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_y.govspeak.erb: 08ec2892f3d1501909183d0db908891e
 lib/smart_answer_flows/check-uk-visa/questions/israeli_document_type.govspeak.erb: 6e6ea79788922c6e4a76f87cac040193


### PR DESCRIPTION
Supersedes #2544 

### Trello card
* [Trello card](https://trello.com/c/4xJSZzZL/116-update-visa-checker-short-term-work)

## Description

Coming from this [Twitter issue](https://twitter.com/rachelnabors/status/709025578649649154).
In this circumstance, the user doesn't need a visa but the page is pretty unclear. It should clearly state "You don't need a visa as long as you.... X,Y,Z." and clearly signpost people to check the permitted paid engagement and documents guidance. Also mops up this factual error, from [archived ticket #263](https://trello.com/c/JZwCQaDx):

The results of the check if you need a visa tool for non-visa nationals applying to work for under 6 months specify incorrectly that it is £900 and not £945.

## Factcheck
[Factcheck](https://smart-answers-pr-2559.herokuapp.com/check-uk-visa/)

## Expected changes

* [URL on GOV.UK](https://www.gov.uk/check-uk-visa/y/usa/work/six_months_or_less)

### Before

<img width="942" alt="screen shot 2016-06-01 at 14 45 12" src="https://cloud.githubusercontent.com/assets/227328/15709910/a2d370e8-2807-11e6-9868-5f6055d54dc0.png">

### After

<img width="942" alt="screen shot 2016-06-01 at 14 45 30" src="https://cloud.githubusercontent.com/assets/227328/15709912/acad8d1a-2807-11e6-919c-f7864d888696.png">
