### PR TITLE
Refactor additional-commodity-code to new-style flow

### DIFF
--- a/lib/smart_answer/calculators/commodity_code_calculator.rb
+++ b/lib/smart_answer/calculators/commodity_code_calculator.rb
@@ -13,6 +13,10 @@ module SmartAnswer::Calculators
       super
       @matrix_data = self.class.commodity_codes_data
       @commodity_code_matrix = self.class.commodity_code_matrix
+      @starch_glucose_weight ||= 0
+      @sucrose_weight ||= 0
+      @milk_fat_weight ||= 0
+      @milk_protein_weight ||= 0
     end
 
     def commodity_code

--- a/lib/smart_answer/calculators/commodity_code_calculator.rb
+++ b/lib/smart_answer/calculators/commodity_code_calculator.rb
@@ -1,16 +1,18 @@
 module SmartAnswer::Calculators
   class CommodityCodeCalculator
+    include ActiveModel::Model
+
     attr_reader :matrix_data, :commodity_code_matrix
+
+    attr_accessor :starch_glucose_weight
+    attr_accessor :sucrose_weight
+    attr_accessor :milk_fat_weight
     attr_accessor :milk_protein_weight
 
-    def initialize(weights)
+    def initialize(attributes = {})
+      super
       @matrix_data = self.class.commodity_codes_data
       @commodity_code_matrix = self.class.commodity_code_matrix
-
-      @starch_glucose_weight = weights[:starch_glucose_weight].to_i
-      @sucrose_weight = weights[:sucrose_weight].to_i
-      @milk_fat_weight = weights[:milk_fat_weight].to_i
-      @milk_protein_weight = weights[:milk_protein_weight].to_i
     end
 
     def commodity_code
@@ -24,11 +26,11 @@ module SmartAnswer::Calculators
   private
 
     def glucose_sucrose_index
-      starch_glucose_to_sucrose[@starch_glucose_weight][@sucrose_weight]
+      starch_glucose_to_sucrose[starch_glucose_weight][sucrose_weight]
     end
 
     def milk_fat_milk_protein_index
-      milk_fat_to_milk_protein[@milk_fat_weight][@milk_protein_weight]
+      milk_fat_to_milk_protein[milk_fat_weight][milk_protein_weight]
     end
 
     def starch_glucose_to_sucrose

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -15,10 +15,9 @@ module SmartAnswer
         option 50
         option 75
 
-        save_input_as :starch_glucose_weight
-
-        calculate :milk_protein_weight do
-          nil
+        on_response do |response|
+          self.calculator = Calculators::CommodityCodeCalculator.new
+          calculator.starch_glucose_weight = response.to_i
         end
 
         next_node do |response|
@@ -43,7 +42,10 @@ module SmartAnswer
         option 50
         option 70
 
-        save_input_as :sucrose_weight
+        on_response do |response|
+          calculator.sucrose_weight = response.to_i
+        end
+
         next_node do
           question :how_much_milk_fat?
         end
@@ -56,7 +58,10 @@ module SmartAnswer
         option 30
         option 50
 
-        save_input_as :sucrose_weight
+        on_response do |response|
+          calculator.sucrose_weight = response.to_i
+        end
+
         next_node do
           question :how_much_milk_fat?
         end
@@ -68,7 +73,10 @@ module SmartAnswer
         option 5
         option 30
 
-        save_input_as :sucrose_weight
+        on_response do |response|
+          calculator.sucrose_weight = response.to_i
+        end
+
         next_node do
           question :how_much_milk_fat?
         end
@@ -79,7 +87,10 @@ module SmartAnswer
         option 0
         option 5
 
-        save_input_as :sucrose_weight
+        on_response do |response|
+          calculator.sucrose_weight = response.to_i
+        end
+
         next_node do
           question :how_much_milk_fat?
         end
@@ -100,7 +111,9 @@ module SmartAnswer
         option 70
         option 85
 
-        save_input_as :milk_fat_weight
+        on_response do |response|
+          calculator.milk_fat_weight = response.to_i
+        end
 
         next_node do |response|
           case response.to_i
@@ -129,7 +142,9 @@ module SmartAnswer
         option 30
         option 60
 
-        save_input_as :milk_protein_weight
+        on_response do |response|
+          calculator.milk_protein_weight = response.to_i
+        end
 
         next_node do
           outcome :commodity_code_result
@@ -142,7 +157,9 @@ module SmartAnswer
         option 2
         option 12
 
-        save_input_as :milk_protein_weight
+        on_response do |response|
+          calculator.milk_protein_weight = response.to_i
+        end
 
         next_node do
           outcome :commodity_code_result
@@ -155,7 +172,9 @@ module SmartAnswer
         option 4
         option 15
 
-        save_input_as :milk_protein_weight
+        on_response do |response|
+          calculator.milk_protein_weight = response.to_i
+        end
 
         next_node do
           outcome :commodity_code_result
@@ -168,7 +187,9 @@ module SmartAnswer
         option 6
         option 18
 
-        save_input_as :milk_protein_weight
+        on_response do |response|
+          calculator.milk_protein_weight = response.to_i
+        end
 
         next_node do
           outcome :commodity_code_result
@@ -180,22 +201,16 @@ module SmartAnswer
         option 0
         option 6
 
-        save_input_as :milk_protein_weight
+        on_response do |response|
+          calculator.milk_protein_weight = response.to_i
+        end
 
         next_node do
           outcome :commodity_code_result
         end
       end
 
