### PR TITLE
Update regression tests first for marriage-abroad Denmark change

### DIFF
--- a/lib/data/marriage_abroad_services.yml
+++ b/lib/data/marriage_abroad_services.yml
@@ -364,7 +364,11 @@ denmark:
       - :receiving_notice_of_marriage
       - :issuing_cni_or_nulla_osta
   same_sex:
-    default:
+    ceremony_country:
+      default:
+      - :receiving_notice_of_marriage
+      - :issuing_cni_or_nulla_osta
+    third_country:
       default:
       - :issuing_cni_or_nulla_osta
   payment_partial_name: pay_by_cash_or_credit_card_no_cheque

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -132,6 +132,9 @@ module SmartAnswer
           elsif calculator.partner_is_opposite_sex?
             if calculator.ceremony_country == 'hong-kong'
               outcome :outcome_opposite_sex_marriage_in_hong_kong
+            elsif calculator.ceremony_country == 'denmark' &&
+                (calculator.resident_of_uk? || calculator.resident_of_ceremony_country?)
+                outcome :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
             elsif calculator.ceremony_country == 'germany'
               outcome :outcome_opposite_sex_marriage_in_germany
             elsif calculator.ceremony_country == 'georgia'
@@ -269,6 +272,7 @@ module SmartAnswer
       outcome :outcome_opposite_sex_marriage_in_commonwealth_countries
       outcome :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_third_country
       outcome :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk_or_ceremony_country
+      outcome :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
       outcome :outcome_opposite_sex_marriage_in_germany
       outcome :outcome_opposite_sex_marriage_in_georgia
       outcome :outcome_opposite_sex_marriage_in_hong_kong

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -113,6 +113,9 @@ module SmartAnswer
         next_node do
           if calculator.ceremony_country == 'brazil' && calculator.resident_outside_of_uk?
             outcome :outcome_marriage_in_brazil_when_residing_in_brazil_or_third_country
+          elsif calculator.ceremony_country == 'denmark' &&
+              (calculator.resident_of_uk? || calculator.resident_of_ceremony_country?)
+            outcome :outcome_ceremonies_in_denmark_when_residing_in_uk_or_denmark
           elsif calculator.ceremony_country == "netherlands"
             outcome :outcome_ceremonies_in_netherlands_or_marriage_via_local_authority_countries
           elsif calculator.ceremony_country == "portugal"
@@ -132,9 +135,6 @@ module SmartAnswer
           elsif calculator.partner_is_opposite_sex?
             if calculator.ceremony_country == 'hong-kong'
               outcome :outcome_opposite_sex_marriage_in_hong_kong
-            elsif calculator.ceremony_country == 'denmark' &&
-                (calculator.resident_of_uk? || calculator.resident_of_ceremony_country?)
-                outcome :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
             elsif calculator.ceremony_country == 'germany'
               outcome :outcome_opposite_sex_marriage_in_germany
             elsif calculator.ceremony_country == 'georgia'
@@ -250,6 +250,7 @@ module SmartAnswer
         end
       end
 
+      outcome :outcome_ceremonies_in_denmark_when_residing_in_uk_or_denmark
       outcome :outcome_ceremonies_in_dominican_republic
       outcome :outcome_ceremonies_in_ireland
       outcome :outcome_ceremonies_in_netherlands_or_marriage_via_local_authority_countries
@@ -272,7 +273,6 @@ module SmartAnswer
       outcome :outcome_opposite_sex_marriage_in_commonwealth_countries
       outcome :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_third_country
       outcome :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk_or_ceremony_country
