### PR TITLE
Refactor estimate-self-assessment-penalties to new-style flow

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -26,6 +26,10 @@ module SmartAnswer::Calculators
       filing_date >= start_of_next_tax_year
     end
 
+    def valid_payment_date?
+      filing_date <= payment_date
+    end
+
     def paid_on_time?
       (filing_date <= filing_deadline) && (payment_date <= payment_deadline)
     end

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -22,6 +22,10 @@ module SmartAnswer::Calculators
       end
     end
 
+    def valid_filing_date?
+      filing_date >= start_of_next_tax_year
+    end
+
     def paid_on_time?
       (filing_date <= filing_deadline) && (payment_date <= payment_deadline)
     end

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -2,6 +2,24 @@ require "ostruct"
 
 module SmartAnswer::Calculators
   class SelfAssessmentPenalties < OpenStruct
+    DEADLINES = {
+      online_filing_deadline: {
+        "2011-12": Date.new(2013, 1, 31),
+        "2012-13": Date.new(2014, 1, 31),
+        "2013-14": Date.new(2015, 1, 31),
+      },
+      offline_filing_deadline: {
+        "2011-12": Date.new(2012, 10, 31),
+        "2012-13": Date.new(2013, 10, 31),
+        "2013-14": Date.new(2014, 10, 31),
+      },
+      payment_deadline: {
+        "2011-12": Date.new(2013, 1, 31),
+        "2012-13": Date.new(2014, 1, 31),
+        "2013-14": Date.new(2015, 1, 31),
+      },
+    }
+
     def start_of_next_tax_year
       if tax_year == '2011-12'
         Date.new(2012, 4, 6)
@@ -123,11 +141,11 @@ module SmartAnswer::Calculators
     end
 
     def filing_deadline
-      submission_method == "online" ? dates[:online_filing_deadline][tax_year.to_sym] : dates[:offline_filing_deadline][tax_year.to_sym]
+      submission_method == "online" ? DEADLINES[:online_filing_deadline][tax_year.to_sym] : DEADLINES[:offline_filing_deadline][tax_year.to_sym]
     end
 
     def payment_deadline
-      dates[:payment_deadline][tax_year.to_sym]
+      DEADLINES[:payment_deadline][tax_year.to_sym]
     end
 
     #interest is 3% per annum

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -2,6 +2,16 @@ require "ostruct"
 
 module SmartAnswer::Calculators
   class SelfAssessmentPenalties < OpenStruct
+    def start_of_next_tax_year
+      if tax_year == '2011-12'
+        Date.new(2012, 4, 6)
+      elsif tax_year == '2012-13'
+        Date.new(2013, 4, 6)
+      else
+        Date.new(2014, 4, 6)
+      end
+    end
+
     def paid_on_time?
       (filing_date <= filing_deadline) && (payment_date <= payment_deadline)
     end

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -12,6 +12,16 @@ module SmartAnswer::Calculators
       end
     end
 
+    def one_year_after_start_date_for_penalties
+      if tax_year == '2011-12'
+        Date.new(2014, 2, 01)
+      elsif tax_year == '2012-13'
+        Date.new(2015, 2, 01)
+      else
+        Date.new(2016, 2, 01)
+      end
+    end
+
     def paid_on_time?
       (filing_date <= filing_deadline) && (payment_date <= payment_deadline)
     end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -6,24 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "100615"
 
-      calculator_dates = {
-        online_filing_deadline: {
-          "2011-12": Date.new(2013, 1, 31),
-          "2012-13": Date.new(2014, 1, 31),
-          "2013-14": Date.new(2015, 1, 31),
-        },
-        offline_filing_deadline: {
-          "2011-12": Date.new(2012, 10, 31),
-          "2012-13": Date.new(2013, 10, 31),
-          "2013-14": Date.new(2014, 10, 31),
-        },
-        payment_deadline: {
-          "2011-12": Date.new(2013, 1, 31),
-          "2012-13": Date.new(2014, 1, 31),
-          "2013-14": Date.new(2015, 1, 31),
-        },
-      }
-
       multiple_choice :which_year? do
         option :"2011-12"
         option :"2012-13"
@@ -78,8 +60,6 @@ module SmartAnswer
         validate { calculator.valid_payment_date? }
 
         next_node do
