### PR TITLE
Stub WorldLocation directly instead of using GdsApi::TestHelpers::Worldwide (with feedback addressed)

### DIFF
--- a/test/fixtures/smart_answer_flows/country-and-date-sample.rb
+++ b/test/fixtures/smart_answer_flows/country-and-date-sample.rb
@@ -4,7 +4,7 @@ module SmartAnswer
       name 'country-and-date-sample'
       status :draft
 
-      country_select :which_country_do_you_live_in?, exclude_countries: %w(afghanistan united-kingdom) do
+      country_select :which_country_do_you_live_in? do
         save_input_as :country
         next_node do
           question :what_date_did_you_move_there?
@@ -25,7 +25,7 @@ module SmartAnswer
         end
       end
 
-      country_select :which_country_were_you_born_in?, include_uk: true do
+      country_select :which_country_were_you_born_in? do
         save_input_as :birth_country
         next_node do
           outcome :ok

--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -1,12 +1,9 @@
 require_relative 'engine_test_helper'
-require 'gds_api/test_helpers/worldwide'
 
 class ChangingAnswerTest < EngineIntegrationTest
-  include GdsApi::TestHelpers::Worldwide
-
   with_and_without_javascript do
     should "be able to change country and date answers" do
-      worldwide_api_has_selection_of_locations
+      stub_worldwide_locations(%w(argentina belarus))
 
       visit "/country-and-date-sample/y"
 
@@ -28,10 +25,10 @@ class ChangingAnswerTest < EngineIntegrationTest
         assert page.has_selector? :select, "response", selected: "Belarus"
       end
 
-      select "South Korea", from: "response"
+      select "Argentina", from: "response"
       click_on "Next step"
 
-      assert_current_url "/country-and-date-sample/y/south-korea"
+      assert_current_url "/country-and-date-sample/y/argentina"
 
       select "10", from: "Day"
       select "June", from: "Month"
@@ -51,7 +48,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       select "2000", from: "Year"
       click_on "Next step"
 
-      assert_current_url "/country-and-date-sample/y/south-korea/2000-04-15"
+      assert_current_url "/country-and-date-sample/y/argentina/2000-04-15"
     end
 
     should "be able to change money and salary answers" do

--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -3,7 +3,7 @@ require_relative 'engine_test_helper'
 class ChangingAnswerTest < EngineIntegrationTest
   with_and_without_javascript do
     should "be able to change country and date answers" do
-      stub_worldwide_locations(%w(argentina belarus))
+      stub_world_locations(%w(argentina belarus))
 
       visit "/country-and-date-sample/y"
 

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -7,13 +7,13 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
   with_and_without_javascript do
     setup do
       @location_slugs = %w(
-        afghanistan angola aruba bangladesh belarus brazil brunei
+        angola aruba bangladesh belarus brazil brunei
         cambodia chad croatia denmark eritrea france ghana iceland
         japan laos luxembourg malta micronesia mozambique nicaragua
         panama portugal sao-tome-and-principe singapore south-korea
         sri-lanka uk-delegation-to-council-of-europe
         uk-delegation-to-organization-for-security-and-co-operation-in-europe
-        united-kingdom venezuela vietnam
+        venezuela vietnam
       )
       worldwide_api_has_locations(@location_slugs)
       Timecop.travel("2013-01-01")
@@ -29,7 +29,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
       within '.question-body' do
         assert page.has_select?("response")