-      outcome :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
       outcome :outcome_opposite_sex_marriage_in_germany
       outcome :outcome_opposite_sex_marriage_in_georgia
       outcome :outcome_opposite_sex_marriage_in_hong_kong

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.govspeak.erb
@@ -1,4 +1,7 @@
-<% if calculator.partner_is_opposite_sex? %>
+<% if calculator.ceremony_country == 'denmark' &&
+  (calculator.resident_of_uk? || calculator.resident_of_ceremony_country?) %>
+  [Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+<% elsif calculator.partner_is_opposite_sex? %>
   <% case calculator.ceremony_country %>
   <% when 'albania' %>
     [Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_no_trace_letters_in_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_no_trace_letters_in_denmark.govspeak.erb
@@ -1,0 +1,10 @@
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
+
+$C
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
+$C

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ceremonies_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ceremonies_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -1,8 +1,12 @@
 <% content_for :title do %>
-  Marriage in <%= calculator.country_name_lowercase_prefix %>
+  <%= ceremony_type(calculator) %> in <%= calculator.country_name_lowercase_prefix %>
 <% end %>
 
 <% content_for :body do %>
+  <% if calculator.partner_is_same_sex? %>
+    <%= render partial: 'synonyms_of_cp.govspeak.erb',
+               locals: { calculator: calculator } %>
+  <% end %>
   <% if calculator.resident_of_uk? %>
     <%= render partial: 'contact_embassy_of_ceremony_country_in_uk_marriage.govspeak.erb',
                locals: { calculator: calculator } %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -6,14 +6,14 @@
   <% if calculator.resident_of_uk? %>
     <%= render partial: 'contact_embassy_of_ceremony_country_in_uk_marriage.govspeak.erb',
                locals: { calculator: calculator } %>
-  <% else %>
+  <% elsif calculator.resident_of_ceremony_country? %>
     <%= render partial: 'contact_local_authorities_in_country_marriage.govspeak.erb',
                locals: { calculator: calculator } %>
   <% end %>
 
   <% if calculator.resident_of_ceremony_country? %>
     <%= render partial: 'get_legal_advice.govspeak.erb' %>
-  <% else %>
+  <% elsif calculator.resident_of_uk? %>
     <%= render partial: 'get_legal_and_travel_advice.govspeak.erb',
                locals: { calculator: calculator } %>
   <% end %>
@@ -77,7 +77,7 @@
 
   <% end %>
 
-  <% if calculator.resident_outside_of_uk? %>
+  <% if calculator.resident_of_ceremony_country? %>
     <%= render partial: 'check_if_cni_needs_to_be_legalised.govspeak.erb',
                locals: { calculator: calculator } %>
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -80,10 +80,6 @@
     <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
                locals: { calculator: calculator } %>
 
-  <% elsif calculator.requires_7_day_notice? # CJR %>
-    <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
-               locals: { calculator: calculator } %>
-
   <% end %>
 
   <% if calculator.resident_outside_of_uk? %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -21,8 +21,6 @@
 
   <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
 
-  ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
-
   <% if calculator.resident_of_uk? %>
     <%= render partial: 'cni_at_local_register_office.govspeak.erb' %>
 
@@ -31,9 +29,7 @@
 
     ###Legalisation and translation
 
-    You might need to exchange your UK-issued CNI for one that’s valid in <%= calculator.country_name_lowercase_prefix %> at the nearest embassy or consulate to where you’re getting married.
-
-    You should also check if it needs to be:
+    You should check if your CNI needs to be:
 
     <%= render partial: 'legalise_translate_and_check_with_authorities.govspeak.erb',
                locals: { calculator: calculator } %>
@@ -61,6 +57,10 @@
 
   <%= render partial: 'names_on_documents_must_match.govspeak.erb' %>
 
+  <% if calculator.resident_of_uk? %>
+    <%= render partial: 'no_trace_letters_in_denmark.govspeak.erb' %>
+  <% end %>
+
   <% if calculator.resident_of_ceremony_country? %>
 
     <% if calculator.partner_british? %>
@@ -70,6 +70,8 @@
     <%= render partial: 'consular_cni_os_not_uk_resident_ceremony_not_germany.govspeak.erb' %>
 
     ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
+
+    <%= render partial: 'no_trace_letters_in_denmark.govspeak.erb' %>
 
     <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
                locals: { calculator: calculator } %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -4,28 +4,11 @@
 
 <% content_for :body do %>
   <% if calculator.resident_of_uk? %>
-    <% if calculator.ceremony_country_is_dutch_caribbean_island? %>
-      <%= calculator.country_name_uppercase_prefix %> is one of the Dutch Caribbean islands.
-
-      Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local marriage laws, including what documents you’ll need
-
-    <% else %>
-      <%= render partial: 'contact_embassy_of_ceremony_country_in_uk_marriage.govspeak.erb',
-                 locals: { calculator: calculator } %>
-    <% end %>
+    <%= render partial: 'contact_embassy_of_ceremony_country_in_uk_marriage.govspeak.erb',
+               locals: { calculator: calculator } %>
   <% else %>
     <%= render partial: 'contact_local_authorities_in_country_marriage.govspeak.erb',
                locals: { calculator: calculator } %>
-  <% end %>
-
-  <% if %w(jordan oman qatar).include?(calculator.ceremony_country) %>
-    <%= render partial: 'gulf_states_os_consular_cni.govspeak.erb',
-               locals: { calculator: calculator } %>
-    <% if calculator.resident_of_ceremony_country? %>
-      <%= render partial: 'gulf_states_os_consular_cni_local_resident.govspeak.erb',
-                 locals: { calculator: calculator } %>
-
-    <% end %>
   <% end %>
 
   <% if calculator.resident_of_ceremony_country? %>
@@ -38,26 +21,7 @@
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
       locals: { calculator: calculator } %>
 
-  <% if calculator.ceremony_country == 'croatia' && calculator.resident_of_ceremony_country? %>
-    You'll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
-
-    The local registrar may also need a certificate of custom and law, which confirms the marriage is valid - the Embassy in Zagreb can provide this.
-
-  <% elsif %w(montenegro kuwait).include?(calculator.ceremony_country) && calculator.resident_outside_of_uk? %>
-    You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
-
-  <% elsif calculator.ceremony_country == 'jordan' %>
-  
-    If you’re getting married at the Sharia Court, you’ll need to provide a [single declaration document](/government/publications/single-declaration-form-for-islamic-marriages-jordan) to prove you’re allowed to marry, or a [single divorced declaration document](/government/publications/single-declaration-form-for-islamic-marriages-if-you-are-divorced-jordan) if you’re divorced.
-
-    Make an appointment at the local British embassy or consulate to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring the single declaration, your passport, your partner’s passport and pay a fee.
-
-    ^Documents must be originals if you are getting married at the Sharia Court.^
-
-    For non-Islamic marriages, you’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
-
-
-  <% elsif calculator.opposite_sex_21_days_residency_required? %>
+  <% if calculator.opposite_sex_21_days_residency_required? # CJR %>
     You need to have been living in the country where you intend to marry for 21 full days.
 
     <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
@@ -74,188 +38,36 @@
     <%= render partial: 'cni_at_local_register_office.govspeak.erb' %>
     <%= render partial: 'cni_issued_locally_validity.govspeak.erb',
                locals: { calculator: calculator } %>
-    <% if calculator.cni_posted_after_14_days? %>
+    <% if calculator.cni_posted_after_14_days? # CJR %>
       They’ll post your notice, and as long as nobody has registered an objection after 14 days, they’ll issue your CNI.
 
     <% end %>
   <% end %>
   <% if calculator.resident_of_uk? %>
 
-    <% if calculator.ceremony_country == 'tunisia' %>
-      You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia at the nearest British embassy to where you’re getting married.
+    <%= render partial: 'legisation_and_translation_intro_uk.govspeak.erb',
+               locals: { calculator: calculator } %>
 
-    <% elsif calculator.ceremony_country == 'montenegro' %>
-      ###Getting a Montenegrin version of your CNI
-
-      You might need to exchange your UK-issued CNI for one that’s valid in Montenegro at the British Embassy in Podgorica.
-
-      Contact the embassy to make an appointment. You’ll need to pay the fee for issuing a CNI or equivalent - see below. Check with the local authorities to make sure they’ll accept your UK-issued CNI, and whether it needs to be:
-
-    <% elsif %w(finland kazakhstan kyrgyzstan).include?(calculator.ceremony_country) %>
-      ###Legalisation and translation
-
-      You should check with the local authorities in <%= calculator.country_name_lowercase_prefix %> to see if your CNI needs to be:
-
-
-    <% elsif calculator.ceremony_country == 'greece' %>
-      <%= render partial: 'legalisation_and_translation.govspeak.erb' %>
-      Your UK-issued CNI should be accepted by the town hall.
-
-      You should also check if it needs to be:
-
-    <% elsif calculator.ceremony_country == 'sweden' %>
-      ###Legalisation and translation
-
-      You should check if your CNI needs to be:
-
-    <% else %>
-      <%= render partial: 'legisation_and_translation_intro_uk.govspeak.erb',
-                 locals: { calculator: calculator } %>
-
-    <% end %>
-    <% if %w(tunisia).exclude?(calculator.ceremony_country) %>
-      <%= render partial: 'legalise_translate_and_check_with_authorities.govspeak.erb',
-                 locals: { calculator: calculator } %>
-    <% end %>
+    <%= render partial: 'legalise_translate_and_check_with_authorities.govspeak.erb',
+               locals: { calculator: calculator } %>
   <% end %>
   <% if calculator.resident_of_ceremony_country? %>
-    <% if calculator.ceremony_country == 'croatia' %>
 
-      ###Applying for a CNI from the <%= calculator.embassy_or_consulate_ceremony_country %>
+    To get a CNI, you must post notice of your intended marriage in <%= calculator.country_name_lowercase_prefix %>. You can do this at the British embassy or in front of a notary public.
 
-      <%= render partial: "three_day_residency_requirement.govspeak.erb",
-                 locals: {
-                   country_name_lowercase_prefix: calculator.country_name_lowercase_prefix
-                 } %>
-
-      You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
-
-    <% elsif calculator.ceremony_country == 'nicaragua' %>
-      If you need a CNI, you must arrange this through the British Embassy in Costa Rica because there aren’t any British consular facilities in Nicaragua.
-
-
-    <% elsif %w(kazakhstan macedonia russia).exclude?(calculator.ceremony_country) %>
-      To get a CNI, you must post notice of your intended marriage in <%= calculator.country_name_lowercase_prefix %>. You can do this at the British embassy or in front of a notary public.
-
-
-    <% end %>
-
-    <% if %w(croatia italy russia).exclude?(calculator.ceremony_country) && calculator.three_day_residency_requirement_applies? %>
+    <% if calculator.three_day_residency_requirement_applies? # CJR %>
       <%= render partial: "three_day_residency_requirement.govspeak.erb",
                  locals: {
                    country_name_lowercase_prefix: calculator.country_name_lowercase_prefix
                  } %>
     <% end %>
 
-    <% if calculator.ceremony_country == 'greece' %>
-      ### Posting notice in front of a notary public
-      If you choose to post notice before a local notary public, you must email the embassy in advance to get the forms you need.
-
-      <consular.athens@fco.gov.uk>
-
-      <% if calculator.resident_of_ceremony_country? %>
-        ^Some notaries public might not let you post notice. If a local notary public doesn’t sign your forms you’ll have to post notice at the British Embassy in Athens.^
-      <% end %>
-
-      ### Posting notice at the embassy
-
-    <% end %>
-    <% if calculator.ceremony_country == 'estonia' && calculator.resident_of_ceremony_country? %>
-      ^You may be able to get married without a CNI if you have a permanent address in Estonia and have a 6 month residence permit - contact the local authorities to find out.^
-
-    <% end %>
-    <% if calculator.ceremony_country == 'kyrgyzstan' %>
-      If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Bishkek.
-
-    <% elsif calculator.ceremony_country == 'kazakhstan' %>
-      If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Astana.
-
-    <% elsif calculator.ceremony_country == 'russia' %>
-      If you need a CNI, you’ll first need to give notice of your intended marriage at your nearest British <%= calculator.embassy_or_consulate_ceremony_country %>.
-
-      ###Applying for a CNI from the consulate
-
-      <%= render partial: "three_day_residency_requirement.govspeak.erb",
-                 locals: {
-                   country_name_lowercase_prefix: "the Russian Federation"
-                 } %>
-      You can then book an appointment at the consulate in the district you’re living in, to give notice of your marriage.
-
-
-    <% end %>
-    <% if calculator.ceremony_country == 'macedonia' %>
-      Contact a notary public or British Embassy in Macedonia to get advice:
-
-      $C
-      British Embassy Macedonia
-      Telephone: + 389 (2) 3299 299
-      <consular.skopje@fco.gov.uk>
-      $C
-
-      %You can’t book an appointment to get advice at the embassy in person.%
-
-    <% elsif calculator.ceremony_country == 'sudan' %>
-      Contact the embassy or consulate to make an appointment.
-
-      $A
-      British Embassy Khartoum
-      off Sharia Al Baladia
-      PO Box No 801, Khartoum East
-      Khartoum
-      Sudan
-      $A
-
-      $C
-      Telephone: +249 (0)156 775500
-      Fax: +249 (0)156 775501
-
-      Email: <information.khartoum@fco.gov.uk>
-
-      [British Embassy Khartoum - opening hours](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact)
-      $C
-
-    <% elsif calculator.ceremony_country == 'moldova' %>
-      Contact the embassy or consulate to make an appointment.
-
-      $A
-      British Embassy Chisinau
-      18 Nicolae Iorga Str.
-      Chisinau
-      MD-2012
-      Moldova
-      $A
-
-      $C
-      Telephone: (+373) (22) 225 902
-      Fax: (+373) (22) 251 859
-
-      Email: <Enquiries.Chisinau@fco.gov.uk>
-
-      [British Embassy Chisinau - opening hours](/government/world/organisations/british-embassy-chisinau/office/british-embassy)
-      $C
-
-    <% else %>
-      <%= render partial: 'contact_method.govspeak.erb',
-                 locals: { calculator: calculator } %>
-    <% end %>
+    <%= render partial: 'contact_method.govspeak.erb',
+               locals: { calculator: calculator } %>
   <% end %>
-  <% if calculator.resident_outside_of_uk? && calculator.ceremony_country == 'egypt' %>
-    <%= render partial: 'required_supporting_documents_egypt.govspeak.erb' %>
-  <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'greece' %>
-    You’ll need to provide supporting documents, including:
 
-    - your passport
-    - Greek ID card (if available)
-    - proof of residence, such as a residence permit - check with the embassy or notary public to find out what you need
-    - equivalent documents for your partner
-
-
-  <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'philippines' %>
-    <%= render partial: 'required_supporting_documents_philippines.govspeak.erb' %>
-  <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'macao' %>
-    <%= render partial: 'required_supporting_documents_macao.govspeak.erb' %>
-  <% elsif calculator.resident_of_ceremony_country? %>
-    <% if calculator.birth_certificate_required_as_supporting_document? && (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) %>
+  <% if calculator.resident_of_ceremony_country? %>
+    <% if calculator.birth_certificate_required_as_supporting_document? && (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) # CJR %>
       You’ll need to provide supporting documents, including:
 
       - your passport
@@ -264,7 +76,7 @@
       - equivalent documents for your partner
 
 
-    <% elsif calculator.birth_certificate_required_as_supporting_document? %>
+    <% elsif calculator.birth_certificate_required_as_supporting_document? # CJR %>
       You’ll need to provide supporting documents, including:
 
       - your passport
@@ -275,7 +87,7 @@
       - equivalent documents for your partner
 
 
-    <% elsif (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) %>
+    <% elsif (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) # CJR %>
       You’ll need to provide supporting documents, including:
 
       - your passport
@@ -288,37 +100,17 @@
                  locals: { calculator: calculator } %>
 
     <% end %>
-    <% if calculator.ceremony_country == 'jordan' %>
-      ^Documents must be originals if you are getting married at the Sharia Court.^
-
-    <% end %>
   <% end %>
 
   <% if calculator.resident_of_ceremony_country? %>
-    <% if calculator.ceremony_country == 'greece' %>
-      You’ll need to fill in forms for your notice of marriage, and complete an affirmation (non-religious) or affidavit (religious) stating that you’re free to marry.
-
-      You can download and fill in (but not sign) the forms in advance. You’ll need to take the forms with you to your appointment.
-
-
-      $D
-      [Download ‘Notice of marriage’](/government/publications/notice-of-marriage-form--2)
-
-      [Download ‘Affidavit and affirmation for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form)
-      $D
-
-
-    <% else %>
-      <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
-
-    <% end %>
+    <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
   <% else %>
     <% if calculator.partner_is_same_sex? ||
       (
         calculator.document_download_link_if_opposite_sex_resident_of_uk_countries? &&
         (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) &&
         %w(greece tunisia).exclude?(calculator.ceremony_country)
-      ) %>
+      ) # CJR %>
       <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
 
     <% end %>
@@ -328,51 +120,18 @@
 
   <% if calculator.resident_of_ceremony_country? %>
 
-    <% if calculator.partner_british? && %w(finland).exclude?(calculator.ceremony_country) %>
+    <% if calculator.partner_british? %>
       ^Your partner will need to follow the same process and pay the fees to get their own CNI.^
     <% end %>
 
-    <% if calculator.ceremony_country == 'kazakhstan' %>
-      <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
-                 locals: { calculator: calculator } %>
-
-    <% end %>
-
     <% if calculator.resident_outside_of_uk? %>
-      <% if calculator.ceremony_country == 'jordan' %>
-
-        If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-        - a [single divorced declaration document](/government/publications/single-declaration-form-for-islamic-marriages-if-you-are-divorced-jordan) if you’re getting married at the Sharia Court
-        - a [decree absolute or final order](/copy-decree-absolute-final-order)
-        - a civil partnership dissolution or annulment certificate
-        - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-      <% else %>
-        <%= render partial: 'consular_cni_os_not_uk_resident_ceremony_not_germany.govspeak.erb' %>
-
-      <% end %>
+      <%= render partial: 'consular_cni_os_not_uk_resident_ceremony_not_germany.govspeak.erb' %>
 
       ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
 
     <% end %>
 
-    <% if calculator.ceremony_country == 'greece' %>
-      ###What happens next
-
-      The embassy or notary public can take your oath or affirmation and witness your notice of marriage. The notary public may charge 2 separate fees for this.
-
-      If you give notice at a notary public, you must post the signed forms and any supporting documents to the British Embassy in Athens afterwards.
-
-      The embassy will display your notice of marriage publicly for 7 days (from the day after they receive your payment). They’ll then issue the CNI on the 8th day (as long as nobody has registered an objection).
-
-      There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
-
-      You can then collect your CNI at the British embassy in Athens or ask for it to be sent to you by post. You must provide the registrar’s original Notice of Marriage if you posted notice in the UK.
-
-      [Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
-
-    <% elsif calculator.notary_public_ceremony_country? %>
+    <% if calculator.notary_public_ceremony_country? # CJR %>
       ###What happens next
 
       The embassy or notary public will charge a fee for taking the oath.
@@ -393,13 +152,9 @@
                  locals: { calculator: calculator } %>
 
     <% end %>
-  <% elsif calculator.requires_7_day_notice? %>
+  <% elsif calculator.requires_7_day_notice? # CJR %>
     <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
                locals: { calculator: calculator } %>
-
-  <% end %>
-  <% if calculator.resident_of_uk? && calculator.partner_is_neither_british_nor_a_national_of_ceremony_country? && "finland" == calculator.ceremony_country %>
-    <%= render partial: 'callout_partner_equivalent_document.govspeak.erb' %>
 
   <% end %>
 
@@ -418,20 +173,10 @@
 
   <% end %>
 
-  <% if calculator.ceremony_country == 'poland' %>
-    <% if calculator.resident_of_uk? %>
-      ## What happens next
-    <% end %>
-
-    If you’re getting married in a registry office, you must give them your CNI at least 2 months before your wedding. If you’re getting married in a church, you can do this 2 days before the wedding.
-
-    You may be asked to provide a copy of your birth certificate. Make sure you send a [certified copy](/order-copy-birth-death-marriage-certificate) as you won’t get it back.
-  <% end %>
-
   <%= render partial: 'consular_fees_table.govspeak.erb',
              locals: { calculator: calculator } %>
 
-  <% unless calculator.country_without_consular_facilities? || calculator.ceremony_country == 'cote-d-ivoire' %>
+  <% unless calculator.country_without_consular_facilities? || calculator.ceremony_country == 'cote-d-ivoire' # CJR %>
     <% if %w(kazakhstan kyrgyzstan).include?(calculator.ceremony_country) %>
       You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Kazakhstan](/government/publications/kazakhstan-kyrgyzstan-consular-fees).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -1,0 +1,448 @@
+<% content_for :title do %>
+  Marriage in <%= calculator.country_name_lowercase_prefix %>
+<% end %>
+
+<% content_for :body do %>
+  <% if calculator.resident_of_uk? %>
+    <% if calculator.ceremony_country_is_dutch_caribbean_island? %>
+      <%= calculator.country_name_uppercase_prefix %> is one of the Dutch Caribbean islands.
+
+      Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local marriage laws, including what documents you’ll need
+
+    <% else %>
+      <%= render partial: 'contact_embassy_of_ceremony_country_in_uk_marriage.govspeak.erb',
+                 locals: { calculator: calculator } %>
+    <% end %>
+  <% else %>
+    <%= render partial: 'contact_local_authorities_in_country_marriage.govspeak.erb',
+               locals: { calculator: calculator } %>
+  <% end %>
+
+  <% if %w(jordan oman qatar).include?(calculator.ceremony_country) %>
+    <%= render partial: 'gulf_states_os_consular_cni.govspeak.erb',
+               locals: { calculator: calculator } %>
+    <% if calculator.resident_of_ceremony_country? %>
+      <%= render partial: 'gulf_states_os_consular_cni_local_resident.govspeak.erb',
+                 locals: { calculator: calculator } %>
+
+    <% end %>
+  <% end %>
+
+  <% if calculator.resident_of_ceremony_country? %>
+    <%= render partial: 'get_legal_advice.govspeak.erb' %>
+  <% else %>
+    <%= render partial: 'get_legal_and_travel_advice.govspeak.erb',
+               locals: { calculator: calculator } %>
+  <% end %>
+
+  <%= render partial: 'what_you_need_to_do.govspeak.erb',
+      locals: { calculator: calculator } %>
+
+  <% if calculator.ceremony_country == 'croatia' && calculator.resident_of_ceremony_country? %>
+    You'll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+
+    The local registrar may also need a certificate of custom and law, which confirms the marriage is valid - the Embassy in Zagreb can provide this.
+
+  <% elsif %w(montenegro kuwait).include?(calculator.ceremony_country) && calculator.resident_outside_of_uk? %>
+    You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
+
+  <% elsif calculator.ceremony_country == 'jordan' %>
+  
+    If you’re getting married at the Sharia Court, you’ll need to provide a [single declaration document](/government/publications/single-declaration-form-for-islamic-marriages-jordan) to prove you’re allowed to marry, or a [single divorced declaration document](/government/publications/single-declaration-form-for-islamic-marriages-if-you-are-divorced-jordan) if you’re divorced.
+
+    Make an appointment at the local British embassy or consulate to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring the single declaration, your passport, your partner’s passport and pay a fee.
+
+    ^Documents must be originals if you are getting married at the Sharia Court.^
+
+    For non-Islamic marriages, you’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+
+
+  <% elsif calculator.opposite_sex_21_days_residency_required? %>
+    You need to have been living in the country where you intend to marry for 21 full days.
+
+    <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
+
+  <% else %>
+    <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
+
+  <% end %>
+  <% if calculator.ceremony_country == 'denmark' %>
+    ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
+
+  <% end %>
+  <% if calculator.resident_of_uk? %>
+    <%= render partial: 'cni_at_local_register_office.govspeak.erb' %>
+    <%= render partial: 'cni_issued_locally_validity.govspeak.erb',
+               locals: { calculator: calculator } %>
+    <% if calculator.cni_posted_after_14_days? %>
+      They’ll post your notice, and as long as nobody has registered an objection after 14 days, they’ll issue your CNI.
+
+    <% end %>
+  <% end %>
+  <% if calculator.resident_of_uk? %>
+
+    <% if calculator.ceremony_country == 'tunisia' %>
+      You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia at the nearest British embassy to where you’re getting married.
+
+    <% elsif calculator.ceremony_country == 'montenegro' %>
+      ###Getting a Montenegrin version of your CNI
+
+      You might need to exchange your UK-issued CNI for one that’s valid in Montenegro at the British Embassy in Podgorica.
+
+      Contact the embassy to make an appointment. You’ll need to pay the fee for issuing a CNI or equivalent - see below. Check with the local authorities to make sure they’ll accept your UK-issued CNI, and whether it needs to be:
+
+    <% elsif %w(finland kazakhstan kyrgyzstan).include?(calculator.ceremony_country) %>
+      ###Legalisation and translation
+
+      You should check with the local authorities in <%= calculator.country_name_lowercase_prefix %> to see if your CNI needs to be:
+
+
+    <% elsif calculator.ceremony_country == 'greece' %>
+      <%= render partial: 'legalisation_and_translation.govspeak.erb' %>
+      Your UK-issued CNI should be accepted by the town hall.
+
+      You should also check if it needs to be:
+
+    <% elsif calculator.ceremony_country == 'sweden' %>
+      ###Legalisation and translation
+
+      You should check if your CNI needs to be:
+
+    <% else %>
+      <%= render partial: 'legisation_and_translation_intro_uk.govspeak.erb',
+                 locals: { calculator: calculator } %>
+
+    <% end %>
+    <% if %w(tunisia).exclude?(calculator.ceremony_country) %>
+      <%= render partial: 'legalise_translate_and_check_with_authorities.govspeak.erb',
+                 locals: { calculator: calculator } %>
+    <% end %>
+  <% end %>
+  <% if calculator.resident_of_ceremony_country? %>
+    <% if calculator.ceremony_country == 'croatia' %>
+
+      ###Applying for a CNI from the <%= calculator.embassy_or_consulate_ceremony_country %>
+
+      <%= render partial: "three_day_residency_requirement.govspeak.erb",
+                 locals: {
+                   country_name_lowercase_prefix: calculator.country_name_lowercase_prefix
+                 } %>
+
+      You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
+
+    <% elsif calculator.ceremony_country == 'nicaragua' %>
+      If you need a CNI, you must arrange this through the British Embassy in Costa Rica because there aren’t any British consular facilities in Nicaragua.
+
+
+    <% elsif %w(kazakhstan macedonia russia).exclude?(calculator.ceremony_country) %>
+      To get a CNI, you must post notice of your intended marriage in <%= calculator.country_name_lowercase_prefix %>. You can do this at the British embassy or in front of a notary public.
+
+
+    <% end %>
+
+    <% if %w(croatia italy russia).exclude?(calculator.ceremony_country) && calculator.three_day_residency_requirement_applies? %>
+      <%= render partial: "three_day_residency_requirement.govspeak.erb",
+                 locals: {
+                   country_name_lowercase_prefix: calculator.country_name_lowercase_prefix
+                 } %>
+    <% end %>
+
+    <% if calculator.ceremony_country == 'greece' %>
+      ### Posting notice in front of a notary public
+      If you choose to post notice before a local notary public, you must email the embassy in advance to get the forms you need.
+
+      <consular.athens@fco.gov.uk>
+
+      <% if calculator.resident_of_ceremony_country? %>
+        ^Some notaries public might not let you post notice. If a local notary public doesn’t sign your forms you’ll have to post notice at the British Embassy in Athens.^
+      <% end %>
+
+      ### Posting notice at the embassy
+
+    <% end %>
+    <% if calculator.ceremony_country == 'estonia' && calculator.resident_of_ceremony_country? %>
+      ^You may be able to get married without a CNI if you have a permanent address in Estonia and have a 6 month residence permit - contact the local authorities to find out.^
+
+    <% end %>
+    <% if calculator.ceremony_country == 'kyrgyzstan' %>
+      If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Bishkek.
+
+    <% elsif calculator.ceremony_country == 'kazakhstan' %>
+      If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Astana.
+
+    <% elsif calculator.ceremony_country == 'russia' %>
+      If you need a CNI, you’ll first need to give notice of your intended marriage at your nearest British <%= calculator.embassy_or_consulate_ceremony_country %>.
+
+      ###Applying for a CNI from the consulate
+
+      <%= render partial: "three_day_residency_requirement.govspeak.erb",
+                 locals: {
+                   country_name_lowercase_prefix: "the Russian Federation"
+                 } %>
+      You can then book an appointment at the consulate in the district you’re living in, to give notice of your marriage.
+
+
+    <% end %>
+    <% if calculator.ceremony_country == 'macedonia' %>
+      Contact a notary public or British Embassy in Macedonia to get advice:
+
+      $C
+      British Embassy Macedonia
+      Telephone: + 389 (2) 3299 299
+      <consular.skopje@fco.gov.uk>
+      $C
+
+      %You can’t book an appointment to get advice at the embassy in person.%
+
+    <% elsif calculator.ceremony_country == 'sudan' %>
+      Contact the embassy or consulate to make an appointment.
+
+      $A
+      British Embassy Khartoum
+      off Sharia Al Baladia
+      PO Box No 801, Khartoum East
+      Khartoum
+      Sudan
+      $A
+
+      $C
+      Telephone: +249 (0)156 775500
+      Fax: +249 (0)156 775501
+
+      Email: <information.khartoum@fco.gov.uk>
+
+      [British Embassy Khartoum - opening hours](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact)
+      $C
+
+    <% elsif calculator.ceremony_country == 'moldova' %>
+      Contact the embassy or consulate to make an appointment.
+
+      $A
+      British Embassy Chisinau
+      18 Nicolae Iorga Str.
+      Chisinau
+      MD-2012
+      Moldova
+      $A
+
+      $C
+      Telephone: (+373) (22) 225 902
+      Fax: (+373) (22) 251 859
+
+      Email: <Enquiries.Chisinau@fco.gov.uk>
+
+      [British Embassy Chisinau - opening hours](/government/world/organisations/british-embassy-chisinau/office/british-embassy)
+      $C
+
+    <% else %>
+      <%= render partial: 'contact_method.govspeak.erb',
+                 locals: { calculator: calculator } %>
+    <% end %>
+  <% end %>
+  <% if calculator.resident_outside_of_uk? && calculator.ceremony_country == 'egypt' %>
+    <%= render partial: 'required_supporting_documents_egypt.govspeak.erb' %>
+  <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'greece' %>
+    You’ll need to provide supporting documents, including:
+
+    - your passport
+    - Greek ID card (if available)
+    - proof of residence, such as a residence permit - check with the embassy or notary public to find out what you need
+    - equivalent documents for your partner
+
+
+  <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'philippines' %>
+    <%= render partial: 'required_supporting_documents_philippines.govspeak.erb' %>
+  <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'macao' %>
+    <%= render partial: 'required_supporting_documents_macao.govspeak.erb' %>
+  <% elsif calculator.resident_of_ceremony_country? %>
+    <% if calculator.birth_certificate_required_as_supporting_document? && (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) %>
+      You’ll need to provide supporting documents, including:
+
+      - your passport
+      - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+      - proof of residence, such as a residence certificate - check with the <%= calculator.embassy_or_consulate_ceremony_country %> or notary public to find out what you need
+      - equivalent documents for your partner
+
+
+    <% elsif calculator.birth_certificate_required_as_supporting_document? %>
+      You’ll need to provide supporting documents, including:
+
+      - your passport
+      <% unless calculator.ceremony_country == 'jordan' && calculator.resident_of_ceremony_country? %>
+        - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+      <% end %>
+      - proof of residence, such as a residence certificate - check with the <%= calculator.embassy_or_consulate_ceremony_country %> to find out what you need
+      - equivalent documents for your partner
+
+
+    <% elsif (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) %>
+      You’ll need to provide supporting documents, including:
+
+      - your passport
+      - proof of residence, such as a residence certificate - check with the <%= calculator.embassy_or_consulate_ceremony_country %> or notary public to find out what you need
+      - equivalent documents for your partner
+
+
+    <% else %>
+      <%= render partial: 'required_supporting_documents.govspeak.erb',
+                 locals: { calculator: calculator } %>
+
+    <% end %>
+    <% if calculator.ceremony_country == 'jordan' %>
+      ^Documents must be originals if you are getting married at the Sharia Court.^
+
+    <% end %>
+  <% end %>
+
+  <% if calculator.resident_of_ceremony_country? %>
+    <% if calculator.ceremony_country == 'greece' %>
+      You’ll need to fill in forms for your notice of marriage, and complete an affirmation (non-religious) or affidavit (religious) stating that you’re free to marry.
+
+      You can download and fill in (but not sign) the forms in advance. You’ll need to take the forms with you to your appointment.
+
+
+      $D
+      [Download ‘Notice of marriage’](/government/publications/notice-of-marriage-form--2)
+
+      [Download ‘Affidavit and affirmation for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form)
+      $D
+
+
+    <% else %>
+      <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
+
+    <% end %>
+  <% else %>
+    <% if calculator.partner_is_same_sex? ||
+      (
+        calculator.document_download_link_if_opposite_sex_resident_of_uk_countries? &&
+        (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) &&
+        %w(greece tunisia).exclude?(calculator.ceremony_country)
+      ) %>
+      <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
+
+    <% end %>
+  <% end %>
+
+  <%= render partial: 'names_on_documents_must_match.govspeak.erb' %>
+
+  <% if calculator.resident_of_ceremony_country? %>
+
+    <% if calculator.partner_british? && %w(finland).exclude?(calculator.ceremony_country) %>
+      ^Your partner will need to follow the same process and pay the fees to get their own CNI.^
+    <% end %>
+
+    <% if calculator.ceremony_country == 'kazakhstan' %>
+      <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
+                 locals: { calculator: calculator } %>
+
+    <% end %>
+
+    <% if calculator.resident_outside_of_uk? %>
+      <% if calculator.ceremony_country == 'jordan' %>
+
+        If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+        - a [single divorced declaration document](/government/publications/single-declaration-form-for-islamic-marriages-if-you-are-divorced-jordan) if you’re getting married at the Sharia Court
+        - a [decree absolute or final order](/copy-decree-absolute-final-order)
+        - a civil partnership dissolution or annulment certificate
+        - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+      <% else %>
+        <%= render partial: 'consular_cni_os_not_uk_resident_ceremony_not_germany.govspeak.erb' %>
+
+      <% end %>
+
+      ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
+
+    <% end %>
+
+    <% if calculator.ceremony_country == 'greece' %>
+      ###What happens next
+
+      The embassy or notary public can take your oath or affirmation and witness your notice of marriage. The notary public may charge 2 separate fees for this.
+
+      If you give notice at a notary public, you must post the signed forms and any supporting documents to the British Embassy in Athens afterwards.
+
+      The embassy will display your notice of marriage publicly for 7 days (from the day after they receive your payment). They’ll then issue the CNI on the 8th day (as long as nobody has registered an objection).
+
+      There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
+
+      You can then collect your CNI at the British embassy in Athens or ask for it to be sent to you by post. You must provide the registrar’s original Notice of Marriage if you posted notice in the UK.
+
+      [Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
+
+    <% elsif calculator.notary_public_ceremony_country? %>
+      ###What happens next
+
+      The embassy or notary public will charge a fee for taking the oath.
+
+      If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
+
+      ^The embassy or consulate may charge a fee to return your documents to you.^
+
+      The consulate will display your notice of marriage publicly for 7 days.
+
+      They’ll then send all of your documentation to the British embassy or consulate nearest to where you’re getting married in <%= calculator.country_name_lowercase_prefix %>, who will issue your CNI (as long as nobody has registered an objection).
+
+      There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
+
+
+    <% else %>
+      <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
+                 locals: { calculator: calculator } %>
+
+    <% end %>
+  <% elsif calculator.requires_7_day_notice? %>
+    <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
+               locals: { calculator: calculator } %>
+
+  <% end %>
+  <% if calculator.resident_of_uk? && calculator.partner_is_neither_british_nor_a_national_of_ceremony_country? && "finland" == calculator.ceremony_country %>
+    <%= render partial: 'callout_partner_equivalent_document.govspeak.erb' %>
+
+  <% end %>
+
+  <% if calculator.resident_outside_of_uk? %>
+    <%= render partial: 'check_if_cni_needs_to_be_legalised.govspeak.erb',
+               locals: { calculator: calculator } %>
+
+  <% end %>
+  <% if calculator.resident_of_ceremony_country? %>
+    <%= render partial: 'you_dont_need_to_stay_in_country.govspeak.erb' %>
+
+  <% end %>
+  <% if calculator.partner_not_british? %>
+
+    <%= render partial: 'partner_naturalisation_in_uk.govspeak.erb' %>
+
+  <% end %>
+
+  <% if calculator.ceremony_country == 'poland' %>
+    <% if calculator.resident_of_uk? %>
+      ## What happens next
+    <% end %>
+
+    If you’re getting married in a registry office, you must give them your CNI at least 2 months before your wedding. If you’re getting married in a church, you can do this 2 days before the wedding.
+
+    You may be asked to provide a copy of your birth certificate. Make sure you send a [certified copy](/order-copy-birth-death-marriage-certificate) as you won’t get it back.
+  <% end %>
+
+  <%= render partial: 'consular_fees_table.govspeak.erb',
+             locals: { calculator: calculator } %>
+
+  <% unless calculator.country_without_consular_facilities? || calculator.ceremony_country == 'cote-d-ivoire' %>
+    <% if %w(kazakhstan kyrgyzstan).include?(calculator.ceremony_country) %>
+      You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Kazakhstan](/government/publications/kazakhstan-kyrgyzstan-consular-fees).
+
+    <% else %>
+      <%= render partial: 'link_to_consular_fees.govspeak.erb',
+                 locals: { calculator: calculator } %>
+    <% end %>
+  <% end %>
+
+  <%= render partial: 'payment_information.govspeak.erb',
+             locals: { calculator: calculator } %>
+
+  *[CNI]:certificate of no impediment
+<% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -54,19 +54,8 @@
   <% end %>
 
   <% if calculator.resident_of_ceremony_country? %>
-    <% if (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) # CJR %>
-      You’ll need to provide supporting documents, including:
-
-      - your passport
-      - proof of residence, such as a residence certificate - check with the <%= calculator.embassy_or_consulate_ceremony_country %> or notary public to find out what you need
-      - equivalent documents for your partner
-
-
-    <% else %>
-      <%= render partial: 'required_supporting_documents.govspeak.erb',
-                 locals: { calculator: calculator } %>
-
-    <% end %>
+    <%= render partial: 'required_supporting_documents.govspeak.erb',
+               locals: { calculator: calculator } %>
   <% end %>
 
   <% if calculator.resident_of_ceremony_country? %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -29,8 +29,11 @@
     <%= render partial: 'cni_issued_locally_validity.govspeak.erb',
                locals: { calculator: calculator } %>
 
-    <%= render partial: 'legisation_and_translation_intro_uk.govspeak.erb',
-               locals: { calculator: calculator } %>
+    ###Legalisation and translation
+
+    You might need to exchange your UK-issued CNI for one that’s valid in <%= calculator.country_name_lowercase_prefix %> at the nearest embassy or consulate to where you’re getting married.
+
+    You should also check if it needs to be:
 
     <%= render partial: 'legalise_translate_and_check_with_authorities.govspeak.erb',
                locals: { calculator: calculator } %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -100,15 +100,8 @@
   <%= render partial: 'consular_fees_table.govspeak.erb',
              locals: { calculator: calculator } %>
 
-  <% unless calculator.country_without_consular_facilities? || calculator.ceremony_country == 'cote-d-ivoire' # CJR %>
-    <% if %w(kazakhstan kyrgyzstan).include?(calculator.ceremony_country) %>
-      You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Kazakhstan](/government/publications/kazakhstan-kyrgyzstan-consular-fees).
-
-    <% else %>
-      <%= render partial: 'link_to_consular_fees.govspeak.erb',
-                 locals: { calculator: calculator } %>
-    <% end %>
-  <% end %>
+  <%= render partial: 'link_to_consular_fees.govspeak.erb',
+             locals: { calculator: calculator } %>
 
   <%= render partial: 'payment_information.govspeak.erb',
              locals: { calculator: calculator } %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -23,10 +23,8 @@
 
   <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
 