-          calculator.dates = calculator_dates
-
           if calculator.paid_on_time?
             outcome :filed_and_paid_on_time
           else
@@ -99,7 +79,6 @@ module SmartAnswer
       outcome :late do
         precalculate :calculator do
           calculator.estimated_bill = estimated_bill
-          calculator.dates = calculator_dates
           calculator
         end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -29,16 +29,15 @@ module SmartAnswer
         option :"2012-13"
         option :"2013-14"
 
-        on_response do
+        on_response do |response|
           self.calculator = Calculators::SelfAssessmentPenalties.new
+          calculator.tax_year = response
         end
 
-        save_input_as :tax_year
-
-        calculate :start_of_next_tax_year do |response|
-          if response == '2011-12'
+        calculate :start_of_next_tax_year do
+          if calculator.tax_year == '2011-12'
             Date.new(2012, 4, 6)
-          elsif response == '2012-13'
+          elsif calculator.tax_year == '2012-13'
             Date.new(2013, 4, 6)
           else
             Date.new(2014, 4, 6)
@@ -48,10 +47,10 @@ module SmartAnswer
           start_of_next_tax_year.strftime("%e %B %Y")
         end
 
-        calculate :one_year_after_start_date_for_penalties do |response|
-          if response == '2011-12'
+        calculate :one_year_after_start_date_for_penalties do
+          if calculator.tax_year == '2011-12'
             Date.new(2014, 2, 01)
-          elsif response == '2012-13'
+          elsif calculator.tax_year == '2012-13'
             Date.new(2015, 2, 01)
           else
             Date.new(2016, 2, 01)
@@ -106,7 +105,6 @@ module SmartAnswer
             calculator.filing_date = filing_date
             calculator.payment_date = response
             calculator.dates = calculator_dates
-            calculator.tax_year = tax_year
 
             if calculator.paid_on_time?
               outcome :filed_and_paid_on_time
@@ -132,7 +130,6 @@ module SmartAnswer
           calculator.payment_date = payment_date
           calculator.estimated_bill = estimated_bill
           calculator.dates = calculator_dates
-          calculator.tax_year = tax_year
           calculator
         end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -79,10 +79,6 @@ module SmartAnswer
       end
 
       outcome :late do
-        precalculate :late_filing_penalty do
-          calculator.late_filing_penalty
-        end
-
         precalculate :total_owed do
           calculator.total_owed_plus_filing_penalty
         end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -34,17 +34,8 @@ module SmartAnswer
           calculator.tax_year = response
         end
 
-        calculate :start_of_next_tax_year do
-          if calculator.tax_year == '2011-12'
-            Date.new(2012, 4, 6)
-          elsif calculator.tax_year == '2012-13'
-            Date.new(2013, 4, 6)
-          else
-            Date.new(2014, 4, 6)
-          end
-        end
         calculate :start_of_next_tax_year_formatted do
-          start_of_next_tax_year.strftime("%e %B %Y")
+          calculator.start_of_next_tax_year.strftime("%e %B %Y")
         end
 
         calculate :one_year_after_start_date_for_penalties do
@@ -83,7 +74,7 @@ module SmartAnswer
         end
 
         next_node do |response|
-          if response < start_of_next_tax_year
+          if response < calculator.start_of_next_tax_year
             raise SmartAnswer::InvalidResponse
           else
             question :when_paid?

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -69,7 +69,9 @@ module SmartAnswer
       end
 
       money_question :how_much_tax? do
-        save_input_as :estimated_bill
+        on_response do |response|
+          calculator.estimated_bill = response
+        end
 
         next_node do
           outcome :late
@@ -78,7 +80,6 @@ module SmartAnswer
 
       outcome :late do
         precalculate :calculator do
-          calculator.estimated_bill = estimated_bill
           calculator
         end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -75,7 +75,7 @@ module SmartAnswer
           calculator.payment_date = response
         end
 
-        validate { calculator.filing_date <= calculator.payment_date }
+        validate { calculator.valid_payment_date? }
 
         next_node do
           calculator.dates = calculator_dates

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -71,13 +71,14 @@ module SmartAnswer
         from { 3.year.ago(Date.today) }
         to { 2.years.since(Date.today) }
 