-      outcome :commodity_code_result do
-        precalculate :calculator do
-          Calculators::CommodityCodeCalculator.new(
-            starch_glucose_weight: starch_glucose_weight.to_i,
-            sucrose_weight: sucrose_weight.to_i,
-            milk_fat_weight: milk_fat_weight.to_i,
-            milk_protein_weight: milk_protein_weight.to_i)
-        end
-      end
+      outcome :commodity_code_result
     end
   end
 end

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -190,10 +190,10 @@ module SmartAnswer
       outcome :commodity_code_result do
         precalculate :calculator do
           Calculators::CommodityCodeCalculator.new(
-            starch_glucose_weight: starch_glucose_weight,
-            sucrose_weight: sucrose_weight,
-            milk_fat_weight: milk_fat_weight,
-            milk_protein_weight: milk_protein_weight)
+            starch_glucose_weight: starch_glucose_weight.to_i,
+            sucrose_weight: sucrose_weight.to_i,
+            milk_fat_weight: milk_fat_weight.to_i,
+            milk_protein_weight: milk_protein_weight.to_i)
         end
       end
     end

--- a/test/data/additional-commodity-code-files.yml
+++ b/test/data/additional-commodity-code-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/additional-commodity-code.rb: 0dbde7aa4f33eb96b5a336c9e9d5bdff
+lib/smart_answer_flows/additional-commodity-code.rb: d14dcd410d4b21ee51f0f583519c3412
 test/data/additional-commodity-code-questions-and-responses.yml: 24243e9af7ed9c7aca5ed6adbfa0c9b7
 test/data/additional-commodity-code-responses-and-expected-results.yml: 3f80e1b92ec7731959b0f8033a4f43c8
 lib/smart_answer_flows/additional-commodity-code/additional_commodity_code.govspeak.erb: 4d11f8bf0bcd29764893c4a12349de17
@@ -15,5 +15,5 @@ lib/smart_answer_flows/additional-commodity-code/questions/how_much_sucrose_1.go
 lib/smart_answer_flows/additional-commodity-code/questions/how_much_sucrose_2.govspeak.erb: 69fa5acf376f4936de63f1bfb5775318
 lib/smart_answer_flows/additional-commodity-code/questions/how_much_sucrose_3.govspeak.erb: 6b3c81896c9981224fddf7996495ee40
 lib/smart_answer_flows/additional-commodity-code/questions/how_much_sucrose_4.govspeak.erb: 46ad361a17576dba3aa9041c7857d2bb
-lib/smart_answer/calculators/commodity_code_calculator.rb: 2ef1afca017d2688f4b30edf1442dcb4
+lib/smart_answer/calculators/commodity_code_calculator.rb: 712cf498c65631b3c9b506d0217e039b
 lib/data/commodity_codes_data.yml: e18434a8a7b02f644e69ebe45f518772

--- a/test/integration/smart_answer_flows/additional_commodity_code_test.rb
+++ b/test/integration/smart_answer_flows/additional_commodity_code_test.rb
@@ -18,7 +18,7 @@ class AdditionalCommodityCodeTest < ActiveSupport::TestCase
     ## Q2c
     should "ask how much sucrose the product contains" do
       add_response 25
-      assert_state_variable "starch_glucose_weight", "25"
+      assert_equal 25, current_state.calculator.starch_glucose_weight
       assert_current_node :how_much_sucrose_2?
     end
   end
@@ -26,7 +26,7 @@ class AdditionalCommodityCodeTest < ActiveSupport::TestCase
     ## Q2d
     should "ask how much sucrose the product contains" do
       add_response 50
-      assert_state_variable "starch_glucose_weight", "50"
+      assert_equal 50, current_state.calculator.starch_glucose_weight
       assert_current_node :how_much_sucrose_3?
     end
   end
@@ -34,7 +34,7 @@ class AdditionalCommodityCodeTest < ActiveSupport::TestCase
     ## Q2e
     should "ask how much sucrose the product contains" do
       add_response 75
-      assert_state_variable "starch_glucose_weight", "75"
+      assert_equal 75, current_state.calculator.starch_glucose_weight
       assert_current_node :how_much_sucrose_4?
     end
   end
@@ -44,7 +44,7 @@ class AdditionalCommodityCodeTest < ActiveSupport::TestCase
     end
     ## Q2ab
     should "ask how much sucrose the product contains" do
-      assert_state_variable "starch_glucose_weight", "5"
+      assert_equal 5, current_state.calculator.starch_glucose_weight
       assert_current_node :how_much_sucrose_1?
     end
     context "answer 30" do
@@ -53,7 +53,7 @@ class AdditionalCommodityCodeTest < ActiveSupport::TestCase
       end
       ## Q3
       should "save the input" do
-        assert_state_variable "sucrose_weight", "30"
+        assert_equal 30, current_state.calculator.sucrose_weight
       end
       should "ask how much milk fat the product contains" do
         assert_current_node :how_much_milk_fat?


### PR DESCRIPTION
## Description

Similar to #2561, this moves the flow towards the style described in the [refactoring documentation][1]. I've concentrated on moving logic out of the flow and into the calculator. This is a fairly simple flow - mostly just a decision tree and so it may not be obvious why I want to do this. However, if we can move all the flows to use this approach, then I'm confident we can significantly simplify the DSL.

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md