### PR TITLE
Remove hyphen from "re-generate", "re-generates" & "re-generating" in documentation

### DIFF
--- a/doc/merging-content-prs.md
+++ b/doc/merging-content-prs.md
@@ -17,7 +17,7 @@ $ git co -b <branch-on-local-repo> <owner-of-forked-repo>/<branch-on-forked-repo
 
 2. Review the changes in the commit(s)
 3. Remove any trailing whitespace
-4. Run the following command to re-generate the Govspeak artefacts (in `test/artefacts/<smart-answer-flow-name>`) for the regression tests:
+4. Run the following command to regenerate the Govspeak artefacts (in `test/artefacts/<smart-answer-flow-name>`) for the regression tests:
 
 ```bash
 $ RUN_REGRESSION_TESTS=<smart-answer-flow-name> ruby test/regression/smart_answers_regression_test.rb

--- a/doc/regression-tests.md
+++ b/doc/regression-tests.md
@@ -112,7 +112,7 @@ Note that the `RUN_REGRESSION_TESTS` environment variable can also be used in co
 
 By default most of the assertions in the regression tests are combined into a single assertion at the end. If you want the regression tests to fail fast then set `ASSERT_EACH_ARTEFACT=true`. However, you should note that this more than doubles the time it takes them to run.
 
-Running the test re-generates a set of HTML/Govspeak files in `test/artefacts` based on the files in `test/data` and these are compared against the files in same directory in the git repository i.e. the *committed* versions of the files.
+Running the test regenerates a set of HTML/Govspeak files in `test/artefacts` based on the files in `test/data` and these are compared against the files in same directory in the git repository i.e. the *committed* versions of the files.
 
 ## Making changes
 
@@ -184,9 +184,9 @@ The Unix `tree` command can be used to generate an ASCII-art view of the relevan
 It should be obvious from the [Structuring commits](#structuring-commits) & [Artefact changes](#artefact-changes) sections above that there isn't one "correct" way to organise your commits in a pull request. However, as a starting point, here are the steps you might use to implement a simple content change:
 
 1. Make the change to the relevant template file
-2. [Run the regression tests](#running-regression-tests) thus re-generating the artefacts
+2. [Run the regression tests](#running-regression-tests) thus regenerating the artefacts
 3. Review the changes to the [artefacts](#artefact-files) and check they are as you expect
-4. If artefact changes are as expected, [re-generate the checksums](#checksum-file)
+4. If artefact changes are as expected, [regenerate the checksums](#checksum-file)
 5. Commit all the changes with a suitable explanation in the commit note
 6. Run the regression tests and check they all pass
 


### PR DESCRIPTION
## Description

This addresses the feedback in [this comment][1].

## External changes

None. This is just a documentation change.

[1]: https://github.com/alphagov/smart-answers/pull/2599/files/9d34b3afd93c058e940c61a30b197421fb6f69d0#r68589448