-  <% if calculator.ceremony_country == 'denmark' %>
-    ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
+  ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
 
-  <% end %>
   <% if calculator.resident_of_uk? %>
     <%= render partial: 'cni_at_local_register_office.govspeak.erb' %>
     <%= render partial: 'cni_issued_locally_validity.govspeak.erb',

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -60,16 +60,6 @@
 
   <% if calculator.resident_of_ceremony_country? %>
     <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
-  <% else %>
-    <% if calculator.partner_is_same_sex? ||
-      (
-        calculator.document_download_link_if_opposite_sex_resident_of_uk_countries? &&
-        (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) &&
-        %w(greece tunisia).exclude?(calculator.ceremony_country)
-      ) # CJR %>
-      <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
-
-    <% end %>
   <% end %>
 
   <%= render partial: 'names_on_documents_must_match.govspeak.erb' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -54,27 +54,7 @@
   <% end %>
 
   <% if calculator.resident_of_ceremony_country? %>
-    <% if calculator.birth_certificate_required_as_supporting_document? && (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) # CJR %>
-      You’ll need to provide supporting documents, including:
-
-      - your passport
-      - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-      - proof of residence, such as a residence certificate - check with the <%= calculator.embassy_or_consulate_ceremony_country %> or notary public to find out what you need
-      - equivalent documents for your partner
-
-
-    <% elsif calculator.birth_certificate_required_as_supporting_document? # CJR %>
-      You’ll need to provide supporting documents, including:
-
-      - your passport
-      <% unless calculator.ceremony_country == 'jordan' && calculator.resident_of_ceremony_country? %>
-        - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-      <% end %>
-      - proof of residence, such as a residence certificate - check with the <%= calculator.embassy_or_consulate_ceremony_country %> to find out what you need
-      - equivalent documents for your partner
-
-
-    <% elsif (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) # CJR %>
+    <% if (calculator.notary_public_ceremony_country? || %w(japan macedonia).include?(calculator.ceremony_country)) # CJR %>
       You’ll need to provide supporting documents, including:
 
       - your passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -68,12 +68,9 @@
       ^Your partner will need to follow the same process and pay the fees to get their own CNI.^
     <% end %>
 