-        save_input_as :payment_date
+        on_response do |response|
+          calculator.payment_date = response
+        end
 
-        next_node do |response|
-          if calculator.filing_date > response
+        next_node do
+          if calculator.filing_date > calculator.payment_date
             raise SmartAnswer::InvalidResponse
           else
-            calculator.payment_date = response
             calculator.dates = calculator_dates
 
             if calculator.paid_on_time?
@@ -99,7 +100,6 @@ module SmartAnswer
 
       outcome :late do
         precalculate :calculator do
-          calculator.payment_date = payment_date
           calculator.estimated_bill = estimated_bill
           calculator.dates = calculator_dates
           calculator

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -34,10 +34,6 @@ module SmartAnswer
           calculator.tax_year = response
         end
 
-        calculate :start_of_next_tax_year_formatted do
-          calculator.start_of_next_tax_year.strftime("%e %B %Y")
-        end
-
         calculate :one_year_after_start_date_for_penalties do
           if calculator.tax_year == '2011-12'
             Date.new(2014, 2, 01)

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -79,10 +79,6 @@ module SmartAnswer
       end
 
       outcome :late do
-        precalculate :interest do
-          calculator.interest
-        end
-
         precalculate :late_payment_penalty do
           calculator.late_payment_penalty
         end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -34,15 +34,6 @@ module SmartAnswer
           calculator.tax_year = response
         end
 
-        calculate :one_year_after_start_date_for_penalties do
-          if calculator.tax_year == '2011-12'
-            Date.new(2014, 2, 01)
-          elsif calculator.tax_year == '2012-13'
-            Date.new(2015, 2, 01)
-          else
-            Date.new(2016, 2, 01)
-          end
-        end
         next_node do
           question :how_submitted?
         end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -79,10 +79,6 @@ module SmartAnswer
       end
 
       outcome :late do
-        precalculate :calculator do
-          calculator
-        end
-
         precalculate :late_filing_penalty do
           calculator.late_filing_penalty
         end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -79,10 +79,6 @@ module SmartAnswer
       end
 
       outcome :late do
-        precalculate :total_owed do
-          calculator.total_owed_plus_filing_penalty
-        end
-
         precalculate :interest do
           calculator.interest
         end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -60,12 +60,10 @@ module SmartAnswer
           calculator.filing_date = response
         end
 
+        validate { calculator.filing_date >= calculator.start_of_next_tax_year }
+
         next_node do
-          if calculator.filing_date < calculator.start_of_next_tax_year
-            raise SmartAnswer::InvalidResponse
-          else
-            question :when_paid?
-          end
+          question :when_paid?
         end
       end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -29,6 +29,10 @@ module SmartAnswer
         option :"2012-13"
         option :"2013-14"
 
+        on_response do
+          self.calculator = Calculators::SelfAssessmentPenalties.new
+        end
+
         save_input_as :tax_year
 
         calculate :start_of_next_tax_year do |response|
@@ -98,13 +102,12 @@ module SmartAnswer
           if filing_date > response
             raise SmartAnswer::InvalidResponse
           else
-            calculator = Calculators::SelfAssessmentPenalties.new(
-              submission_method: submission_method,
-              filing_date: filing_date,
-              payment_date: response,
-              dates: calculator_dates,
-              tax_year: tax_year
-            )
+            calculator.submission_method = submission_method
+            calculator.filing_date = filing_date
+            calculator.payment_date = response
+            calculator.dates = calculator_dates
+            calculator.tax_year = tax_year
+
             if calculator.paid_on_time?
               outcome :filed_and_paid_on_time
             else
@@ -124,14 +127,13 @@ module SmartAnswer
 
       outcome :late do
         precalculate :calculator do
-          Calculators::SelfAssessmentPenalties.new(
-            submission_method: submission_method,
-            filing_date: filing_date,
-            payment_date: payment_date,
-            estimated_bill: estimated_bill,
-            dates: calculator_dates,
-            tax_year: tax_year
-          )
+          calculator.submission_method = submission_method
+          calculator.filing_date = filing_date
+          calculator.payment_date = payment_date
+          calculator.estimated_bill = estimated_bill
+          calculator.dates = calculator_dates
+          calculator.tax_year = tax_year
+          calculator
         end
 
         precalculate :late_filing_penalty do

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -78,11 +78,7 @@ module SmartAnswer
         end
       end
 
