### PR TITLE
Avoid using worldwide API helpers in regression tests

### DIFF
--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -9,10 +9,12 @@ require 'webmock'
 WebMock.disable_net_connect!(allow_localhost: true)
 
 require_relative '../support/fixture_methods'
+require_relative '../support/world_location_stubbing_methods'
 
 require 'gds_api/test_helpers/content_api'
-require 'gds_api/test_helpers/worldwide'
 require 'gds_api/test_helpers/imminence'
+
+require 'mocha/api'
 
 class SmartAnswersRegressionTest < ActionController::TestCase
   i_suck_and_my_tests_are_order_dependent!
@@ -41,10 +43,11 @@ class SmartAnswersRegressionTest < ActionController::TestCase
   end
 
   include GdsApi::TestHelpers::ContentApi
-  include GdsApi::TestHelpers::Worldwide
   include GdsApi::TestHelpers::Imminence
   include WebMock::API
   include FixtureMethods
+  include Mocha::API
+  include WorldLocationStubbingMethods
 
   tests SmartAnswersController
 
@@ -151,13 +154,6 @@ private
 
   def setup_worldwide_locations
     location_slugs = YAML.load(read_fixture_file("worldwide_locations.yml"))
-    worldwide_api_has_locations(location_slugs)
-    location_slugs.each do |location|
-      path_to_organisations_fixture = fixture_file("worldwide/#{location}_organisations.json")
-      if File.exist?(path_to_organisations_fixture)
-        json = File.read(path_to_organisations_fixture)
-        worldwide_api_has_organisations_for_location(location, json)
-      end
-    end
+    stub_world_locations(location_slugs, load_fco_organisation_data: true)
   end
 end

--- a/test/support/world_location_stubbing_methods.rb
+++ b/test/support/world_location_stubbing_methods.rb
@@ -1,21 +1,44 @@
 require 'gds_api/test_helpers/common_responses'
+require 'gds_api/response'
 
 module WorldLocationStubbingMethods
   include GdsApi::TestHelpers::CommonResponses
 
-  def stub_world_location(location_slug)
+  def stub_world_location(location_slug, load_fco_organisation_data: false)
     location = stub.quacks_like(WorldLocation.new({}))
     location.stubs(:slug).returns(location_slug)
     name = titleize_slug(location_slug, title_case: true)
     location.stubs(:name).returns(name)
-    location.stubs(:fco_organisation).returns(nil)
+
+    fco_organisation = nil
+    if load_fco_organisation_data
+      path_to_organisations_fixture = fixture_file("worldwide/#{location_slug}_organisations.json")
+      if File.exist?(path_to_organisations_fixture)
+        json = File.read(path_to_organisations_fixture)
+        data = JSON.parse(json)
+        organisations_data = data['results']
+
+        fco_organisation_data = organisations_data.find do |organisation_data|
+          organisation_data['sponsors'].find do |sponsor_data|
+            sponsor_data['details']['acronym'] == 'FCO'
+          end
+        end
+
+        if fco_organisation_data
+          ostruct = GdsApi::Response.build_ostruct_recursively(fco_organisation_data)
+          fco_organisation = WorldwideOrganisation.new(ostruct)
+        end
+      end
+    end
+    location.stubs(:fco_organisation).returns(fco_organisation)
+
     WorldLocation.stubs(:find).with(location_slug).returns(location)
     location
   end
 
-  def stub_world_locations(location_slugs)
+  def stub_world_locations(location_slugs, load_fco_organisation_data: false)
     locations = location_slugs.map do |slug|
-      stub_world_location(slug)
+      stub_world_location(slug, load_fco_organisation_data: load_fco_organisation_data)
     end
     WorldLocation.stubs(:all).returns(locations)
   end


### PR DESCRIPTION
Trello card: https://trello.com/c/Hiizo5g6

This follows on from the work in PRs #2540 and #2555 and applies the same
changes to the regression tests.

Switching from WebMock to Mocha appears to reduce the time taken to run all
regression tests by about 15 minutes on my machine.

== Regression test duration before this commit:

    $ time RUN_REGRESSION_TESTS=true \
    ruby -Itest test/regression/smart_answers_regression_test.rb

    real  56m34.146s
    user  45m49.017s
    sys   9m19.234s

== Regression test duration after this commit:

    $ time RUN_REGRESSION_TESTS=true \
    ruby -Itest test/regression/smart_answers_regression_test.rb

    real  36m29.928s
    user  27m45.692s
    sys   8m33.085s

== Notes

The main difference between this and PRs #2540 and #2555 is that a number of
the regression tests rely on `WorldLocation#fco_organisation` returning a
`WorldwideOrganisation` rather than nil. I've satisfied this requirement by
adding the optional `load_fco_organisation_data` parameter to both
`#stub_world_locations` and `#stub_world_location`, and loading the FCO data
when the parameter is true.

The implementation in `#stub_world_location` uses the organisation data that
was previously being used in `#setup_worldwide_locations`. I've reimplemented
the logic from `WorldwideOrganisation#fco_sponsored?` by querying the
`organisations_data` hash. On finding an FCO organisation in the data I use
`GdsApi::Response.build_ostruct_recursively` to turn it into a "deep"
openstruct that can be passed to the `WorldwideOrganisation` initializer.

I was using the Hashugar Gem to create the "deep" openstruct before @floehopper
pointed out the code in `GdsApi::Response`.

I experimented with _always_ loading the FCO organisation data in
`stub_world_location` but this resulted in the non-regression tests taking an
additional couple of minutes to run on my machine.