-        # Options above missing delegations and uk
+        # Options above missing delegations
         expected = %w(
           angola aruba bangladesh belarus brazil brunei
           cambodia chad croatia denmark eritrea france ghana iceland
@@ -106,20 +106,20 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         assert page.has_select?("response")
         # Options above excluding delegations
         expected = %w(
-          afghanistan angola aruba bangladesh belarus brazil brunei
+          angola aruba bangladesh belarus brazil brunei
           cambodia chad croatia denmark eritrea france ghana iceland
           japan laos luxembourg malta micronesia mozambique nicaragua
           panama portugal sao-tome-and-principe singapore south-korea
-          sri-lanka united-kingdom venezuela vietnam
+          sri-lanka venezuela vietnam
         )
         actual = page.all('select option').map(&:value)
         assert_equal expected, actual
       end
 
-      select "United Kingdom", from: "response"
+      select "Venezuela", from: "response"
       click_on "Next step"
 
-      assert_current_url "/country-and-date-sample/y/belarus/1975-05-05/united-kingdom"
+      assert_current_url "/country-and-date-sample/y/belarus/1975-05-05/venezuela"
 
       within '.done-questions' do
         assert page.has_link?("Start again", href: '/country-and-date-sample')
@@ -145,14 +145,14 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
             assert_page_has_content "Which country were you born in?"
           end
 
-          within('.previous-question-body') { assert_page_has_content "United Kingdom" }
-          within('.link-right') { assert page.has_link?("Change", href: "/country-and-date-sample/y/belarus/1975-05-05?previous_response=united-kingdom") }
+          within('.previous-question-body') { assert_page_has_content "Venezuela" }
+          within('.link-right') { assert page.has_link?("Change", href: "/country-and-date-sample/y/belarus/1975-05-05?previous_response=venezuela") }
         end
       end
 
       within '.outcome:nth-child(1)' do
         within '.result-info' do
-          within('h2.result-title') { assert_page_has_content "Great - you've lived in belarus for 37 years, and were born in united-kingdom!" }
+          within('h2.result-title') { assert_page_has_content "Great - you've lived in belarus for 37 years, and were born in venezuela!" }
         end
       end
     end

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -1,9 +1,6 @@
 require_relative 'engine_test_helper'
-require 'gds_api/test_helpers/worldwide'
 
 class CountryAndDateQuestionsTest < EngineIntegrationTest
-  include GdsApi::TestHelpers::Worldwide
-
   with_and_without_javascript do
     setup do
       @location_slugs = %w(
@@ -13,7 +10,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         panama portugal sao-tome-and-principe singapore south-korea
         sri-lanka venezuela vietnam
       )
-      worldwide_api_has_locations(@location_slugs)
+      stub_worldwide_locations(@location_slugs)
       Timecop.travel("2013-01-01")
     end
 

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -27,15 +27,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
       within '.question-body' do
         assert page.has_select?("response")
-        expected = %w(
-          angola aruba bangladesh belarus brazil brunei
-          cambodia chad croatia denmark eritrea france ghana iceland
-          japan laos luxembourg malta micronesia mozambique nicaragua
-          panama portugal sao-tome-and-principe singapore south-korea
-          sri-lanka venezuela vietnam
-        )
         actual = page.all('select option').map(&:value)
-        assert_equal expected, actual
+        assert_equal @location_slugs, actual
       end
 
       select "Belarus", from: "response"
@@ -101,15 +94,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
       within '.question-body' do
         assert page.has_select?("response")
-        expected = %w(
-          angola aruba bangladesh belarus brazil brunei
-          cambodia chad croatia denmark eritrea france ghana iceland
-          japan laos luxembourg malta micronesia mozambique nicaragua
-          panama portugal sao-tome-and-principe singapore south-korea
-          sri-lanka venezuela vietnam
-        )
         actual = page.all('select option').map(&:value)
-        assert_equal expected, actual
+        assert_equal @location_slugs, actual
       end
 
       select "Venezuela", from: "response"

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -11,9 +11,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         cambodia chad croatia denmark eritrea france ghana iceland
         japan laos luxembourg malta micronesia mozambique nicaragua
         panama portugal sao-tome-and-principe singapore south-korea
-        sri-lanka uk-delegation-to-council-of-europe
-        uk-delegation-to-organization-for-security-and-co-operation-in-europe
-        venezuela vietnam
+        sri-lanka venezuela vietnam
       )
       worldwide_api_has_locations(@location_slugs)
       Timecop.travel("2013-01-01")
@@ -29,7 +27,6 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
       within '.question-body' do
         assert page.has_select?("response")