-    <% if calculator.resident_outside_of_uk? %>
-      <%= render partial: 'consular_cni_os_not_uk_resident_ceremony_not_germany.govspeak.erb' %>
+    <%= render partial: 'consular_cni_os_not_uk_resident_ceremony_not_germany.govspeak.erb' %>
 
-      ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
-
-    <% end %>
+    ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
 
     <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
                locals: { calculator: calculator } %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -21,15 +21,8 @@
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
       locals: { calculator: calculator } %>
 
-  <% if calculator.opposite_sex_21_days_residency_required? # CJR %>
-    You need to have been living in the country where you intend to marry for 21 full days.
+  <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
 
-    <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
-
-  <% else %>
-    <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
-
-  <% end %>
   <% if calculator.ceremony_country == 'denmark' %>
     ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -6,16 +6,14 @@
   <% if calculator.resident_of_uk? %>
     <%= render partial: 'contact_embassy_of_ceremony_country_in_uk_marriage.govspeak.erb',
                locals: { calculator: calculator } %>
+
+    <%= render partial: 'get_legal_and_travel_advice.govspeak.erb',
+               locals: { calculator: calculator } %>
   <% elsif calculator.resident_of_ceremony_country? %>
     <%= render partial: 'contact_local_authorities_in_country_marriage.govspeak.erb',
                locals: { calculator: calculator } %>