-      outcome :late do
-        precalculate :late_payment_penalty do
-          calculator.late_payment_penalty
-        end
-      end
+      outcome :late
 
       outcome :filed_and_paid_on_time
     end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -60,10 +60,6 @@ module SmartAnswer
           calculator.filing_date = response
         end
 
-        calculate :filing_date_formatted do
-          calculator.filing_date.strftime("%e %B %Y")
-        end
-
         next_node do
           if calculator.filing_date < calculator.start_of_next_tax_year
             raise SmartAnswer::InvalidResponse

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -43,7 +43,9 @@ module SmartAnswer
         option :online
         option :paper
 
-        save_input_as :submission_method
+        on_response do |response|
+          calculator.submission_method = response
+        end
 
         next_node do
           question :when_submitted?
@@ -79,7 +81,6 @@ module SmartAnswer
           if filing_date > response
             raise SmartAnswer::InvalidResponse
           else
-            calculator.submission_method = submission_method
             calculator.filing_date = filing_date
             calculator.payment_date = response
             calculator.dates = calculator_dates
@@ -103,7 +104,6 @@ module SmartAnswer
 
       outcome :late do
         precalculate :calculator do
-          calculator.submission_method = submission_method
           calculator.filing_date = filing_date
           calculator.payment_date = payment_date
           calculator.estimated_bill = estimated_bill

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -75,17 +75,15 @@ module SmartAnswer
           calculator.payment_date = response
         end
 
-        next_node do
-          if calculator.filing_date > calculator.payment_date
-            raise SmartAnswer::InvalidResponse
-          else
-            calculator.dates = calculator_dates
+        validate { calculator.filing_date <= calculator.payment_date }
 
-            if calculator.paid_on_time?
-              outcome :filed_and_paid_on_time
-            else
-              question :how_much_tax?
-            end
+        next_node do
+          calculator.dates = calculator_dates
+
+          if calculator.paid_on_time?
+            outcome :filed_and_paid_on_time
+          else
+            question :how_much_tax?
           end
         end
       end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -60,7 +60,7 @@ module SmartAnswer
           calculator.filing_date = response
         end
 
-        validate { calculator.filing_date >= calculator.start_of_next_tax_year }
+        validate { calculator.valid_filing_date? }
 
         next_node do
           question :when_paid?

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
@@ -18,7 +18,7 @@
     | Estimate of the total you owe | <%= format_money(total_owed) %> |
   <% end %>
 
-  <% if payment_date >= calculator.one_year_after_start_date_for_penalties %>
+  <% if calculator.payment_date >= calculator.one_year_after_start_date_for_penalties %>
     Your penalty can be up to 100% of your tax bill if you deliberately don’t pay it.
   <% end %>
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
@@ -7,12 +7,12 @@
   |-----------|--------------|
   | Your penalty for sending the return late | <%= late_filing_penalty == 0 ? 'none' : format_money(late_filing_penalty) %> |
   <% if calculator.late_payment_penalty == 0 %>
-    | What you said your tax bill was | <%= format_money(estimated_bill) %> |
+    | What you said your tax bill was | <%= format_money(calculator.estimated_bill) %> |
     | Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |
     | Penalty for paying your bill late | none |
     | Estimate of the total you owe | <%= format_money(total_owed) %> |
   <% else %>
-    | What you said your tax bill was | <%= format_money(estimated_bill) %> |
+    | What you said your tax bill was | <%= format_money(calculator.estimated_bill) %> |
     | Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |
     | Penalty for paying your bill late | <%= format_money(late_payment_penalty) %> |
     | Estimate of the total you owe | <%= format_money(total_owed) %> |

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
@@ -5,7 +5,7 @@
 <% content_for :body do %>
   | Key facts | Your results |
   |-----------|--------------|
-  | Your penalty for sending the return late | <%= late_filing_penalty == 0 ? 'none' : format_money(late_filing_penalty) %> |
+  | Your penalty for sending the return late | <%= calculator.late_filing_penalty == 0 ? 'none' : format_money(calculator.late_filing_penalty) %> |
   <% if calculator.late_payment_penalty == 0 %>
     | What you said your tax bill was | <%= format_money(calculator.estimated_bill) %> |
     | Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