-        # Options above missing delegations
         expected = %w(
           angola aruba bangladesh belarus brazil brunei
           cambodia chad croatia denmark eritrea france ghana iceland
@@ -104,7 +101,6 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
       within '.question-body' do
         assert page.has_select?("response")
-        # Options above excluding delegations
         expected = %w(
           angola aruba bangladesh belarus brazil brunei
           cambodia chad croatia denmark eritrea france ghana iceland

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -157,11 +157,4 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
     end
   end # with_and_without_javascript
-
-  should "return a 503 if the worldwide API errors" do
-    stub_request(:get, %r{\A#{GdsApi::TestHelpers::Worldwide::WORLDWIDE_API_ENDPOINT}}).to_timeout
-
-    visit "/country-and-date-sample/y"
-    assert_equal 503, page.status_code
-  end
 end

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -10,7 +10,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         panama portugal sao-tome-and-principe singapore south-korea
         sri-lanka venezuela vietnam
       )
-      stub_worldwide_locations(@location_slugs)
+      stub_world_locations(@location_slugs)
       Timecop.travel("2013-01-01")
     end
 

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -8,7 +8,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
 
   setup do
     @location_slugs = %w(andorra anguilla armenia bolivia canada china colombia croatia mexico south-africa stateless-or-refugee syria turkey yemen oman united-arab-emirates qatar taiwan venezuela)
-    stub_worldwide_locations(@location_slugs)
+    stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::CheckUkVisaFlow
   end
 

--- a/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
+++ b/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
@@ -8,7 +8,7 @@ class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
 
   setup do
     @location_slugs = %w(aruba belgium greece iran syria)
-    stub_worldwide_locations(@location_slugs)
+    stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::HelpIfYouAreArrestedAbroadFlow
   end
 

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -12,7 +12,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
   setup do
     @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china costa-rica cote-d-ivoire croatia colombia cyprus czech-republic democratic-republic-of-congo denmark ecuador egypt estonia finland france germany greece hong-kong indonesia iran ireland italy japan jordan kazakhstan kosovo kyrgyzstan laos latvia lebanon lithuania macao macedonia malta mayotte mexico monaco montenegro morocco netherlands nicaragua north-korea norway oman guatemala paraguay peru philippines poland portugal qatar romania russia rwanda saint-barthelemy san-marino saudi-arabia serbia seychelles slovakia slovenia south-africa st-maarten st-martin south-korea spain sweden switzerland thailand turkey turkmenistan ukraine united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe).uniq
-    stub_worldwide_locations(@location_slugs)
+    stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::MarriageAbroadFlow
   end
 
@@ -22,7 +22,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
   context "newly added country that has no logic to handle opposite sex marriages" do
     setup do
-      stub_worldwide_locations(['narnia'])
+      stub_world_locations(['narnia'])
       add_response 'ceremony_country'
       add_response 'partner_local'
       assert_raises(SmartAnswer::Question::Base::NextNodeUndefined) do

--- a/test/integration/smart_answer_flows/overseas_passports_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_test.rb
@@ -8,7 +8,7 @@ class OverseasPassportsTest < ActiveSupport::TestCase
 
   setup do
     @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan laos malta nepal nigeria pakistan pitcairn-island saint-barthelemy saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha st-maarten st-martin tajikistan tanzania timor-leste turkey turkmenistan ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
-    stub_worldwide_locations(@location_slugs)
+    stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::OverseasPassportsFlow
   end
 

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -8,7 +8,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
 
   setup do
     @location_slugs = %w(afghanistan algeria andorra australia bangladesh barbados belize cambodia cameroon democratic-republic-of-congo el-salvador estonia germany guatemala grenada india iran iraq israel laos libya maldives morocco netherlands north-korea pakistan philippines pitcairn-island saint-barthelemy serbia sierra-leone spain sri-lanka st-kitts-and-nevis st-martin thailand turkey uganda united-arab-emirates venezuela)
-    stub_worldwide_locations(@location_slugs)
+    stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::RegisterABirthFlow
   end
 

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -8,7 +8,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
 
   setup do
     @location_slugs = %w(afghanistan algeria andorra argentina australia austria barbados belgium brazil cameroon dominica egypt france germany iran italy kenya libya morocco nigeria north-korea pakistan pitcairn-island poland saint-barthelemy serbia slovakia spain st-kitts-and-nevis st-martin uganda)
-    stub_worldwide_locations(@location_slugs)
+    stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::RegisterADeathFlow
   end
 

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
@@ -8,7 +8,7 @@ class ReportALostOrStolenPassportTest < ActiveSupport::TestCase
 
   setup do
     @location_slugs = %w(azerbaijan canada)
-    stub_worldwide_locations(@location_slugs)
+    stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::ReportALostOrStolenPassportFlow
   end
 

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -8,7 +8,7 @@ class UKBenefitsAbroadTest < ActiveSupport::TestCase
 
   setup do
     setup_for_testing_flow SmartAnswer::UkBenefitsAbroadFlow
-    stub_worldwide_locations %w(albania austria canada jamaica kosovo)
+    stub_world_locations %w(albania austria canada jamaica kosovo)
   end
 
   # Q1

--- a/test/support/world_location_stubbing_methods.rb
+++ b/test/support/world_location_stubbing_methods.rb
@@ -1,0 +1,17 @@
+module WorldLocationStubbingMethods
+  def stub_worldwide_location(location_slug)
+    location = stub.quacks_like(WorldLocation.new({}))
+    location.stubs(:slug).returns(location_slug)
+    location.stubs(:name).returns(location_slug.humanize)
+    location.stubs(:fco_organisation).returns(nil)
+    WorldLocation.stubs(:find).with(location_slug).returns(location)
+    location
+  end
+
+  def stub_worldwide_locations(location_slugs)
+    locations = location_slugs.map do |slug|
+      stub_worldwide_location(slug)
+    end
+    WorldLocation.stubs(:all).returns(locations)
+  end
+end

--- a/test/support/world_location_stubbing_methods.rb
+++ b/test/support/world_location_stubbing_methods.rb
@@ -1,5 +1,5 @@
 module WorldLocationStubbingMethods
-  def stub_worldwide_location(location_slug)
+  def stub_world_location(location_slug)
     location = stub.quacks_like(WorldLocation.new({}))
     location.stubs(:slug).returns(location_slug)
     location.stubs(:name).returns(location_slug.humanize)
@@ -8,9 +8,9 @@ module WorldLocationStubbingMethods
     location
   end
 
-  def stub_worldwide_locations(location_slugs)
+  def stub_world_locations(location_slugs)
     locations = location_slugs.map do |slug|
-      stub_worldwide_location(slug)
+      stub_world_location(slug)
     end
     WorldLocation.stubs(:all).returns(locations)
   end

--- a/test/support/world_location_stubbing_methods.rb
+++ b/test/support/world_location_stubbing_methods.rb
@@ -1,8 +1,13 @@
+require 'gds_api/test_helpers/common_responses'
+
 module WorldLocationStubbingMethods
+  include GdsApi::TestHelpers::CommonResponses
+
   def stub_world_location(location_slug)
     location = stub.quacks_like(WorldLocation.new({}))
     location.stubs(:slug).returns(location_slug)
-    location.stubs(:name).returns(location_slug.humanize)
+    name = titleize_slug(location_slug, title_case: true)
+    location.stubs(:name).returns(name)
     location.stubs(:fco_organisation).returns(nil)
     WorldLocation.stubs(:find).with(location_slug).returns(location)
     location

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,25 +31,11 @@ end
 
 require 'gds_api/test_helpers/json_client_helper'
 require_relative 'support/fixture_methods'
+require_relative 'support/world_location_stubbing_methods'
 
 class ActiveSupport::TestCase
   include FixtureMethods
-
-  def stub_worldwide_location(location_slug)
-    location = stub.quacks_like(WorldLocation.new({}))
-    location.stubs(:slug).returns(location_slug)
-    location.stubs(:name).returns(location_slug.humanize)
-    location.stubs(:fco_organisation).returns(nil)
-    WorldLocation.stubs(:find).with(location_slug).returns(location)
-    location
-  end
-
-  def stub_worldwide_locations(location_slugs)
-    locations = location_slugs.map do |slug|
-      stub_worldwide_location(slug)
-    end
-    WorldLocation.stubs(:all).returns(locations)
-  end
+  include WorldLocationStubbingMethods
 end
 
 require 'govuk-content-schema-test-helpers/test_unit'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,14 +43,18 @@ GovukContentSchemaTestHelpers.configure do |config|
   config.project_root = Rails.root
 end
 
+def stub_worldwide_location(location_slug)
+  location = stub.quacks_like(WorldLocation.new({}))
+  location.stubs(:slug).returns(location_slug)
+  location.stubs(:name).returns(location_slug.humanize)
+  location.stubs(:fco_organisation).returns(nil)
+  WorldLocation.stubs(:find).with(location_slug).returns(location)
+  location
+end
+
 def stub_worldwide_locations(location_slugs)
   locations = location_slugs.map do |slug|
-    location = stub.quacks_like(WorldLocation.new({}))
-    location.stubs(:slug).returns(slug)
-    location.stubs(:name).returns(slug.humanize)
-    location.stubs(:fco_organisation).returns(nil)
-    WorldLocation.stubs(:find).with(slug).returns(location)
-    location
+    stub_worldwide_location(slug)
   end
   WorldLocation.stubs(:all).returns(locations)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,22 @@ require_relative 'support/fixture_methods'
 
 class ActiveSupport::TestCase
   include FixtureMethods
+
+  def stub_worldwide_location(location_slug)
+    location = stub.quacks_like(WorldLocation.new({}))
+    location.stubs(:slug).returns(location_slug)
+    location.stubs(:name).returns(location_slug.humanize)
+    location.stubs(:fco_organisation).returns(nil)
+    WorldLocation.stubs(:find).with(location_slug).returns(location)
+    location
+  end
+
+  def stub_worldwide_locations(location_slugs)
+    locations = location_slugs.map do |slug|
+      stub_worldwide_location(slug)
+    end
+    WorldLocation.stubs(:all).returns(locations)
+  end
 end
 
 require 'govuk-content-schema-test-helpers/test_unit'
@@ -41,20 +57,4 @@ require 'govuk-content-schema-test-helpers/test_unit'
 GovukContentSchemaTestHelpers.configure do |config|
   config.schema_type = 'publisher_v2'
   config.project_root = Rails.root
-end
-
-def stub_worldwide_location(location_slug)
-  location = stub.quacks_like(WorldLocation.new({}))
-  location.stubs(:slug).returns(location_slug)
-  location.stubs(:name).returns(location_slug.humanize)
-  location.stubs(:fco_organisation).returns(nil)
-  WorldLocation.stubs(:find).with(location_slug).returns(location)
-  location
-end
-
-def stub_worldwide_locations(location_slugs)
-  locations = location_slugs.map do |slug|
-    stub_worldwide_location(slug)
-  end
-  WorldLocation.stubs(:all).returns(locations)
 end

--- a/test/unit/calculators/country_name_formatter_test.rb
+++ b/test/unit/calculators/country_name_formatter_test.rb
@@ -8,17 +8,17 @@ module SmartAnswer::Calculators
       end
 
       should 'return the country name prepended by "the"' do
-        stub_worldwide_location('bahamas')
+        stub_world_location('bahamas')
         assert_equal 'the Bahamas', @formatter.definitive_article('bahamas')
       end
 
       should 'return the country name prepended by "The"' do
-        stub_worldwide_location('bahamas')
+        stub_world_location('bahamas')
         assert_equal 'The Bahamas', @formatter.definitive_article('bahamas', true)
       end
 
       should 'return the country name when definite article is not required' do
-        stub_worldwide_location('argentina')
+        stub_world_location('argentina')
         assert_equal 'Argentina', @formatter.definitive_article('argentina')
       end
     end

--- a/test/unit/calculators/country_name_formatter_test.rb
+++ b/test/unit/calculators/country_name_formatter_test.rb
@@ -1,28 +1,25 @@
 require_relative '../../test_helper'
-require 'gds_api/test_helpers/worldwide'
 
 module SmartAnswer::Calculators
   class CountryNameFormatterTest < ActiveSupport::TestCase
-    include GdsApi::TestHelpers::Worldwide
-
     context '#definitive_article' do
       setup do
         @formatter = CountryNameFormatter.new
       end
 
       should 'return the country name prepended by "the"' do
-        worldwide_api_has_location('bahamas')
+        stub_worldwide_location('bahamas')
         assert_equal 'the Bahamas', @formatter.definitive_article('bahamas')
       end
 
       should 'return the country name prepended by "The"' do
-        worldwide_api_has_location('bahamas')
+        stub_worldwide_location('bahamas')
         assert_equal 'The Bahamas', @formatter.definitive_article('bahamas', true)
       end
 
       should 'return the country name when definite article is not required' do
-        worldwide_api_has_location('antigua-and-barbuda')
-        assert_equal 'Antigua And Barbuda', @formatter.definitive_article('antigua-and-barbuda')
+        stub_worldwide_location('argentina')
+        assert_equal 'Argentina', @formatter.definitive_article('argentina')
       end
     end
 

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -1,11 +1,7 @@
 
 require_relative '../test_helper'
 
-require 'gds_api/test_helpers/worldwide'
-
 class FlowTest < ActiveSupport::TestCase
-  include GdsApi::TestHelpers::Worldwide
-
   test "Can set the name" do
     s = SmartAnswer::Flow.new do
       name "sweet-or-savoury"
@@ -65,8 +61,7 @@ class FlowTest < ActiveSupport::TestCase
   end
 
   test "Can build country select question nodes" do
-    location_slugs = YAML.load(read_fixture_file("worldwide_locations.yml"))
-    worldwide_api_has_locations(location_slugs)
+    stub_worldwide_locations(%w(afghanistan))
 
     s = SmartAnswer::Flow.new do
       country_select :which_country?

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -61,7 +61,7 @@ class FlowTest < ActiveSupport::TestCase
   end
 
   test "Can build country select question nodes" do
-    stub_worldwide_locations(%w(afghanistan))
+    stub_world_locations(%w(afghanistan))
 
     s = SmartAnswer::Flow.new do
       country_select :which_country?

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -22,12 +22,12 @@ class WorldLocationTest < ActiveSupport::TestCase
       assert_equal @location_slugs, results.map(&:slug)
     end
 
-    should "filter out any results that aren't locations" do
-      @location_slugs = %w(the-shire rivendel rohan delegation-to-lorien gondor arnor mordor)
+    should "filter out any results that are not world locations e.g. delegations & missions" do
+      @location_slugs = %w(the-shire rivendel rohan delegation-to-lorien gondor arnor mission-to-mordor)
       worldwide_api_has_locations(@location_slugs)
 
       results = WorldLocation.all
-      assert_equal %w(the-shire rivendel rohan gondor arnor mordor), results.map(&:slug)
+      assert_equal %w(the-shire rivendel rohan gondor arnor), results.map(&:slug)
     end
 
     should "filter out any results that don't have a slug" do


### PR DESCRIPTION
## Description

Supersedes #2555.

Trello cards:

* https://trello.com/c/Ps4kj7ME
* https://trello.com/c/5Ruw6swd

Previously many of the tests were using methods on `GdsApi::TestHelpers::Worldwide` to stub calls to the Worldwide API. Each of these helper methods set up a bunch of `WebMock` stubs to stub at the `Net::HTTP`/`RestClient` level.

It seems simpler and clearer to stub at the `WorldLocation` level in the `smart-answers` tests and rely on the `gds-api-adapters` tests to verify that the lower level behaviour is correct.

This PR follows on from #2540 and converts most of the remaining occurrences of `GdsApi::TestHelpers::Worldwide` methods. The only places left are:

* `WorldLocationTest` - It doesn't make sense to stub `WorldLocation` in this unit test. However, I think it would make sense to stub `Services.worldwide_api` instead of using `GdsApi::TestHelpers::Worldwide` methods. I did briefly look into doing this, but it wasn't completely straightforward, so I've left it in favour of getting the other changes in this PR merged. I've created a [new Trello card][1] to capture this.

* `SmartAnswersRegressionTest` - I did [some work on this][2] but ran into problems, so I've left it in favour of getting the other changes in this PR merged. However, I have made some changes which should make this easier to do in the future.

## External changes

None. This is just an internal refactoring and no production code has changed.

[1]: https://trello.com/c/M4Y09qFy
[2]: https://github.com/alphagov/smart-answers/compare/stub-world-location-directly-in-regression-tests