-  <% end %>
 
-  <% if calculator.resident_of_ceremony_country? %>
     <%= render partial: 'get_legal_advice.govspeak.erb' %>
-  <% elsif calculator.resident_of_uk? %>
-    <%= render partial: 'get_legal_and_travel_advice.govspeak.erb',
-               locals: { calculator: calculator } %>
   <% end %>
 
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
@@ -27,10 +25,9 @@
 
   <% if calculator.resident_of_uk? %>
     <%= render partial: 'cni_at_local_register_office.govspeak.erb' %>
+
     <%= render partial: 'cni_issued_locally_validity.govspeak.erb',
                locals: { calculator: calculator } %>
-  <% end %>
-  <% if calculator.resident_of_uk? %>
 
     <%= render partial: 'legisation_and_translation_intro_uk.govspeak.erb',
                locals: { calculator: calculator } %>
@@ -38,6 +35,7 @@
     <%= render partial: 'legalise_translate_and_check_with_authorities.govspeak.erb',
                locals: { calculator: calculator } %>
   <% end %>
+
   <% if calculator.resident_of_ceremony_country? %>
 
     To get a CNI, you must post notice of your intended marriage in <%= calculator.country_name_lowercase_prefix %>. You can do this at the British embassy or in front of a notary public.
@@ -54,9 +52,7 @@
   <% if calculator.resident_of_ceremony_country? %>
     <%= render partial: 'required_supporting_documents.govspeak.erb',
                locals: { calculator: calculator } %>
