### PR TITLE
Updates to student finance form finder

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_continuing.govspeak.erb
@@ -10,8 +10,11 @@
   2016 to 2017 | [EUPTLC - form (PDF, 613KB)](http://media.slc.co.uk/sfe/1617/eu/eu_ptlc_form_1617_d.pdf)
   2016 to 2017 | [EUPTLC - guidance notes (PDF, 96KB)](http://media.slc.co.uk/sfe/1617/eu/eu_ptlc_notes_1617_d.pdf)
 
-  If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant. The application forms will be available later in the summer.
-
+  If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant. 
+  
+  **Academic year** | **Form** |-
+  2016 to 2017 | [EUPTG1 - form (PDF, 613KB)](http://media.slc.co.uk/sfe/1617/eu/eu_ptg1_form_1617_d.pdf)
+  2016 to 2017 | [EUPTG1 - guidance notes (PDF, 483KB)](http://media.slc.co.uk/sfe/1617/eu/eu_ptg1_notes_1617_d.pdf)
 
   ##Additional information
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant.govspeak.erb
@@ -12,6 +12,14 @@ To apply for a Fee Grant and Course Grant download and fill in form PTGC.
 
 You can apply up to 9 months after your course starts.
 
+##If you're applying for student finance for the first time
+
+To apply for a Fee Grant and Course Grant for the first time download and fill in form PTGN.
+
+**Academic year** | **Form** |-
+2016 to 2017 | [PTGN - form (PDF, 615KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_ptgn_form_1617_d.pdf)
+2016 to 2017 | [PTGN - guidance notes (PDF, 100KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_ptgn_notes_1617_d.pdf)
+
 ##You or your partner get benefits
 
 You need to download and fill in [form CB1 (PDF, 463KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_cb1_form_1617_d.pdf) if you or your partner gets:

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant.govspeak.erb
@@ -12,14 +12,6 @@ To apply for a Fee Grant and Course Grant download and fill in form PTGC.
 
 You can apply up to 9 months after your course starts.
 
-##If you're applying for student finance for the first time
-
-To apply for a Fee Grant and Course Grant for the first time download and fill in form PTGN.
-
-**Academic year** | **Form** |-
-2016 to 2017 | [PTGN - form (PDF, 615KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_ptgn_form_1617_d.pdf)
-2016 to 2017 | [PTGN - guidance notes (PDF, 100KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_ptgn_notes_1617_d.pdf)
-
 ##You or your partner get benefits
 
 You need to download and fill in [form CB1 (PDF, 463KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_cb1_form_1617_d.pdf) if you or your partner gets:

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant.govspeak.erb
@@ -1,5 +1,34 @@
-<% content_for :body do %>
+<% content_for :title do %>
+Student finance - application form
+<% end %>
   
-  The forms to apply for a Fee Grant and Course Grant will be available later in the summer. 
+<% content_for :body do %>
+
+To apply for a Fee Grant and Course Grant download and fill in form PTGC.
+
+**Academic year** | **Form** |-
+2016 to 2017 | [PTGC - form (PDF, 400KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_ptgc_form_1617_d.pdf)
+2016 to 2017 | [PTGC - guidance notes (PDF, 100KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_ptgc_notes_1617_d.pdf)
+
+You can apply up to 9 months after your course starts.
+
+##You or your partner get benefits
+
+You need to download and fill in [form CB1 (PDF, 463KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_cb1_form_1617_d.pdf) if you or your partner gets:
+
+- Universal Credit
+- Income Support
+- Income-based Jobseeker’s Allowance (JSA)
+- Income-related Employment Support Allowance (ESA)
+- Housing Benefit
+- Local Housing Allowance
+
+##Your circumstances have changed
+
+You need to download and fill in [form CO2 (PDF, 98KB)](http://media.slc.co.uk/sfe/1617/pt/sfe_co2_form_1617_d.pdf) if you’ve changed:
+
+- your course, or left it
+- university or college
+- your name, address or contact details
 
 <% end %>


### PR DESCRIPTION
Zen: https://govuk.zendesk.com/agent/tickets/1333717

These need to go live for July 11. 

I've updated 2 outcomes as per SLC's request. Grant applications for part-time students open on July 11, so I've added the requested forms and text.

Part of these changes also require a logic tweak and a new outcome to be added - I've added a Google Doc to the ticket on the Dev Trello which explains this. 