@@ -8,12 +8,12 @@
   | Your penalty for sending the return late | <%= calculator.late_filing_penalty == 0 ? 'none' : format_money(calculator.late_filing_penalty) %> |
   <% if calculator.late_payment_penalty == 0 %>
     | What you said your tax bill was | <%= format_money(calculator.estimated_bill) %> |
-    | Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |
+    | Interest added for paying your bill late | <%= calculator.interest == 0 ? 0 : format_money(calculator.interest) %> |
     | Penalty for paying your bill late | none |
     | Estimate of the total you owe | <%= format_money(calculator.total_owed_plus_filing_penalty) %> |
   <% else %>
     | What you said your tax bill was | <%= format_money(calculator.estimated_bill) %> |
-    | Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |
+    | Interest added for paying your bill late | <%= calculator.interest == 0 ? 0 : format_money(calculator.interest) %> |
     | Penalty for paying your bill late | <%= format_money(late_payment_penalty) %> |
     | Estimate of the total you owe | <%= format_money(calculator.total_owed_plus_filing_penalty) %> |
   <% end %>

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
@@ -14,7 +14,7 @@
   <% else %>
     | What you said your tax bill was | <%= format_money(calculator.estimated_bill) %> |
     | Interest added for paying your bill late | <%= calculator.interest == 0 ? 0 : format_money(calculator.interest) %> |
-    | Penalty for paying your bill late | <%= format_money(late_payment_penalty) %> |
+    | Penalty for paying your bill late | <%= format_money(calculator.late_payment_penalty) %> |
     | Estimate of the total you owe | <%= format_money(calculator.total_owed_plus_filing_penalty) %> |
   <% end %>
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
@@ -10,12 +10,12 @@
     | What you said your tax bill was | <%= format_money(calculator.estimated_bill) %> |
     | Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |
     | Penalty for paying your bill late | none |
-    | Estimate of the total you owe | <%= format_money(total_owed) %> |
+    | Estimate of the total you owe | <%= format_money(calculator.total_owed_plus_filing_penalty) %> |
   <% else %>
     | What you said your tax bill was | <%= format_money(calculator.estimated_bill) %> |
     | Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |
     | Penalty for paying your bill late | <%= format_money(late_payment_penalty) %> |
-    | Estimate of the total you owe | <%= format_money(total_owed) %> |
+    | Estimate of the total you owe | <%= format_money(calculator.total_owed_plus_filing_penalty) %> |
   <% end %>
 
   <% if calculator.payment_date >= calculator.one_year_after_start_date_for_penalties %>

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb
@@ -18,7 +18,7 @@
     | Estimate of the total you owe | <%= format_money(total_owed) %> |
   <% end %>
 
-  <% if payment_date >= one_year_after_start_date_for_penalties %>
+  <% if payment_date >= calculator.one_year_after_start_date_for_penalties %>
     Your penalty can be up to 100% of your tax bill if you deliberately don’t pay it.
   <% end %>
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% content_for :error_message do %>
-  Please enter a date on or after <%= filing_date_formatted %>
+  Please enter a date on or after <%= format_date(calculator.filing_date) %>
 <% end %>

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% content_for :error_message do %>
-  Please enter a date on or after <%= start_of_next_tax_year_formatted %>
+  Please enter a date on or after <%= format_date(calculator.start_of_next_tax_year) %>
 <% end %>

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -1,13 +1,13 @@
 ---
-lib/smart_answer_flows/estimate-self-assessment-penalties.rb: 687dd3dacb2cb08fad2f6fb0db3cd50f
+lib/smart_answer_flows/estimate-self-assessment-penalties.rb: a1fcc633178b7be88bf9f06df8cc9754
 test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 186d93854ea5dc9321408e14dcc8d61f
 test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 4da19a0a153e226139199a1b393de4e9
 lib/smart_answer_flows/estimate-self-assessment-penalties/estimate_self_assessment_penalties.govspeak.erb: d35eaf0334a9e871fa14294682fb7322
 lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/filed_and_paid_on_time.govspeak.erb: c7c2b164d05b3f757bc9ee9439aa560a
-lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb: 8d41e6cf1ef1df7446cf655ef69f5321
+lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb: b88d8257149cb0af87681e03493ace43
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_much_tax.govspeak.erb: 03ab00ce650ed9912c038268c15adf4e
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_submitted.govspeak.erb: c3fffa8a0386144630fae76250114191
-lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb: 85df11ceb680641a5609a8f1293aadb3
-lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb: a8b6dd429dd5e35db172200fe9940657
+lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb: fd629bd5e95648f5a22246a423cfd026
+lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb: 590022eac4fbf8db1976da66d777f776
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: f935ce15559590ca785df0c6730b764e
-lib/smart_answer/calculators/self_assessment_penalties.rb: ac08616aec7a29e0756808968a5b26df
+lib/smart_answer/calculators/self_assessment_penalties.rb: 0ba888c7ff57f01c996f3ce2e60eeaf1

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -101,7 +101,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
               assert_current_node :late
               assert_equal 0, current_state.calculator.late_filing_penalty
               assert_equal 0, current_state.calculator.total_owed_plus_filing_penalty
-              assert_state_variable :interest, 0
+              assert_equal 0, current_state.calculator.interest
               assert_state_variable :late_payment_penalty, 0
             end
           end
@@ -195,7 +195,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       should "show results" do
         assert_equal 1500, current_state.calculator.late_filing_penalty
         assert_equal 10000, current_state.calculator.estimated_bill
-        assert_state_variable :interest, 148.77
+        assert_equal 148.77, current_state.calculator.interest
         assert_state_variable :late_payment_penalty, 1000
         assert_equal 12648, current_state.calculator.total_owed_plus_filing_penalty
       end
@@ -224,7 +224,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       should "show results" do
         assert_equal 2000, current_state.calculator.late_filing_penalty
         assert_equal 10000, current_state.calculator.estimated_bill
-        assert_state_variable :interest, 300
+        assert_equal 300, current_state.calculator.interest
         assert_state_variable :late_payment_penalty, 1500
         assert_equal 13800, current_state.calculator.total_owed_plus_filing_penalty
       end

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -99,7 +99,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
             end
             should "show results" do
               assert_current_node :late
-              assert_state_variable :late_filing_penalty, 0
+              assert_equal 0, current_state.calculator.late_filing_penalty
               assert_state_variable :total_owed, 0
               assert_state_variable :interest, 0
               assert_state_variable :late_payment_penalty, 0
@@ -141,7 +141,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_state_variable :late_filing_penalty, 100
+        assert_equal 100, current_state.calculator.late_filing_penalty
         assert_state_variable :total_owed, 100
       end
     end
@@ -154,7 +154,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_state_variable :late_filing_penalty, 110
+        assert_equal 110, current_state.calculator.late_filing_penalty
         assert_state_variable :total_owed, 110
       end
     end
@@ -167,7 +167,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_state_variable :late_filing_penalty, 1000
+        assert_equal 1000, current_state.calculator.late_filing_penalty
         assert_state_variable :total_owed, 1000
       end
     end
@@ -180,7 +180,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_state_variable :late_filing_penalty, 1300
+        assert_equal 1300, current_state.calculator.late_filing_penalty
         assert_state_variable :total_owed, 1300
       end
     end
@@ -193,7 +193,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "10000.00"
       end
       should "show results" do
-        assert_state_variable :late_filing_penalty, 1500
+        assert_equal 1500, current_state.calculator.late_filing_penalty
         assert_equal 10000, current_state.calculator.estimated_bill
         assert_state_variable :interest, 148.77
         assert_state_variable :late_payment_penalty, 1000
@@ -209,7 +209,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_state_variable :late_filing_penalty, 1600
+        assert_equal 1600, current_state.calculator.late_filing_penalty
         assert_state_variable :total_owed, 1600
       end
     end
@@ -222,7 +222,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "10000.00"
       end
       should "show results" do
-        assert_state_variable :late_filing_penalty, 2000
+        assert_equal 2000, current_state.calculator.late_filing_penalty
         assert_equal 10000, current_state.calculator.estimated_bill
         assert_state_variable :interest, 300
         assert_state_variable :late_payment_penalty, 1500

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -100,7 +100,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
             should "show results" do
               assert_current_node :late
               assert_equal 0, current_state.calculator.late_filing_penalty
-              assert_state_variable :total_owed, 0
+              assert_equal 0, current_state.calculator.total_owed_plus_filing_penalty
               assert_state_variable :interest, 0
               assert_state_variable :late_payment_penalty, 0
             end