-  <% end %>
 
-  <% if calculator.resident_of_ceremony_country? %>
     <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
   <% end %>
 
@@ -75,17 +71,13 @@
     <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
                locals: { calculator: calculator } %>
 
-  <% end %>
-
-  <% if calculator.resident_of_ceremony_country? %>
     <%= render partial: 'check_if_cni_needs_to_be_legalised.govspeak.erb',
                locals: { calculator: calculator } %>
 
-  <% end %>
-  <% if calculator.resident_of_ceremony_country? %>
     <%= render partial: 'you_dont_need_to_stay_in_country.govspeak.erb' %>
 
   <% end %>
+
   <% if calculator.partner_not_british? %>
 
     <%= render partial: 'partner_naturalisation_in_uk.govspeak.erb' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -44,12 +44,10 @@
 
     To get a CNI, you must post notice of your intended marriage in <%= calculator.country_name_lowercase_prefix %>. You can do this at the British embassy or in front of a notary public.
 
-    <% if calculator.three_day_residency_requirement_applies? # CJR %>
-      <%= render partial: "three_day_residency_requirement.govspeak.erb",
-                 locals: {
-                   country_name_lowercase_prefix: calculator.country_name_lowercase_prefix
-                 } %>
-    <% end %>
+    <%= render partial: "three_day_residency_requirement.govspeak.erb",
+               locals: {
+                 country_name_lowercase_prefix: calculator.country_name_lowercase_prefix
+               } %>
 
     <%= render partial: 'contact_method.govspeak.erb',
                locals: { calculator: calculator } %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -77,27 +77,9 @@
 
     <% end %>
 
-    <% if calculator.notary_public_ceremony_country? # CJR %>
-      ###What happens next
+    <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
+               locals: { calculator: calculator } %>
 
-      The embassy or notary public will charge a fee for taking the oath.
-
-      If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
-
-      ^The embassy or consulate may charge a fee to return your documents to you.^
-
-      The consulate will display your notice of marriage publicly for 7 days.
-
-      They’ll then send all of your documentation to the British embassy or consulate nearest to where you’re getting married in <%= calculator.country_name_lowercase_prefix %>, who will issue your CNI (as long as nobody has registered an objection).
-
-      There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
-
-
-    <% else %>
-      <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
-                 locals: { calculator: calculator } %>
-
-    <% end %>
   <% elsif calculator.requires_7_day_notice? # CJR %>
     <%= render partial: 'display_notice_of_marriage_7_days.govspeak.erb',
                locals: { calculator: calculator } %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark.govspeak.erb
@@ -31,10 +31,6 @@
     <%= render partial: 'cni_at_local_register_office.govspeak.erb' %>
     <%= render partial: 'cni_issued_locally_validity.govspeak.erb',
                locals: { calculator: calculator } %>
-    <% if calculator.cni_posted_after_14_days? # CJR %>
-      They’ll post your notice, and as long as nobody has registered an objection after 14 days, they’ll issue your CNI.
-
-    <% end %>
   <% end %>
   <% if calculator.resident_of_uk? %>
 

--- a/script/marriage-abroad-query-responses-and-expected-results.rb
+++ b/script/marriage-abroad-query-responses-and-expected-results.rb
@@ -1,0 +1,35 @@
+# This script allows you to "query" the marriage-abroad
+# responses-and-expected-results data.
+#
+# Usage:
+# $ rails r script/marriage-abroad-query-responses-and-expected-results.rb \
+#   space separated list of responses
+#
+# Example:
+# $ rails r script/marriage-abroad-query-responses-and-expected-results.rb \
+#   malta uk partner_british
+#
+# Responses: malta/uk/partner_british/opposite_sex
+#   Outcome: outcome_opposite_sex_marriage_in_commonwealth_countries
+#
+# Responses: malta/uk/partner_british/same_sex
+#   Outcome: outcome_same_sex_marriage_and_civil_partnership_in_malta
+
+responses = ARGV
+
+filename = 'marriage-abroad-responses-and-expected-results.yml'
+filepath = Rails.root.join('test', 'data', filename)
+
+yaml = File.read(filepath)
+responses_and_expected_results = YAML.load(yaml)
+
+outcomes_for_responses = responses_and_expected_results.select do |hash|
+  hash[:outcome_node] == true &&
+    hash[:responses] & responses == responses
+end
+
+outcomes_for_responses.each do |hash|
+  puts "Responses: #{hash[:responses].join('/')}"
+  puts "  Outcome: #{hash[:next_node]}"
+  puts
+end

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_british/opposite_sex.txt
@@ -8,8 +8,6 @@ Contact the relevant local authorities in Denmark to find out about local marria
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
-
 To get a CNI, you must post notice of your intended marriage in Denmark. You can do this at the British embassy or in front of a notary public.
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -39,6 +37,17 @@ If you or your partner have been divorced, widowed or previously in a civil part
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
 
 ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.^
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
+
+$C
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
+$C
 
 ###What happens next
 

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_british/same_sex.txt
@@ -6,39 +6,75 @@ Same-sex relationships in Denmark that are recognised as civil partnerships unde
 - ’registreret partnerskab’ (’registered partnership’)
 - ‘nalunaarsukkamik inooqatigiinneq’ (in Greenland)
 
