### PR TITLE
Content changes to PIP checker (29 june release)

### DIFF
--- a/lib/smart_answer_flows/pip-checker/outcomes/qualifies_for_pip_at_16.govspeak.erb
+++ b/lib/smart_answer_flows/pip-checker/outcomes/qualifies_for_pip_at_16.govspeak.erb
@@ -5,6 +5,8 @@
 
    * shortly after your 16th birthday
 
+   * when you leave hospital, if you were in hospital on your 16th birthday
+
    * about 20 weeks before your DLA award ends, if you were awarded DLA under the rules for people who are terminally ill
 
   You must claim PIP within 28 days of the date on the letter.

--- a/test/artefacts/pip-checker/yes/2000-04-05.txt
+++ b/test/artefacts/pip-checker/yes/2000-04-05.txt
@@ -6,6 +6,8 @@ If you’re still getting [Disability Living Allowance (DLA)](/disability-living
 
 * shortly after your 16th birthday
 
+* when you leave hospital, if you were in hospital on your 16th birthday
+
 * about 20 weeks before your DLA award ends, if you were awarded DLA under the rules for people who are terminally ill
 
 You must claim PIP within 28 days of the date on the letter.

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -7,7 +7,7 @@ lib/smart_answer_flows/pip-checker/outcomes/no_claim_for_dla.govspeak.erb: 31468
 lib/smart_answer_flows/pip-checker/outcomes/over_65.govspeak.erb: 110dd1d34a19961fdc2c18bad5edf2ca
 lib/smart_answer_flows/pip-checker/outcomes/over_65_in_2013.govspeak.erb: cc30663895d9934cd052bf304caf7488
 lib/smart_answer_flows/pip-checker/outcomes/qualifies_for_pip.govspeak.erb: a132eb9126e114790e5d43fbb679a4dd
-lib/smart_answer_flows/pip-checker/outcomes/qualifies_for_pip_at_16.govspeak.erb: 39e83b195e42ddca955289316bff2832
+lib/smart_answer_flows/pip-checker/outcomes/qualifies_for_pip_at_16.govspeak.erb: 27c9fc85e99d49faea80a7aac17cc723
 lib/smart_answer_flows/pip-checker/outcomes/under_16.govspeak.erb: 39378651df7f8e02c45f1ed5cb5d1a05
 lib/smart_answer_flows/pip-checker/pip_checker.govspeak.erb: 05500842dad33cd660d3387925a3d5e9
 lib/smart_answer_flows/pip-checker/questions/are_you_getting_dla.govspeak.erb: 0668b501c4ad913dbbf0e8ffc8af59bb


### PR DESCRIPTION
[Trello Card](https://trello.com/c/oiF97JOL/111-pip-checker)

#### This PR is a follow up of #2482 and can only be merged after #2482 has been merged 

After the merge of #2482.. kindly rebase with master.

The commits that concern this PR are 73f280e...80f2532


* Content changes to PIP Checker from page 4 of this document 
 https://docs.google.com/document/d/1KbYzCS0Weq0t_YQpmuVebkSPP0AgObq6ZqT5RSw3p2Q/edit
 
## Factcheck
[Preview Link](https://smart-answers-pr-2595.herokuapp.com/pip-checker/y/yes/2000-04-05)
[GOV.UK](https://gov.uk/pip-checker/y/yes/2000-04-05)

### Expected changes
*  Content changes to the qualifies_for_pip_at_16 template

### Before

![screen shot 2016-06-23 at 15 09 37](https://cloud.githubusercontent.com/assets/84896/16306116/8a2371b6-3954-11e6-8724-cabc1f6576c5.png)


### After

![screen shot 2016-06-23 at 15 09 08](https://cloud.githubusercontent.com/assets/84896/16306121/91b0c974-3954-11e6-9a62-31501da4509a.png)
