### PR TITLE
Add an option for the 2014-2015 tax year to estimate self assessment penalties

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -7,16 +7,19 @@ module SmartAnswer::Calculators
         "2011-12": Date.new(2013, 1, 31),
         "2012-13": Date.new(2014, 1, 31),
         "2013-14": Date.new(2015, 1, 31),
+        "2014-15": Date.new(2016, 1, 31),
       },
       offline_filing_deadline: {
         "2011-12": Date.new(2012, 10, 31),
         "2012-13": Date.new(2013, 10, 31),
         "2013-14": Date.new(2014, 10, 31),
+        "2014-15": Date.new(2015, 10, 31),
       },
       payment_deadline: {
         "2011-12": Date.new(2013, 1, 31),
         "2012-13": Date.new(2014, 1, 31),
         "2013-14": Date.new(2015, 1, 31),
+        "2014-15": Date.new(2016, 1, 31),
       },
     }
 
@@ -25,8 +28,10 @@ module SmartAnswer::Calculators
         Date.new(2012, 4, 6)
       elsif tax_year == '2012-13'
         Date.new(2013, 4, 6)
-      else
+      elsif tax_year == '2013-14'
         Date.new(2014, 4, 6)
+      else
+        Date.new(2015, 4, 6)
       end
     end
 
@@ -35,8 +40,10 @@ module SmartAnswer::Calculators
         Date.new(2014, 2, 01)
       elsif tax_year == '2012-13'
         Date.new(2015, 2, 01)
-      else
+      elsif tax_year == '2013-14'
         Date.new(2016, 2, 01)
+      else
+        Date.new(2017, 2, 01)
       end
     end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -10,6 +10,7 @@ module SmartAnswer
         option :"2011-12"
         option :"2012-13"
         option :"2013-14"
+        option :"2014-15"
 
         on_response do |response|
           self.calculator = Calculators::SelfAssessmentPenalties.new

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
@@ -5,5 +5,6 @@
 <% options(
   "2011-12": "6 April 2011 to 5 April 2012",
   "2012-13": "6 April 2012 to 5 April 2013",
-  "2013-14": "6 April 2013 to 5 April 2014"
+  "2013-14": "6 April 2013 to 5 April 2014",
+  "2014-15": "6 April 2014 to 5 April 2015"
 ) %>

--- a/test/artefacts/estimate-self-assessment-penalties/2014-15/online/2015-04-07/2015-04-08.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/2014-15/online/2015-04-07/2015-04-08.txt
@@ -1,0 +1,8 @@
+You don't have to pay a penalty
+
+You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
+
+You paid your bill on time, so there is no interest or penalty for late payment.
+
+
+

--- a/test/artefacts/estimate-self-assessment-penalties/2014-15/paper/2015-04-07/2015-04-08.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/2014-15/paper/2015-04-07/2015-04-08.txt
@@ -1,0 +1,8 @@
+You don't have to pay a penalty
+
+You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
+
+You paid your bill on time, so there is no interest or penalty for late payment.
+
+
+

--- a/test/artefacts/estimate-self-assessment-penalties/y.html
+++ b/test/artefacts/estimate-self-assessment-penalties/y.html
@@ -58,6 +58,12 @@
         6 April 2013 to 5 April 2014
       </label>
     </li>
+    <li>
+      <label for="response_3" class="selectable">
+        <input type="radio" name="response" id="response_3" value="2014-15" />
+        6 April 2014 to 5 April 2015
+      </label>
+    </li>
 </ul>
 
 

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -1,7 +1,7 @@
 ---
-lib/smart_answer_flows/estimate-self-assessment-penalties.rb: a1fcc633178b7be88bf9f06df8cc9754
-test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 186d93854ea5dc9321408e14dcc8d61f
-test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 4da19a0a153e226139199a1b393de4e9
+lib/smart_answer_flows/estimate-self-assessment-penalties.rb: c11afabc77193e30122b41441cb1ff14
+test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 22157fec1db01301777ab651a8e6fe16
+test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 7cd14ec238d300bd2885dfef64f06440
 lib/smart_answer_flows/estimate-self-assessment-penalties/estimate_self_assessment_penalties.govspeak.erb: d35eaf0334a9e871fa14294682fb7322
 lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/filed_and_paid_on_time.govspeak.erb: c7c2b164d05b3f757bc9ee9439aa560a
 lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb: b88d8257149cb0af87681e03493ace43