-Contact the relevant local authorities in Denmark to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Denmark to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Denmark.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+To get a CNI, you must post notice of your intended marriage in Denmark. You can do this at the British embassy or in front of a notary public.
 
-$A
-British Embassy Copenhagen
-Kastelsvej 36-40
-DK-2100  Copenhagen
-Denmark
-$A
+You’ll need to have been living in Denmark for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+
+You’ll need to provide supporting documents, including:
+
+- your passport
+- proof of residence, such as a residence certificate - check with the embassy to find out what you need
+- equivalent documents for your partner
+
+You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+^Your partner will need to follow the same process and pay the fees to get their own CNI.^
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
 
 $C
-Consular / passport enquiries: consular.copenhagen@fco.gov.uk
-Telephone : +45 35 44 52 00
-
-Email: <Enquiry.Copenhagen@fco.gov.uk>
-
-[British Embassy Copenhagen - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-copenhagen/office/british-embassy)
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
+
+###What happens next
+
+The embassy will charge a fee for taking the oath, and then display your notice of marriage publicly for a further 7 days. They’ll then issue the CNI, as long as nobody has registered an objection. There’s an additional fee for this.
+
+You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in Denmark.
+
+^You don't need to stay in the country while your notice is posted.^
 
 ## Fees
 
 Service | Fee
 -|-
+Receiving a notice of marriage | £65
 Issuing a CNI, Nulla Osta or equivalent | £65
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Denmark](/government/publications/denmark-consular-fees).
 
 You can pay by cash or credit card, but not by personal cheque.
+
+*[CNI]:certificate of no impediment
 
 
 

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_local/opposite_sex.txt
@@ -8,8 +8,6 @@ Contact the relevant local authorities in Denmark to find out about local marria
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
-
 To get a CNI, you must post notice of your intended marriage in Denmark. You can do this at the British embassy or in front of a notary public.
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -37,6 +35,17 @@ If you or your partner have been divorced, widowed or previously in a civil part
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
 
 ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.^
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
+
+$C
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
+$C
 
 ###What happens next
 

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_local/same_sex.txt
@@ -6,29 +6,60 @@ Same-sex relationships in Denmark that are recognised as civil partnerships unde
 - ’registreret partnerskab’ (’registered partnership’)
 - ‘nalunaarsukkamik inooqatigiinneq’ (in Greenland)
 
-Contact the relevant local authorities in Denmark to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Denmark to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Denmark.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+To get a CNI, you must post notice of your intended marriage in Denmark. You can do this at the British embassy or in front of a notary public.
 
-$A
-British Embassy Copenhagen
-Kastelsvej 36-40
-DK-2100  Copenhagen
-Denmark
-$A
+You’ll need to have been living in Denmark for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+
+You’ll need to provide supporting documents, including:
+
+- your passport
+- proof of residence, such as a residence certificate - check with the embassy to find out what you need
+- equivalent documents for your partner
+
+You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
 
 $C
-Consular / passport enquiries: consular.copenhagen@fco.gov.uk
-Telephone : +45 35 44 52 00
-
-Email: <Enquiry.Copenhagen@fco.gov.uk>
-
-[British Embassy Copenhagen - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-copenhagen/office/british-embassy)
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
+
+###What happens next
+
+The embassy will charge a fee for taking the oath, and then display your notice of marriage publicly for a further 7 days. They’ll then issue the CNI, as long as nobody has registered an objection. There’s an additional fee for this.
+
+You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in Denmark.
+
+^You don't need to stay in the country while your notice is posted.^
 
 ##Naturalisation of your partner if they move to the UK
 
@@ -38,11 +69,14 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
 
 Service | Fee
 -|-
+Receiving a notice of marriage | £65
 Issuing a CNI, Nulla Osta or equivalent | £65
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Denmark](/government/publications/denmark-consular-fees).
 
 You can pay by cash or credit card, but not by personal cheque.
+
+*[CNI]:certificate of no impediment
 
 
 

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_other/opposite_sex.txt
@@ -8,8 +8,6 @@ Contact the relevant local authorities in Denmark to find out about local marria
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
-
 To get a CNI, you must post notice of your intended marriage in Denmark. You can do this at the British embassy or in front of a notary public.
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -37,6 +35,17 @@ If you or your partner have been divorced, widowed or previously in a civil part
 - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
 
 ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.^
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
+
+$C
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
+$C
 
 ###What happens next
 

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_other/same_sex.txt
@@ -6,29 +6,60 @@ Same-sex relationships in Denmark that are recognised as civil partnerships unde
 - ’registreret partnerskab’ (’registered partnership’)
 - ‘nalunaarsukkamik inooqatigiinneq’ (in Greenland)
 
-Contact the relevant local authorities in Denmark to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Denmark to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Denmark.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+To get a CNI, you must post notice of your intended marriage in Denmark. You can do this at the British embassy or in front of a notary public.
 
-$A
-British Embassy Copenhagen
-Kastelsvej 36-40
-DK-2100  Copenhagen
-Denmark
-$A
+You’ll need to have been living in Denmark for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+
+You’ll need to provide supporting documents, including:
+
+- your passport
+- proof of residence, such as a residence certificate - check with the embassy to find out what you need
+- equivalent documents for your partner
+
+You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
 
 $C
-Consular / passport enquiries: consular.copenhagen@fco.gov.uk
-Telephone : +45 35 44 52 00
-
-Email: <Enquiry.Copenhagen@fco.gov.uk>
-
-[British Embassy Copenhagen - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-copenhagen/office/british-embassy)
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
+
+###What happens next
+
+The embassy will charge a fee for taking the oath, and then display your notice of marriage publicly for a further 7 days. They’ll then issue the CNI, as long as nobody has registered an objection. There’s an additional fee for this.
+
+You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in Denmark.
+
+^You don't need to stay in the country while your notice is posted.^
 
 ##Naturalisation of your partner if they move to the UK
 
@@ -38,11 +69,14 @@ Your partner can apply to [become a British citizen](/becoming-a-british-citizen
 
 Service | Fee
 -|-
+Receiving a notice of marriage | £65
 Issuing a CNI, Nulla Osta or equivalent | £65
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Denmark](/government/publications/denmark-consular-fees).
 
 You can pay by cash or credit card, but not by personal cheque.
+
+*[CNI]:certificate of no impediment
 
 
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_british/opposite_sex.txt
@@ -8,17 +8,13 @@ Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-t
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
-
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Denmark at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
+You should check if your CNI needs to be:
 
 - ‘[legalised](/get-document-legalised)’ (certified as genuine)
 - translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
@@ -26,6 +22,17 @@ You should also check if it needs to be:
 You should also check with the local authorities in Denmark to find out if you need to provide legalised and translated copies of any other documents.
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
+
+$C
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
+$C
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Denmark](/government/publications/denmark-consular-fees).
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_british/same_sex.txt
@@ -6,41 +6,45 @@ Same-sex relationships in Denmark that are recognised as civil partnerships unde
 - ’registreret partnerskab’ (’registered partnership’)
 - ‘nalunaarsukkamik inooqatigiinneq’ (in Greenland)
 
-Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
+Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-You should also check the [travel advice for Denmark](/foreign-travel-advice/denmark).
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Denmark](/foreign-travel-advice/denmark) before making any plans.
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Denmark.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-$A
-British Embassy Copenhagen
-Kastelsvej 36-40
-DK-2100  Copenhagen
-Denmark
-$A
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
+
+###Legalisation and translation
+
+You should check if your CNI needs to be:
+
+- ‘[legalised](/get-document-legalised)’ (certified as genuine)
+- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
+
+You should also check with the local authorities in Denmark to find out if you need to provide legalised and translated copies of any other documents.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
 
 $C
-Consular / passport enquiries: consular.copenhagen@fco.gov.uk
-Telephone : +45 35 44 52 00
-
-Email: <Enquiry.Copenhagen@fco.gov.uk>
-
-[British Embassy Copenhagen - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-copenhagen/office/british-embassy)
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
-
-## Fees
-
-Service | Fee
--|-
-Issuing a CNI, Nulla Osta or equivalent | £65
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Denmark](/government/publications/denmark-consular-fees).
 
 You can pay by cash or credit card, but not by personal cheque.
+
+*[CNI]:certificate of no impediment
 
 
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_local/opposite_sex.txt
@@ -8,17 +8,13 @@ Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-t
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
-
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Denmark at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
+You should check if your CNI needs to be:
 
 - ‘[legalised](/get-document-legalised)’ (certified as genuine)
 - translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