@@ -142,7 +142,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       end
       should "show results" do
         assert_equal 100, current_state.calculator.late_filing_penalty
-        assert_state_variable :total_owed, 100
+        assert_equal 100, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
     #band 2
@@ -155,7 +155,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       end
       should "show results" do
         assert_equal 110, current_state.calculator.late_filing_penalty
-        assert_state_variable :total_owed, 110
+        assert_equal 110, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
     # #band 2
@@ -168,7 +168,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       end
       should "show results" do
         assert_equal 1000, current_state.calculator.late_filing_penalty
-        assert_state_variable :total_owed, 1000
+        assert_equal 1000, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
     # #band 3 case 1
@@ -181,7 +181,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       end
       should "show results" do
         assert_equal 1300, current_state.calculator.late_filing_penalty
-        assert_state_variable :total_owed, 1300
+        assert_equal 1300, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
     # #band 3 case 2
@@ -197,7 +197,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         assert_equal 10000, current_state.calculator.estimated_bill
         assert_state_variable :interest, 148.77
         assert_state_variable :late_payment_penalty, 1000
-        assert_state_variable :total_owed, 12648
+        assert_equal 12648, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
     # #band 4 case 1
@@ -210,7 +210,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       end
       should "show results" do
         assert_equal 1600, current_state.calculator.late_filing_penalty
-        assert_state_variable :total_owed, 1600
+        assert_equal 1600, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
     # #band 4 case 2
@@ -226,7 +226,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         assert_equal 10000, current_state.calculator.estimated_bill
         assert_state_variable :interest, 300
         assert_state_variable :late_payment_penalty, 1500
-        assert_state_variable :total_owed, 13800
+        assert_equal 13800, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
   end

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -194,7 +194,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       end
       should "show results" do
         assert_state_variable :late_filing_penalty, 1500
-        assert_state_variable :estimated_bill, 10000
+        assert_equal 10000, current_state.calculator.estimated_bill
         assert_state_variable :interest, 148.77
         assert_state_variable :late_payment_penalty, 1000
         assert_state_variable :total_owed, 12648
@@ -223,7 +223,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       end
       should "show results" do
         assert_state_variable :late_filing_penalty, 2000
-        assert_state_variable :estimated_bill, 10000
+        assert_equal 10000, current_state.calculator.estimated_bill
         assert_state_variable :interest, 300
         assert_state_variable :late_payment_penalty, 1500
         assert_state_variable :total_owed, 13800

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -102,7 +102,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
               assert_equal 0, current_state.calculator.late_filing_penalty
               assert_equal 0, current_state.calculator.total_owed_plus_filing_penalty
               assert_equal 0, current_state.calculator.interest
-              assert_state_variable :late_payment_penalty, 0
+              assert_equal 0, current_state.calculator.late_payment_penalty
             end
           end
         end #end testing paid late but less than 3 months after
@@ -196,7 +196,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         assert_equal 1500, current_state.calculator.late_filing_penalty
         assert_equal 10000, current_state.calculator.estimated_bill
         assert_equal 148.77, current_state.calculator.interest
-        assert_state_variable :late_payment_penalty, 1000
+        assert_equal 1000, current_state.calculator.late_payment_penalty
         assert_equal 12648, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
@@ -225,7 +225,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         assert_equal 2000, current_state.calculator.late_filing_penalty
         assert_equal 10000, current_state.calculator.estimated_bill
         assert_equal 300, current_state.calculator.interest
-        assert_state_variable :late_payment_penalty, 1500
+        assert_equal 1500, current_state.calculator.late_payment_penalty
         assert_equal 13800, current_state.calculator.total_owed_plus_filing_penalty
       end
     end

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -41,6 +41,18 @@ module SmartAnswer::Calculators
       end
     end
 
+    context "valid_payment_date?" do
+      should "be valid if payment date is on or after filing date" do
+        @calculator.payment_date = @calculator.filing_date
+        assert @calculator.valid_payment_date?
+      end
+
+      should "be invalid if filing date is before filing date" do
+        @calculator.payment_date = @calculator.filing_date - 1
+        refute @calculator.valid_payment_date?
+      end
+    end
+
     context "online submission" do
       context "filed and paid on time" do
         setup do

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -29,6 +29,18 @@ module SmartAnswer::Calculators
       )
     end
 