@@ -9,5 +9,5 @@ lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_much_tax
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_submitted.govspeak.erb: c3fffa8a0386144630fae76250114191
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb: fd629bd5e95648f5a22246a423cfd026
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb: 590022eac4fbf8db1976da66d777f776
-lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: f935ce15559590ca785df0c6730b764e
-lib/smart_answer/calculators/self_assessment_penalties.rb: 0ba888c7ff57f01c996f3ce2e60eeaf1
+lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: a77dd8bf04e80f877c22f246d787fed1
+lib/smart_answer/calculators/self_assessment_penalties.rb: bd90e1d33ee15ce63141fa9a266dc5a6

--- a/test/data/estimate-self-assessment-penalties-questions-and-responses.yml
+++ b/test/data/estimate-self-assessment-penalties-questions-and-responses.yml
@@ -3,6 +3,7 @@
 - 2011-12
 - 2012-13
 - 2013-14
+- 2014-15
 :how_submitted?:
 - online
 - paper
@@ -14,6 +15,7 @@
 - 2013-07-31 # 2011-12 - 181 days after online filing deadline (2013-01-31)
 - 2013-04-07 # 2012-13 - After start of next tax year (2013-04-06)
 - 2014-04-07 # 2013-14 - After start of next tax year (2014-04-06)
+- 2015-04-07 # 2014-15 - After start of next tax year (2015-04-06)
 :when_paid?:
 - 2012-04-06 # 2011-12 - Paid before submitted (2012-04-07)
 - 2012-04-08 # 2011-12 - Paid after submitted (2012-04-07)
@@ -22,6 +24,7 @@
 - 2014-01-31 # 2011-12 - 365 days after payment deadline (2013-01-31)
 - 2013-04-08 # 2012-13 - Paid after submitted
 - 2014-04-08 # 2013-14 - Paid after submitted
+- 2015-04-08 # 2014-15 - Paid after submitted
 :how_much_tax?:
 - 500
 - 6003 # Estimated bill value greater than £6002

--- a/test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml
+++ b/test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml
@@ -2314,3 +2314,50 @@
   - '2014-04-08'
   :next_node: :filed_and_paid_on_time
   :outcome_node: true
+- :current_node: :which_year?
+  :responses:
+  - 2014-15
+  :next_node: :how_submitted?
+  :outcome_node: false
+- :current_node: :how_submitted?
+  :responses:
+  - 2014-15
+  - online
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2014-15
+  - online
+  - '2015-04-07'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2014-15
+  - online
+  - '2015-04-07'
+  - '2015-04-08'
+  :next_node: :filed_and_paid_on_time
+  :outcome_node: true
+- :current_node: :how_submitted?
+  :responses:
+  - 2014-15
+  - paper
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2014-15
+  - paper
+  - '2015-04-07'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2014-15
+  - paper
+  - '2015-04-07'
+  - '2015-04-08'
+  :next_node: :filed_and_paid_on_time
+  :outcome_node: true

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -8,16 +8,19 @@ TEST_CALCULATOR_DATES = {
     "2011-12": Date.new(2013, 1, 31),
     "2012-13": Date.new(2014, 1, 31),
     "2013-14": Date.new(2015, 1, 31),
+    "2014-15": Date.new(2016, 1, 31),
   },
   offline_filing_deadline: {
     "2011-12": Date.new(2012, 10, 31),
     "2012-13": Date.new(2013, 10, 31),
     "2013-14": Date.new(2014, 10, 31),
+    "2014-15": Date.new(2015, 10, 31),
   },
   payment_deadline: {
     "2011-12": Date.new(2013, 1, 31),
     "2012-13": Date.new(2014, 1, 31),
     "2013-14": Date.new(2015, 1, 31),
+    "2014-15": Date.new(2016, 1, 31),
   },
 }
 class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase


### PR DESCRIPTION
Trello card: https://trello.com/c/kPcIQYAL/191-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments-content-change-request

## Factcheck
[Estimate self assessment penalties](https://smart-answers-pr-2590.herokuapp.com/estimate-self-assessment-penalties/y)

## Expected changes
[URL on GOV.UK](https://www.gov.uk/estimate-self-assessment-penalties/y)
* Add an option for the 2014-2015 tax year

### Before

![screen shot 2016-06-16 at 17 27 12](https://cloud.githubusercontent.com/assets/5793815/16124620/97286c26-33e7-11e6-9ee7-7abd0109f632.png)

### After

![screen shot 2016-06-16 at 17 28 29](https://cloud.githubusercontent.com/assets/5793815/16124666/c54902d2-33e7-11e6-8617-bd311f56a79b.png)