@@ -26,6 +22,17 @@ You should also check if it needs to be:
 You should also check with the local authorities in Denmark to find out if you need to provide legalised and translated copies of any other documents.
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
+
+$C
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
+$C
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_local/same_sex.txt
@@ -6,45 +6,49 @@ Same-sex relationships in Denmark that are recognised as civil partnerships unde
 - ’registreret partnerskab’ (’registered partnership’)
 - ‘nalunaarsukkamik inooqatigiinneq’ (in Greenland)
 
-Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
+Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-You should also check the [travel advice for Denmark](/foreign-travel-advice/denmark).
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Denmark](/foreign-travel-advice/denmark) before making any plans.
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Denmark.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-$A
-British Embassy Copenhagen
-Kastelsvej 36-40
-DK-2100  Copenhagen
-Denmark
-$A
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
+
+###Legalisation and translation
+
+You should check if your CNI needs to be:
+
+- ‘[legalised](/get-document-legalised)’ (certified as genuine)
+- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
+
+You should also check with the local authorities in Denmark to find out if you need to provide legalised and translated copies of any other documents.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
 
 $C
-Consular / passport enquiries: consular.copenhagen@fco.gov.uk
-Telephone : +45 35 44 52 00
-
-Email: <Enquiry.Copenhagen@fco.gov.uk>
-
-[British Embassy Copenhagen - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-copenhagen/office/british-embassy)
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
-## Fees
-
-Service | Fee
--|-
-Issuing a CNI, Nulla Osta or equivalent | £65
-
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Denmark](/government/publications/denmark-consular-fees).
 
 You can pay by cash or credit card, but not by personal cheque.
+
+*[CNI]:certificate of no impediment
 
 
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_other/opposite_sex.txt
@@ -8,17 +8,13 @@ Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-t
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
-
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Denmark at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
+You should check if your CNI needs to be:
 
 - ‘[legalised](/get-document-legalised)’ (certified as genuine)
 - translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
@@ -26,6 +22,17 @@ You should also check if it needs to be:
 You should also check with the local authorities in Denmark to find out if you need to provide legalised and translated copies of any other documents.
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
+
+$C
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
+$C
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_other/same_sex.txt
@@ -6,45 +6,49 @@ Same-sex relationships in Denmark that are recognised as civil partnerships unde
 - ’registreret partnerskab’ (’registered partnership’)
 - ‘nalunaarsukkamik inooqatigiinneq’ (in Greenland)
 
-Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
+Contact the [Embassy of Denmark](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-You should also check the [travel advice for Denmark](/foreign-travel-advice/denmark).
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Denmark](/foreign-travel-advice/denmark) before making any plans.
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Denmark.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-$A
-British Embassy Copenhagen
-Kastelsvej 36-40
-DK-2100  Copenhagen
-Denmark
-$A
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
+
+###Legalisation and translation
+
+You should check if your CNI needs to be:
+
+- ‘[legalised](/get-document-legalised)’ (certified as genuine)
+- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
+
+You should also check with the local authorities in Denmark to find out if you need to provide legalised and translated copies of any other documents.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+###No trace letters
+
+The Danish authorities will sometimes accept a ‘no trace letter’ instead of a CNI. Check with the Danish authorities to find out if they’ll accept a ‘no trace letter’.
+
+You can get a ‘no trace letter’ from the General Register Office. Ask them to make a search and quote reference ‘SEARCH 123’.
 
 $C
-Consular / passport enquiries: consular.copenhagen@fco.gov.uk
-Telephone : +45 35 44 52 00
-
-Email: <Enquiry.Copenhagen@fco.gov.uk>
-
-[British Embassy Copenhagen - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-copenhagen/office/british-embassy)
+**General Register Office**
+Telephone: +44 (0)300 123 1837 (8am to 8pm Monday to Friday and 9am to 4pm Saturday)
 $C
 
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
-## Fees
-
-Service | Fee
--|-
-Issuing a CNI, Nulla Osta or equivalent | £65
-
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Denmark](/government/publications/denmark-consular-fees).
 
 You can pay by cash or credit card, but not by personal cheque.
+
+*[CNI]:certificate of no impediment
 
 
 

--- a/test/data/marriage-abroad-responses-and-expected-results.yml
+++ b/test/data/marriage-abroad-responses-and-expected-results.yml
@@ -6463,7 +6463,7 @@
   - uk
   - partner_british
   - opposite_sex
-  :next_node: :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk_or_ceremony_country
+  :next_node: :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -6486,7 +6486,7 @@
   - uk
   - partner_local
   - opposite_sex
-  :next_node: :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk_or_ceremony_country
+  :next_node: :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -6509,7 +6509,7 @@
   - uk
   - partner_other
   - opposite_sex
-  :next_node: :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk_or_ceremony_country
+  :next_node: :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -6538,7 +6538,7 @@
   - ceremony_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk_or_ceremony_country
+  :next_node: :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -6561,7 +6561,7 @@
   - ceremony_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk_or_ceremony_country
+  :next_node: :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -6584,7 +6584,7 @@
   - ceremony_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk_or_ceremony_country
+  :next_node: :outcome_opposite_sex_marriage_in_denmark_when_residing_in_uk_or_denmark
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -56,7 +56,7 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
     next unless smart_answer_helper.run_regression_tests?
 
-    smart_answer_helper.delete_saved_output_files
+    # smart_answer_helper.delete_saved_output_files
     responses_and_expected_results = smart_answer_helper.read_responses_and_expected_results
 
     context "Smart Answer: #{flow_name}" do
@@ -119,6 +119,8 @@ class SmartAnswersRegressionTest < ActionController::TestCase
         next_node    = responses_and_expected_node[:next_node]
         responses    = responses_and_expected_node[:responses]
         outcome_node = responses_and_expected_node[:outcome_node]
+
+        next unless responses.first == 'denmark'
 
         if !visited_nodes.include?(next_node) || outcome_node
           visited_nodes << next_node


### PR DESCRIPTION
This PR demonstrates an approach to making marriage-abroad content changes by updating the regression test artefacts _first_.

We currently make these sort of changes by updating the flows/templates and then regenerating the regression test artefacts to confirm that the changes have had the desired effect. One of the problems with this approach is that it's not always easy/possible to see the effect of the changes by looking at the diff of the regression test artefacts. This, in combination with the overly complicated marriage-abroad code, makes it possible to commit unintentional changes to the rendered outcomes.

Updating the regression test artefacts first, and then updating the flows/templates, gives us confidence that the changes we make _only_ affect the things we want.

I chose a recent marriage-abroad content change (PR #2576) and have reimplemented it in this branch by updating the regression test artefacts first.

The branch contains a number of preparatory commits that aren't interesting when it comes to understanding this approach. These commits refactor the code (i.e. don't change behaviour and therefore don't result in changes to the regression test artefacts) to make the actual change easier.

The last 6 commits are the only ones of real interest:

1. Update marriage-abroad denmark/uk opposite sex test artefacts (https://github.com/alphagov/smart-answers/pull/2591/commits/72a4bd440953b2468ca6e0d5863c285aae9380c2)
  * Manually updates 3 regression test artefacts based on the requirements in the Google Doc.
  * Results in 3 failing regression tests. For paths containing "denmark/uk/*/opposite_sex".
2. Update marriage-abroad denmark/ceremony_country opposite sex test artefacts (https://github.com/alphagov/smart-answers/pull/2591/commits/1592f2b3b38acf541f1679deea3c5dc955363f55)
  * Manually updates 3 regression test artefacts based on the requirements in the Google Doc
  * Results in 3 more failing regression tests. For paths containing "denmark/ceremony_country/*/opposite_sex".
3. Make changes required by opposite sex cereonies in Denmark (https://github.com/alphagov/smart-answers/pull/2591/commits/de3b90942dae22d9b9de7c8d9de2fbe43a4db825)
  * Update the outcome template to fix the 6 failing regression tests.
4. Update marriage-abroad denmark/uk same-sex test artefacts (https://github.com/alphagov/smart-answers/pull/2591/commits/59d2c7756ec869baef584dbcdbcb52b4e8c498b8)
  * Manually updates 3 regression test artefacts based on the requirements in the Google Doc.
  * Results in 3 failing regression tests. For paths containing "denmark/uk/*/same_sex".
5. Update marriage-abroad denmark/ceremony_country same-sex test artefacts (https://github.com/alphagov/smart-answers/pull/2591/commits/a38a3a6664b18e1a049bf3914b7c505c3140e564)
  * Manually updates 3 regression test artefacts based on the requirements in the Google Doc.
  * Results in 3 more failing regression tests. For paths containing "denmark/ceremony_country/*/same_sex".
6. Make changes for same sex ceremonies in Denmark (https://github.com/alphagov/smart-answers/pull/2591/commits/42a424445a3cf88b7bc15788b61b697a8a47c191)
  * Update the flow, data and outcome to fix the 6 failing regression tests.

I think there's an additional benefit of this approach in that I can imagine helping the content team/department to make changes to the regression test artefacts directly; allowing us to remove the intermediate step of translating the requirements in a Google Doc.

What do you think, @ikennaokpala, @pmanrubia, @leenagupte and @floehopper? Does this seem like a good approach to you?

Note that while I've focussed on marriage-abroad, I can't see any reason we can't use this approach for all these sort of content changes.