+    context "valid_filing_date?" do
+      should "be valid if filing date is on or after start of next tax year" do
+        @calculator.filing_date = @calculator.start_of_next_tax_year
+        assert @calculator.valid_filing_date?
+      end
+
+      should "be invalid if filing date is before start of next tax year" do
+        @calculator.filing_date = @calculator.start_of_next_tax_year - 1
+        refute @calculator.valid_filing_date?
+      end
+    end
+
     context "online submission" do
       context "filed and paid on time" do
         setup do

--- a/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
+++ b/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
@@ -43,5 +43,38 @@ module SmartAnswer
         end
       end
     end
+
+    context 'when answering when_paid? question' do
+      setup do
+        @calculator.stubs(:paid_on_time?).returns(true)
+        @calculator.stubs(:valid_payment_date?).returns(true)
+        setup_states_for_question(:when_paid?,
+          responding_with: '2017-05-01',
+          initial_state: { calculator: @calculator })
+      end
+
+      should 'store parsed response on calculator as payment_date' do
+        assert_equal Date.parse('2017-05-01'), @calculator.payment_date
+      end
+
+      should 'go to filed_and_paid_on_time outcome' do
+        assert_equal :filed_and_paid_on_time, @new_state.current_node
+        assert_node_exists :filed_and_paid_on_time
+      end
+
+      context 'responding with an invalid response' do
+        setup do
+          @calculator.stubs(:valid_payment_date?).returns(false)
+        end
+
+        should 'raise an exception' do
+          assert_raise(SmartAnswer::InvalidResponse) do
+            setup_states_for_question(:when_paid?,
+              responding_with: '2017-05-01',
+              initial_state: { calculator: @calculator })
+          end
+        end
+      end
+    end
   end
 end

--- a/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
+++ b/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
@@ -1,0 +1,47 @@
+require_relative '../../test_helper'
+require_relative 'flow_unit_test_helper'
+
+require 'smart_answer_flows/estimate-self-assessment-penalties'
+
+module SmartAnswer
+  class EstimateSelfAssessmentPenaltiesFlowTest < ActiveSupport::TestCase
+    include FlowUnitTestHelper
+
+    setup do
+      @calculator = Calculators::SelfAssessmentPenalties.new
+      @flow = EstimateSelfAssessmentPenaltiesFlow.build
+    end
+
+    context 'when answering when_submitted? question' do
+      setup do
+        @calculator.stubs(:valid_filing_date?).returns(true)
+        setup_states_for_question(:when_submitted?,
+          responding_with: '2017-05-01',
+          initial_state: { calculator: @calculator })
+      end
+
+      should 'store parsed response on calculator as filing_date' do
+        assert_equal Date.parse('2017-05-01'), @calculator.filing_date
+      end
+
+      should 'go to when_paid? question' do
+        assert_equal :when_paid?, @new_state.current_node
+        assert_node_exists :when_paid?
+      end
+
+      context 'responding with an invalid response' do
+        setup do
+          @calculator.stubs(:valid_filing_date?).returns(false)
+        end
+
+        should 'raise an exception' do
+          assert_raise(SmartAnswer::InvalidResponse) do
+            setup_states_for_question(:when_submitted?,
+              responding_with: '2017-05-01',
+              initial_state: { calculator: @calculator })
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Similar to #2561, this moves the flow towards the style described in the [refactoring documentation][1]. I've concentrated on moving logic out of the flow and into the calculator and presentational concerns into the templates. The idea is to change all the flows to use this approach so we can significantly simplify the DSL.

I haven't really done any significant work on the calculator itself e.g. extracting domain concepts. I added a comment to [this Trello card][2] to say that this flow has some logic where it would make sense to use the `TaxYear` class. The money formatting logic in the templates could probably also be considerably simplified, but this wasn't possible without affecting the regression test artefacts, so I've left that for now. Also I haven't made any significant changes to the tests - we'll still need to move them towards the [new-style approach][3] at some point.

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md
[2]: https://trello.com/c/pNH4EBs0
[3]: https://github.com/alphagov/smart-answers/blob/master/doc/new-style-testing.md
