### PR TITLE
Refactor register-a-birth to new-style flow

### DIFF
--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -7,6 +7,7 @@ module SmartAnswer::Calculators
     attr_accessor :married_couple_or_civil_partnership
     attr_accessor :childs_date_of_birth
     attr_accessor :current_location
+    attr_accessor :current_country
 
     def initialize
       @reg_data_query = RegistrationsDataQuery.new

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -48,5 +48,9 @@ module SmartAnswer::Calculators
     def in_the_uk?
       current_location == 'in_the_uk'
     end
+
+    def no_birth_certificate_exception?
+      @reg_data_query.has_birth_registration_exception?(country_of_birth) & paternity_declaration?
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -3,6 +3,7 @@ module SmartAnswer::Calculators
     include ActiveModel::Model
 
     attr_accessor :country_of_birth
+    attr_accessor :british_national_parent
 
     def initialize
       @reg_data_query = RegistrationsDataQuery.new

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -5,6 +5,7 @@ module SmartAnswer::Calculators
     attr_accessor :country_of_birth
     attr_accessor :british_national_parent
     attr_accessor :married_couple_or_civil_partnership
+    attr_accessor :childs_date_of_birth
 
     def initialize
       @reg_data_query = RegistrationsDataQuery.new

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -81,5 +81,9 @@ module SmartAnswer::Calculators
     def fee_for_copy_of_birth_registration_certificate
       @reg_data_query.register_a_birth_fees.copy_of_birth_registration_certificate
     end
+
+    def document_return_fees
+      @reg_data_query.document_return_fees
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -6,6 +6,7 @@ module SmartAnswer::Calculators
     attr_accessor :british_national_parent
     attr_accessor :married_couple_or_civil_partnership
     attr_accessor :childs_date_of_birth
+    attr_accessor :current_location
 
     def initialize
       @reg_data_query = RegistrationsDataQuery.new

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -44,5 +44,9 @@ module SmartAnswer::Calculators
     def another_country?
       current_location == 'another_country'
     end
+
+    def in_the_uk?
+      current_location == 'in_the_uk'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -57,5 +57,10 @@ module SmartAnswer::Calculators
     def born_in_north_korea?
       country_of_birth == 'north-korea'
     end
+
+    def currently_in_north_korea?
+      # TODO: current_country == 'north-korea'
+      nil == 'north-korea'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -66,6 +66,10 @@ module SmartAnswer::Calculators
       nil == 'north-korea'
     end
 
+    def british_national_father?
+      british_national_parent == 'father'
+    end
+
     def overseas_passports_embassies
       location = WorldLocation.find(registration_country)
       organisations = [location.fco_organisation]

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -3,5 +3,13 @@ module SmartAnswer::Calculators
     include ActiveModel::Model
 
     attr_accessor :country_of_birth
+
+    def initialize
+      @reg_data_query = RegistrationsDataQuery.new
+    end
+
+    def registration_country
+      @reg_data_query.registration_country_slug(country_of_birth)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -95,6 +95,10 @@ module SmartAnswer::Calculators
       @reg_data_query.lower_risk_country?(country_of_birth)
     end
 
+    def higher_risk_country?
+      @reg_data_query.higher_risk_country?(registration_country)
+    end
+
     def translator_link_url
       @translator_query.links[country_of_birth]
     end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -111,6 +111,10 @@ module SmartAnswer::Calculators
       @reg_data_query.oru_courier_variant?(registration_country)
     end
 
+    def oru_courier_by_high_commission?
+      @reg_data_query.oru_courier_by_high_commission?(registration_country)
+    end
+
     def translator_link_url
       @translator_query.links[country_of_birth]
     end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -16,5 +16,9 @@ module SmartAnswer::Calculators
     def registration_country_name_lowercase_prefix
       @country_name_query.definitive_article(registration_country)
     end
+
+    def country_has_no_embassy?
+      %w(iran syria yemen).include?(country_of_birth)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -103,6 +103,10 @@ module SmartAnswer::Calculators
       @reg_data_query.oru_documents_variant_for_birth?(country_of_birth)
     end
 
+    def may_require_dna_tests?
+      @reg_data_query.may_require_dna_tests?(country_of_birth)
+    end
+
     def translator_link_url
       @translator_query.links[country_of_birth]
     end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -12,6 +12,7 @@ module SmartAnswer::Calculators
     def initialize
       @reg_data_query = RegistrationsDataQuery.new
       @country_name_query = CountryNameFormatter.new
+      @translator_query = TranslatorLinks.new
     end
 
     def registration_country
@@ -92,6 +93,10 @@ module SmartAnswer::Calculators
 
     def born_in_lower_risk_country?
       @reg_data_query.lower_risk_country?(country_of_birth)
+    end
+
+    def translator_link_url
+      @translator_query.links[country_of_birth]
     end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -85,5 +85,9 @@ module SmartAnswer::Calculators
     def document_return_fees
       @reg_data_query.document_return_fees
     end
+
+    def custom_waiting_time
+      @reg_data_query.custom_registration_duration(country_of_birth)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -89,5 +89,9 @@ module SmartAnswer::Calculators
     def custom_waiting_time
       @reg_data_query.custom_registration_duration(country_of_birth)
     end
+
+    def born_in_lower_risk_country?
+      @reg_data_query.lower_risk_country?(country_of_birth)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -65,7 +65,6 @@ module SmartAnswer::Calculators
 
     def overseas_passports_embassies
       location = WorldLocation.find(registration_country)
-      raise SmartAnswer::InvalidResponse unless location
       organisations = [location.fco_organisation]
       if organisations && organisations.any?
         service_title = 'Births and Deaths registration service'

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -1,5 +1,7 @@
 module SmartAnswer::Calculators
   class RegisterABirthCalculator
     include ActiveModel::Model
+
+    attr_accessor :country_of_birth
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -73,5 +73,13 @@ module SmartAnswer::Calculators
         []
       end
     end
+
+    def fee_for_registering_a_birth
+      @reg_data_query.register_a_birth_fees.register_a_birth
+    end
+
+    def fee_for_copy_of_birth_registration_certificate
+      @reg_data_query.register_a_birth_fees.copy_of_birth_registration_certificate
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -50,7 +50,7 @@ module SmartAnswer::Calculators
     end
 
     def no_birth_certificate_exception?
-      @reg_data_query.has_birth_registration_exception?(country_of_birth) & paternity_declaration?
+      @reg_data_query.has_birth_registration_exception?(country_of_birth) && paternity_declaration?
     end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -15,7 +15,7 @@ module SmartAnswer::Calculators
     end
 
     def registration_country
-      @reg_data_query.registration_country_slug(country_of_birth)
+      @reg_data_query.registration_country_slug(current_country || country_of_birth)
     end
 
     def registration_country_name_lowercase_prefix

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -107,6 +107,10 @@ module SmartAnswer::Calculators
       @reg_data_query.may_require_dna_tests?(country_of_birth)
     end
 
+    def oru_courier_variant?
+      @reg_data_query.oru_courier_variant?(registration_country)
+    end
+
     def translator_link_url
       @translator_query.links[country_of_birth]
     end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -99,6 +99,10 @@ module SmartAnswer::Calculators
       @reg_data_query.higher_risk_country?(registration_country)
     end
 
+    def oru_documents_variant_for_birth?
+      @reg_data_query.oru_documents_variant_for_birth?(country_of_birth)
+    end
+
     def translator_link_url
       @translator_query.links[country_of_birth]
     end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -1,0 +1,5 @@
+module SmartAnswer::Calculators
+  class RegisterABirthCalculator
+    include ActiveModel::Model
+  end
+end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -31,5 +31,9 @@ module SmartAnswer::Calculators
     def paternity_declaration?
       married_couple_or_civil_partnership == 'no'
     end
+
+    def before_july_2006?
+      Date.new(2006, 07, 01) > childs_date_of_birth
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -36,5 +36,9 @@ module SmartAnswer::Calculators
     def before_july_2006?
       Date.new(2006, 07, 01) > childs_date_of_birth
     end
+
+    def same_country?
+      current_location == 'same_country'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -26,5 +26,9 @@ module SmartAnswer::Calculators
     def responded_with_commonwealth_country?
       RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(country_of_birth)
     end
+
+    def paternity_declaration?
+      married_couple_or_civil_partnership == 'no'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -2,6 +2,8 @@ module SmartAnswer::Calculators
   class RegisterABirthCalculator
     include ActiveModel::Model
 
+    EXCLUDE_COUNTRIES = %w(holy-see british-antarctic-territory)
+
     attr_accessor :country_of_birth
     attr_accessor :british_national_parent
     attr_accessor :married_couple_or_civil_partnership

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -6,10 +6,15 @@ module SmartAnswer::Calculators
 
     def initialize
       @reg_data_query = RegistrationsDataQuery.new
+      @country_name_query = CountryNameFormatter.new
     end
 
     def registration_country
       @reg_data_query.registration_country_slug(country_of_birth)
+    end
+
+    def registration_country_name_lowercase_prefix
+      @country_name_query.definitive_article(registration_country)
     end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -40,5 +40,9 @@ module SmartAnswer::Calculators
     def same_country?
       current_location == 'same_country'
     end
+
+    def another_country?
+      current_location == 'another_country'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -62,5 +62,17 @@ module SmartAnswer::Calculators
       # TODO: current_country == 'north-korea'
       nil == 'north-korea'
     end
+
+    def overseas_passports_embassies
+      location = WorldLocation.find(registration_country)
+      raise SmartAnswer::InvalidResponse unless location
+      organisations = [location.fco_organisation]
+      if organisations && organisations.any?
+        service_title = 'Births and Deaths registration service'
+        organisations.first.offices_with_service(service_title)
+      else
+        []
+      end
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -20,5 +20,9 @@ module SmartAnswer::Calculators
     def country_has_no_embassy?
       %w(iran syria yemen).include?(country_of_birth)
     end
+
+    def responded_with_commonwealth_country?
+      RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(country_of_birth)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -52,5 +52,9 @@ module SmartAnswer::Calculators
     def no_birth_certificate_exception?
       @reg_data_query.has_birth_registration_exception?(country_of_birth) && paternity_declaration?
     end
+
+    def born_in_north_korea?
+      country_of_birth == 'north-korea'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -4,6 +4,7 @@ module SmartAnswer::Calculators
 
     attr_accessor :country_of_birth
     attr_accessor :british_national_parent
+    attr_accessor :married_couple_or_civil_partnership
 
     def initialize
       @reg_data_query = RegistrationsDataQuery.new

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -6,6 +6,7 @@ module SmartAnswer
       status :published
       satisfies_need "101003"
 
+      country_name_query = Calculators::CountryNameFormatter.new
       reg_data_query = Calculators::RegistrationsDataQuery.new
       translator_query = Calculators::TranslatorLinks.new
       exclude_countries = %w(holy-see british-antarctic-territory)
@@ -25,16 +26,12 @@ module SmartAnswer
           calculator.registration_country_name_lowercase_prefix
         end
 
-        next_node_calculation :country_has_no_embassy do
-          %w(iran syria yemen).include?(calculator.country_of_birth)
-        end
-
         next_node_calculation :responded_with_commonwealth_country do
           Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(calculator.country_of_birth)
         end
 
         next_node do
-          if country_has_no_embassy
+          if calculator.country_has_no_embassy?
             outcome :no_embassy_result
           elsif responded_with_commonwealth_country
             outcome :commonwealth_result

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -104,10 +104,6 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        calculate :in_the_uk do |response|
-          calculator.current_location == 'in_the_uk'
-        end
-
         next_node_calculation(:no_birth_certificate_exception) {
           reg_data_query.has_birth_registration_exception?(calculator.country_of_birth) & calculator.paternity_declaration?
         }

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -23,7 +23,7 @@ module SmartAnswer
         end
 
         calculate :registration_country_name_lowercase_prefix do
-          country_name_query.definitive_article(calculator.registration_country)
+          calculator.registration_country_name_lowercase_prefix
         end
 
         next_node_calculation :country_has_no_embassy do

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -68,7 +68,7 @@ module SmartAnswer
         end
 
         next_node do
-          if calculator.married_couple_or_civil_partnership == 'no' && calculator.british_national_parent == 'father'
+          if calculator.paternity_declaration? && calculator.british_national_parent == 'father'
             question :childs_date_of_birth?
           else
             question :where_are_you_now?

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -132,10 +132,6 @@ module SmartAnswer
           reg_data_query
         end
 
-        precalculate :born_in_lower_risk_country do
-          reg_data_query.lower_risk_country?(calculator.country_of_birth)
-        end
-
         precalculate :translator_link_url do
           translator_query.links[calculator.country_of_birth]
         end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -44,7 +44,9 @@ module SmartAnswer
         option :mother_and_father
         option :neither
 
-        save_input_as :british_national_parent
+        on_response do |response|
+          calculator.british_national_parent = response
+        end
 
         next_node do |response|
           case response
@@ -66,7 +68,7 @@ module SmartAnswer
         end
 
         next_node do |response|
-          if response == 'no' && british_national_parent == 'father'
+          if response == 'no' && calculator.british_national_parent == 'father'
             question :childs_date_of_birth?
           else
             question :where_are_you_now?

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -187,7 +187,7 @@ module SmartAnswer
       outcome :homeoffice_result
       outcome :no_birth_certificate_result do
         precalculate :overseas_passports_embassies do
-          location = WorldLocation.find(calculator.country_of_birth)
+          location = WorldLocation.find(calculator.registration_country)
           raise InvalidResponse unless location
           organisations = [location.fco_organisation]
           if organisations && organisations.any?

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -164,17 +164,10 @@ module SmartAnswer
           reg_data_query.lower_risk_country?(calculator.country_of_birth)
         end
 
-        precalculate :location do
-          loc = WorldLocation.find(calculator.registration_country)
-          raise InvalidResponse unless loc
-          loc
-        end
-
-        precalculate :organisations do
-          [location.fco_organisation]
-        end
-
         precalculate :overseas_passports_embassies do
+          location = WorldLocation.find(calculator.registration_country)
+          raise InvalidResponse unless location
+          organisations = [location.fco_organisation]
           if organisations && organisations.any?
             service_title = 'Births and Deaths registration service'
             organisations.first.offices_with_service(service_title)
@@ -193,17 +186,10 @@ module SmartAnswer
       outcome :no_embassy_result
       outcome :homeoffice_result
       outcome :no_birth_certificate_result do
-        precalculate :location do
-          loc = WorldLocation.find(calculator.country_of_birth)
-          raise InvalidResponse unless loc
-          loc
-        end
-
-        precalculate :organisations do
-          [location.fco_organisation]
-        end
-
         precalculate :overseas_passports_embassies do
+          location = WorldLocation.find(calculator.country_of_birth)
+          raise InvalidResponse unless location
+          organisations = [location.fco_organisation]
           if organisations && organisations.any?
             service_title = 'Births and Deaths registration service'
             organisations.first.offices_with_service(service_title)

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -123,8 +123,8 @@ module SmartAnswer
           calculator.current_country = response
         end
 
-        calculate :registration_country do |response|
-          reg_data_query.registration_country_slug(response)
+        calculate :registration_country do
+          calculator.registration_country
         end
 
         calculate :registration_country_name_lowercase_prefix do

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -18,20 +18,20 @@ module SmartAnswer
           calculator.country_of_birth = response
         end
 
-        calculate :registration_country do |response|
-          reg_data_query.registration_country_slug(response)
+        calculate :registration_country do
+          reg_data_query.registration_country_slug(calculator.country_of_birth)
         end
 
         calculate :registration_country_name_lowercase_prefix do
           country_name_query.definitive_article(registration_country)
         end
 
-        next_node_calculation :country_has_no_embassy do |response|
-          %w(iran syria yemen).include?(response)
+        next_node_calculation :country_has_no_embassy do
+          %w(iran syria yemen).include?(calculator.country_of_birth)
         end
 
-        next_node_calculation :responded_with_commonwealth_country do |response|
-          Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(response)
+        next_node_calculation :responded_with_commonwealth_country do
+          Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(calculator.country_of_birth)
         end
 
         next_node do

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -63,12 +63,16 @@ module SmartAnswer
         option :yes
         option :no
 
-        calculate :paternity_declaration do |response|
-          response == 'no'
+        on_response do |response|
+          calculator.married_couple_or_civil_partnership = response
         end
 
-        next_node do |response|
-          if response == 'no' && calculator.british_national_parent == 'father'
+        calculate :paternity_declaration do
+          calculator.married_couple_or_civil_partnership == 'no'
+        end
+
+        next_node do
+          if calculator.married_couple_or_civil_partnership == 'no' && calculator.british_national_parent == 'father'
             question :childs_date_of_birth?
           else
             question :where_are_you_now?

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -131,15 +131,7 @@ module SmartAnswer
         end
 
         precalculate :overseas_passports_embassies do
-          location = WorldLocation.find(calculator.registration_country)
-          raise InvalidResponse unless location
-          organisations = [location.fco_organisation]
-          if organisations && organisations.any?
-            service_title = 'Births and Deaths registration service'
-            organisations.first.offices_with_service(service_title)
-          else
-            []
-          end
+          calculator.overseas_passports_embassies
         end
       end
 
@@ -165,15 +157,7 @@ module SmartAnswer
         end
 
         precalculate :overseas_passports_embassies do
-          location = WorldLocation.find(calculator.registration_country)
-          raise InvalidResponse unless location
-          organisations = [location.fco_organisation]
-          if organisations && organisations.any?
-            service_title = 'Births and Deaths registration service'
-            organisations.first.offices_with_service(service_title)
-          else
-            []
-          end
+          calculator.overseas_passports_embassies
         end
 
         precalculate :translator_link_url do
@@ -187,15 +171,7 @@ module SmartAnswer
       outcome :homeoffice_result
       outcome :no_birth_certificate_result do
         precalculate :overseas_passports_embassies do
-          location = WorldLocation.find(calculator.registration_country)
-          raise InvalidResponse unless location
-          organisations = [location.fco_organisation]
-          if organisations && organisations.any?
-            service_title = 'Births and Deaths registration service'
-            organisations.first.offices_with_service(service_title)
-          else
-            []
-          end
+          calculator.overseas_passports_embassies
         end
       end
     end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -104,16 +104,16 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        calculate :same_country do |response|
-          response == 'same_country'
+        calculate :same_country do
+          calculator.current_location == 'same_country'
         end
 
         calculate :another_country do |response|
-          response == 'another_country'
+          calculator.current_location == 'another_country'
         end
 
         calculate :in_the_uk do |response|
-          response == 'in_the_uk'
+          calculator.current_location == 'in_the_uk'
         end
 
         next_node_calculation(:no_birth_certificate_exception) {
@@ -124,12 +124,12 @@ module SmartAnswer
           calculator.country_of_birth == 'north-korea'
         }
 
-        next_node do |response|
+        next_node do
           if no_birth_certificate_exception
             outcome :no_birth_certificate_result
-          elsif response == 'another_country'
+          elsif calculator.current_location == 'another_country'
             question :which_country?
-          elsif response == 'same_country' && born_in_north_korea
+          elsif calculator.current_location == 'same_country' && born_in_north_korea
             outcome :north_korea_result
           else
             outcome :oru_result

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -13,11 +13,10 @@ module SmartAnswer
 
       # Q1
       country_select :country_of_birth?, exclude_countries: exclude_countries do
-        on_response do
+        on_response do |response|
           self.calculator = Calculators::RegisterABirthCalculator.new
+          calculator.country_of_birth = response
         end
-
-        save_input_as :country_of_birth
 
         calculate :registration_country do |response|
           reg_data_query.registration_country_slug(response)
@@ -120,11 +119,11 @@ module SmartAnswer
         end
 
         next_node_calculation(:no_birth_certificate_exception) {
-          reg_data_query.has_birth_registration_exception?(country_of_birth) & paternity_declaration
+          reg_data_query.has_birth_registration_exception?(calculator.country_of_birth) & paternity_declaration
         }
 
         next_node_calculation(:born_in_north_korea) {
-          country_of_birth == 'north-korea'
+          calculator.country_of_birth == 'north-korea'
         }
 
         next_node do |response|
@@ -197,11 +196,11 @@ module SmartAnswer
         end
 
         precalculate :custom_waiting_time do
-          reg_data_query.custom_registration_duration(country_of_birth)
+          reg_data_query.custom_registration_duration(calculator.country_of_birth)
         end
 
         precalculate :born_in_lower_risk_country do
-          reg_data_query.lower_risk_country?(country_of_birth)
+          reg_data_query.lower_risk_country?(calculator.country_of_birth)
         end
 
         precalculate :location do
@@ -224,7 +223,7 @@ module SmartAnswer
         end
 
         precalculate :translator_link_url do
-          translator_query.links[country_of_birth]
+          translator_query.links[calculator.country_of_birth]
         end
       end
 
@@ -234,7 +233,7 @@ module SmartAnswer
       outcome :homeoffice_result
       outcome :no_birth_certificate_result do
         precalculate :location do
-          loc = WorldLocation.find(country_of_birth)
+          loc = WorldLocation.find(calculator.country_of_birth)
           raise InvalidResponse unless loc
           loc
         end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -129,10 +129,6 @@ module SmartAnswer
         precalculate :reg_data_query do
           reg_data_query
         end
-
-        precalculate :overseas_passports_embassies do
-          calculator.overseas_passports_embassies
-        end
       end
 
       outcome :oru_result do
@@ -156,10 +152,6 @@ module SmartAnswer
           reg_data_query.lower_risk_country?(calculator.country_of_birth)
         end
 
-        precalculate :overseas_passports_embassies do
-          calculator.overseas_passports_embassies
-        end
-
         precalculate :translator_link_url do
           translator_query.links[calculator.country_of_birth]
         end
@@ -169,11 +161,7 @@ module SmartAnswer
       outcome :no_registration_result
       outcome :no_embassy_result
       outcome :homeoffice_result
-      outcome :no_birth_certificate_result do
-        precalculate :overseas_passports_embassies do
-          calculator.overseas_passports_embassies
-        end
-      end
+      outcome :no_birth_certificate_result
     end
   end
 end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -6,7 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "101003"
 
-      reg_data_query = Calculators::RegistrationsDataQuery.new
       exclude_countries = %w(holy-see british-antarctic-territory)
 
       # Q1
@@ -125,13 +124,7 @@ module SmartAnswer
       # Outcomes
 
       outcome :north_korea_result
-
-      outcome :oru_result do
-        precalculate :reg_data_query do
-          reg_data_query
-        end
-      end
-
+      outcome :oru_result
       outcome :commonwealth_result
       outcome :no_registration_result
       outcome :no_embassy_result

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -55,7 +55,7 @@ module SmartAnswer
         end
 
         next_node do
-          if calculator.paternity_declaration? && calculator.british_national_parent == 'father'
+          if calculator.paternity_declaration? && calculator.british_national_father?
             question :childs_date_of_birth?
           else
             question :where_are_you_now?

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -19,11 +19,11 @@ module SmartAnswer
         end
 
         calculate :registration_country do
-          reg_data_query.registration_country_slug(calculator.country_of_birth)
+          calculator.registration_country
         end
 
         calculate :registration_country_name_lowercase_prefix do
-          country_name_query.definitive_article(registration_country)
+          country_name_query.definitive_article(calculator.registration_country)
         end
 
         next_node_calculation :country_has_no_embassy do

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -17,10 +17,6 @@ module SmartAnswer
           calculator.country_of_birth = response
         end
 
-        calculate :registration_country do
-          calculator.registration_country
-        end
-
         next_node do
           if calculator.country_has_no_embassy?
             outcome :no_embassy_result
@@ -116,10 +112,6 @@ module SmartAnswer
       country_select :which_country?, exclude_countries: exclude_countries do
         on_response do |response|
           calculator.current_country = response
-        end
-
-        calculate :registration_country do
-          calculator.registration_country
         end
 
         next_node_calculation(:currently_in_north_korea) {

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -104,10 +104,6 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        calculate :another_country do |response|
-          calculator.current_location == 'another_country'
-        end
-
         calculate :in_the_uk do |response|
           calculator.current_location == 'in_the_uk'
         end
@@ -123,7 +119,7 @@ module SmartAnswer
         next_node do
           if no_birth_certificate_exception
             outcome :no_birth_certificate_result
-          elsif calculator.current_location == 'another_country'
+          elsif calculator.another_country?
             question :which_country?
           elsif calculator.same_country? && born_in_north_korea
             outcome :north_korea_result

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -7,7 +7,6 @@ module SmartAnswer
       satisfies_need "101003"
 
       reg_data_query = Calculators::RegistrationsDataQuery.new
-      translator_query = Calculators::TranslatorLinks.new
       exclude_countries = %w(holy-see british-antarctic-territory)
 
       # Q1
@@ -130,10 +129,6 @@ module SmartAnswer
       outcome :oru_result do
         precalculate :reg_data_query do
           reg_data_query
-        end
-
-        precalculate :translator_link_url do
-          translator_query.links[calculator.country_of_birth]
         end
       end
 

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -26,14 +26,10 @@ module SmartAnswer
           calculator.registration_country_name_lowercase_prefix
         end
 
-        next_node_calculation :responded_with_commonwealth_country do
-          Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(calculator.country_of_birth)
-        end
-
         next_node do
           if calculator.country_has_no_embassy?
             outcome :no_embassy_result
-          elsif responded_with_commonwealth_country
+          elsif calculator.responded_with_commonwealth_country?
             outcome :commonwealth_result
           else
             question :who_has_british_nationality?

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -132,10 +132,6 @@ module SmartAnswer
           reg_data_query
         end
 
-        precalculate :custom_waiting_time do
-          reg_data_query.custom_registration_duration(calculator.country_of_birth)
-        end
-
         precalculate :born_in_lower_risk_country do
           reg_data_query.lower_risk_country?(calculator.country_of_birth)
         end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -125,11 +125,7 @@ module SmartAnswer
 
       # Outcomes
 
-      outcome :north_korea_result do
-        precalculate :reg_data_query do
-          reg_data_query
-        end
-      end
+      outcome :north_korea_result
 
       outcome :oru_result do
         precalculate :reg_data_query do

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -114,12 +114,8 @@ module SmartAnswer
           calculator.current_country = response
         end
 
-        next_node_calculation(:currently_in_north_korea) {
-          response == 'north-korea'
-        }
-
         next_node do
-          if currently_in_north_korea
+          if calculator.currently_in_north_korea?
             outcome :north_korea_result
           else
             outcome :oru_result

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -6,7 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "101003"
 
-      country_name_query = Calculators::CountryNameFormatter.new
       reg_data_query = Calculators::RegistrationsDataQuery.new
       translator_query = Calculators::TranslatorLinks.new
       exclude_countries = %w(holy-see british-antarctic-territory)

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -143,7 +143,7 @@ module SmartAnswer
         end
 
         precalculate :overseas_passports_embassies do
-          location = WorldLocation.find(registration_country)
+          location = WorldLocation.find(calculator.registration_country)
           raise InvalidResponse unless location
           organisations = [location.fco_organisation]
           if organisations && organisations.any?
@@ -177,7 +177,7 @@ module SmartAnswer
         end
 
         precalculate :location do
-          loc = WorldLocation.find(registration_country)
+          loc = WorldLocation.find(calculator.registration_country)
           raise InvalidResponse unless loc
           loc
         end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -104,16 +104,12 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        next_node_calculation(:born_in_north_korea) {
-          calculator.country_of_birth == 'north-korea'
-        }
-
         next_node do
           if calculator.no_birth_certificate_exception?
             outcome :no_birth_certificate_result
           elsif calculator.another_country?
             question :which_country?
-          elsif calculator.same_country? && born_in_north_korea
+          elsif calculator.same_country? && calculator.born_in_north_korea?
             outcome :north_korea_result
           else
             outcome :oru_result

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -104,10 +104,6 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        calculate :same_country do
-          calculator.current_location == 'same_country'
-        end
-
         calculate :another_country do |response|
           calculator.current_location == 'another_country'
         end
@@ -129,7 +125,7 @@ module SmartAnswer
             outcome :no_birth_certificate_result
           elsif calculator.current_location == 'another_country'
             question :which_country?
-          elsif calculator.current_location == 'same_country' && born_in_north_korea
+          elsif calculator.same_country? && born_in_north_korea
             outcome :north_korea_result
           else
             outcome :oru_result

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -132,10 +132,6 @@ module SmartAnswer
           reg_data_query
         end
 
-        precalculate :button_data do
-          { text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk/start" }
-        end
-
         precalculate :custom_waiting_time do
           reg_data_query.custom_registration_duration(calculator.country_of_birth)
         end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -21,10 +21,6 @@ module SmartAnswer
           calculator.registration_country
         end
 
-        calculate :registration_country_name_lowercase_prefix do
-          calculator.registration_country_name_lowercase_prefix
-        end
-
         next_node do
           if calculator.country_has_no_embassy?
             outcome :no_embassy_result
@@ -124,10 +120,6 @@ module SmartAnswer
 
         calculate :registration_country do
           calculator.registration_country
-        end
-
-        calculate :registration_country_name_lowercase_prefix do
-          calculator.registration_country_name_lowercase_prefix
         end
 
         next_node_calculation(:currently_in_north_korea) {

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -13,6 +13,10 @@ module SmartAnswer
 
       # Q1
       country_select :country_of_birth?, exclude_countries: exclude_countries do
+        on_response do
+          self.calculator = Calculators::RegisterABirthCalculator.new
+        end
+
         save_input_as :country_of_birth
 
         calculate :registration_country do |response|

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -104,16 +104,12 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        next_node_calculation(:no_birth_certificate_exception) {
-          reg_data_query.has_birth_registration_exception?(calculator.country_of_birth) & calculator.paternity_declaration?
-        }
-
         next_node_calculation(:born_in_north_korea) {
           calculator.country_of_birth == 'north-korea'
         }
 
         next_node do
-          if no_birth_certificate_exception
+          if calculator.no_birth_certificate_exception?
             outcome :no_birth_certificate_result
           elsif calculator.another_country?
             question :which_country?

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -100,6 +100,10 @@ module SmartAnswer
         option :another_country
         option :in_the_uk
 
+        on_response do |response|
+          calculator.current_location = response
+        end
+
         calculate :same_country do |response|
           response == 'same_country'
         end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -85,12 +85,8 @@ module SmartAnswer
           calculator.childs_date_of_birth = response
         end
 
-        next_node_calculation :before_july_2006 do
-          Date.new(2006, 07, 01) > calculator.childs_date_of_birth
-        end
-
         next_node do
-          if before_july_2006
+          if calculator.before_july_2006?
             outcome :homeoffice_result
           else
             question :where_are_you_now?

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -132,10 +132,6 @@ module SmartAnswer
           reg_data_query
         end
 
-        precalculate :document_return_fees do
-          reg_data_query.document_return_fees
-        end
-
         precalculate :button_data do
           { text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk/start" }
         end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -81,8 +81,12 @@ module SmartAnswer
         from { Date.today.end_of_year }
         to { 50.years.ago(Date.today) }
 
-        next_node_calculation :before_july_2006 do |response|
-          Date.new(2006, 07, 01) > response
+        on_response do |response|
+          calculator.childs_date_of_birth = response
+        end
+
+        next_node_calculation :before_july_2006 do
+          Date.new(2006, 07, 01) > calculator.childs_date_of_birth
         end
 
         next_node do

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -67,10 +67,6 @@ module SmartAnswer
           calculator.married_couple_or_civil_partnership = response
         end
 
-        calculate :paternity_declaration do
-          calculator.married_couple_or_civil_partnership == 'no'
-        end
-
         next_node do
           if calculator.married_couple_or_civil_partnership == 'no' && calculator.british_national_parent == 'father'
             question :childs_date_of_birth?
@@ -117,7 +113,7 @@ module SmartAnswer
         end
 
         next_node_calculation(:no_birth_certificate_exception) {
-          reg_data_query.has_birth_registration_exception?(calculator.country_of_birth) & paternity_declaration
+          reg_data_query.has_birth_registration_exception?(calculator.country_of_birth) & calculator.paternity_declaration?
         }
 
         next_node_calculation(:born_in_north_korea) {

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -48,8 +48,8 @@ module SmartAnswer
           calculator.british_national_parent = response
         end
 
-        next_node do |response|
-          case response
+        next_node do
+          case calculator.british_national_parent
           when 'mother', 'father', 'mother_and_father'
             question :married_couple_or_civil_partnership?
           when 'neither'

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -6,7 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "101003"
 
-      country_name_query = Calculators::CountryNameFormatter.new
       reg_data_query = Calculators::RegistrationsDataQuery.new
       translator_query = Calculators::TranslatorLinks.new
       exclude_countries = %w(holy-see british-antarctic-territory)
@@ -128,7 +127,7 @@ module SmartAnswer
         end
 
         calculate :registration_country_name_lowercase_prefix do
-          country_name_query.definitive_article(registration_country)
+          calculator.registration_country_name_lowercase_prefix
         end
 
         next_node_calculation(:currently_in_north_korea) {

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -6,10 +6,8 @@ module SmartAnswer
       status :published
       satisfies_need "101003"
 
-      exclude_countries = %w(holy-see british-antarctic-territory)
-
       # Q1
-      country_select :country_of_birth?, exclude_countries: exclude_countries do
+      country_select :country_of_birth?, exclude_countries: Calculators::RegisterABirthCalculator::EXCLUDE_COUNTRIES do
         on_response do |response|
           self.calculator = Calculators::RegisterABirthCalculator.new
           calculator.country_of_birth = response
@@ -107,7 +105,7 @@ module SmartAnswer
       end
 
       # Q6
-      country_select :which_country?, exclude_countries: exclude_countries do
+      country_select :which_country?, exclude_countries: Calculators::RegisterABirthCalculator::EXCLUDE_COUNTRIES do
         on_response do |response|
           calculator.current_country = response
         end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -119,6 +119,10 @@ module SmartAnswer
 
       # Q6
       country_select :which_country?, exclude_countries: exclude_countries do
+        on_response do |response|
+          calculator.current_country = response
+        end
+
         calculate :registration_country do |response|
           reg_data_query.registration_country_slug(response)
         end

--- a/lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb
@@ -1,4 +1,4 @@
 Service | Fee
 -|-
-Register a birth | <%= format_money(reg_data_query.register_a_birth_fees.register_a_birth) %>
-Copy of a birth registration certificate | <%= format_money(reg_data_query.register_a_birth_fees.copy_of_birth_registration_certificate) %>
+Register a birth | <%= format_money(calculator.fee_for_registering_a_birth) %>
+Copy of a birth registration certificate | <%= format_money(calculator.fee_for_copy_of_birth_registration_certificate) %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  ^You must register the birth according to the regulations in <%= registration_country_name_lowercase_prefix %>.^
+  ^You must register the birth according to the regulations in <%= calculator.registration_country_name_lowercase_prefix %>.^
 
-  You can’t register the birth with the UK authorities. However, the birth certificate you are given in <%= registration_country_name_lowercase_prefix %> will be recognised and accepted in the UK, so this isn’t necessary.
+  You can’t register the birth with the UK authorities. However, the birth certificate you are given in <%= calculator.registration_country_name_lowercase_prefix %> will be recognised and accepted in the UK, so this isn’t necessary.
 <% end %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!You must register the birth according to the regulations in <%= registration_country_name_lowercase_prefix %>.$!
+  $!You must register the birth according to the regulations in <%= calculator.registration_country_name_lowercase_prefix %>.$!
 
   You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  <% if same_country %>
+  <% if calculator.same_country? %>
     <% case calculator.country_of_birth %>
     <% when 'afghanistan' %>
       ^It’s illegal in Afghanistan to have a child outside of marriage. You can’t get a local birth certificate.^

--- a/lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.govspeak.erb
@@ -1,6 +1,6 @@
 <% content_for :body do %>
   <% if same_country %>
-    <% case country_of_birth %>
+    <% case calculator.country_of_birth %>
     <% when 'afghanistan' %>
       ^It’s illegal in Afghanistan to have a child outside of marriage. You can’t get a local birth certificate.^
 
@@ -40,7 +40,7 @@
       A local birth certificate is normally needed to register an overseas birth. Contact the FCO at <birthregistrationenquiries@fco.gov.uk> for advice.
     <% end %>
   <% else %>
-    <% case country_of_birth %>
+    <% case calculator.country_of_birth %>
     <% when 'afghanistan' %>
       You can’t get a local birth certificate if you weren’t married when you had your child.
     <% when 'iraq' %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/no_embassy_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/no_embassy_result.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
-  $!You must register the birth according to the regulations in <%= registration_country_name_lowercase_prefix %>.$!
+  $!You must register the birth according to the regulations in <%= calculator.registration_country_name_lowercase_prefix %>.$!
 
   You can’t currently register the birth with the UK authorities.
 
-  The local birth certificate, with a [certified translation](/certifying-a-document), should be acceptable for all purposes in the UK. You can apply for registration at any time in the future - check [travel advice](/foreign-travel-advice) to find out if consular services have reopened in <%= registration_country_name_lowercase_prefix %>.
+  The local birth certificate, with a [certified translation](/certifying-a-document), should be acceptable for all purposes in the UK. You can apply for registration at any time in the future - check [travel advice](/foreign-travel-advice) to find out if consular services have reopened in <%= calculator.registration_country_name_lowercase_prefix %>.
 <% end %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!You can apply to register the birth with the British embassy in <%= registration_country_name_lowercase_prefix %>.$!
+  $!You can apply to register the birth with the British embassy in <%= calculator.registration_country_name_lowercase_prefix %>.$!
 
   Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
@@ -51,7 +51,7 @@
     Either parent can register the birth.
   <% end %>
 
-  <%= render partial: 'shared/overseas_passports_embassies.govspeak.erb', locals: { overseas_passports_embassies: overseas_passports_embassies } %>
+  <%= render partial: 'shared/overseas_passports_embassies.govspeak.erb', locals: { overseas_passports_embassies: calculator.overseas_passports_embassies } %>
 
   ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
@@ -31,7 +31,7 @@
   ##Cost
 
   <%= render partial: 'fees.govspeak.erb',
-             locals: { reg_data_query: reg_data_query } %>
+             locals: { calculator: calculator } %>
 
   You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
@@ -43,7 +43,7 @@
 
   Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
 
-  <% if paternity_declaration %>
+  <% if calculator.paternity_declaration? %>
     The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
 
     Paternity declarations are free. Contact the consulate for more details.

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -5,7 +5,7 @@
     %You’ll need to get a court order to have the father named on the birth certificate before registering if you’re unmarried and only the father has British nationality.%
   <% end %>
 
-  <% if reg_data_query.higher_risk_country?(calculator.registration_country) %>
+  <% if calculator.higher_risk_country? %>
     <% if calculator.registration_country == 'libya' %>
       You can also register the birth with the UK authorities.
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   $!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
 
-  <% if registration_country == 'indonesia' and british_national_parent == 'father' and paternity_declaration %>
+  <% if registration_country == 'indonesia' and calculator.british_national_parent == 'father' and paternity_declaration %>
     %You’ll need to get a court order to have the father named on the birth certificate before registering if you’re unmarried and only the father has British nationality.%
   <% end %>
 
@@ -142,7 +142,7 @@
   <% if calculator.country_of_birth.in?(%w(philippines sierra-leone uganda)) %>
     If the child doesn't have a British passport you must also send the original copies of:
 
-    <% if calculator.country_of_birth == 'philippines' and british_national_parent.exclude?('mother') %>
+    <% if calculator.country_of_birth == 'philippines' and calculator.british_national_parent.exclude?('mother') %>
       - a Certificate of No Marriage ("Cenomar") issued by the National Statistics Office (NSO) or Philippine Statistics Authority (PSA) - if the Filipino mother is single
       - an Advisory on Marriage certificate issued by the NSO or PSA - if the Filipino mother is married
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -191,7 +191,7 @@
 
   ##3. Pay
 
-  <% if !in_the_uk && registration_country == 'algeria' %>
+  <% if !calculator.in_the_uk? && registration_country == 'algeria' %>
     Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
   <% else %>
     You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
@@ -222,7 +222,7 @@
 
     Post the registration form and documents by secure post to:
 
-    <% if in_the_uk %>
+    <% if calculator.in_the_uk? %>
 
       $A
       Overseas Registration Unit
@@ -277,7 +277,7 @@
     They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
   <% end %>
 
-  <% if reg_data_query.oru_courier_variant?(registration_country) && !in_the_uk %>
+  <% if reg_data_query.oru_courier_variant?(registration_country) && !calculator.in_the_uk? %>
     <% case registration_country %>
       <% when 'cambodia' %>
         Your documents will be returned to the British Embassy in Phnom Penh after the birth has been registered.

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -1,12 +1,12 @@
 <% content_for :body do %>
   $!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
 
-  <% if registration_country == 'indonesia' and calculator.british_national_parent == 'father' and calculator.paternity_declaration? %>
+  <% if calculator.registration_country == 'indonesia' and calculator.british_national_parent == 'father' and calculator.paternity_declaration? %>
     %You’ll need to get a court order to have the father named on the birth certificate before registering if you’re unmarried and only the father has British nationality.%
   <% end %>
 
-  <% if reg_data_query.higher_risk_country?(registration_country) %>
-    <% if registration_country == 'libya' %>
+  <% if reg_data_query.higher_risk_country?(calculator.registration_country) %>
+    <% if calculator.registration_country == 'libya' %>
       You can also register the birth with the UK authorities.
 
       ^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
@@ -191,7 +191,7 @@
 
   ##3. Pay
 
-  <% if !calculator.in_the_uk? && registration_country == 'algeria' %>
+  <% if !calculator.in_the_uk? && calculator.registration_country == 'algeria' %>
     Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
   <% else %>
     You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
@@ -269,7 +269,7 @@
     * 5 working days if the child has a British passport
 
     The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
-  <% elsif registration_country == 'north-korea' and born_in_lower_risk_country %>
+  <% elsif calculator.registration_country == 'north-korea' and born_in_lower_risk_country %>
     ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
   <% else %>
     It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
@@ -277,8 +277,8 @@
     They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
   <% end %>
 
-  <% if reg_data_query.oru_courier_variant?(registration_country) && !calculator.in_the_uk? %>
-    <% case registration_country %>
+  <% if reg_data_query.oru_courier_variant?(calculator.registration_country) && !calculator.in_the_uk? %>
+    <% case calculator.registration_country %>
       <% when 'cambodia' %>
         Your documents will be returned to the British Embassy in Phnom Penh after the birth has been registered.
       <% when 'kenya' %>
@@ -300,7 +300,7 @@
       <% when 'uganda' %>
         Your documents will be returned to the British High Commission in Kampala after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>
-    <% unless reg_data_query.oru_courier_by_high_commission?(registration_country) %>
+    <% unless reg_data_query.oru_courier_by_high_commission?(calculator.registration_country) %>
 
       You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -31,7 +31,7 @@
 
   ##1. Check your documents
 
-  ^Send English translations of all foreign documents. <%= translator_link_url ? "Use an [approved translator](#{translator_link_url}) and include their name and address with your application" : 'Use a professional translator and include their name and address with your application' %>. Don't send laminated documents.^
+  ^Send English translations of all foreign documents. <%= calculator.translator_link_url ? "Use an [approved translator](#{calculator.translator_link_url}) and include their name and address with your application" : 'Use a professional translator and include their name and address with your application' %>. Don't send laminated documents.^
 
   <% if calculator.country_of_birth == 'morocco' && calculator.paternity_declaration? %>
     ^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -202,7 +202,7 @@
   Once you’ve paid you will be given a reference number to use on your birth registration form.
 
   <%= render partial: 'fees.govspeak.erb',
-             locals: { reg_data_query: reg_data_query } %>
+             locals: { calculator: calculator } %>
 
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
   <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: button_data } %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -207,7 +207,7 @@
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
   <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: button_data } %>
 
-  <% if calculator.country_of_birth == 'venezuela' && same_country %>
+  <% if calculator.country_of_birth == 'venezuela' && calculator.same_country? %>
 
     ##4. Go to the British embassy
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -39,7 +39,7 @@
 
   You must send the original versions of:
 
-  <% if reg_data_query.oru_documents_variant_for_birth?(calculator.country_of_birth) %>
+  <% if calculator.oru_documents_variant_for_birth? %>
     <% if calculator.country_of_birth == 'united-arab-emirates' && calculator.paternity_declaration? %>
       - both English and Arabic versions of your child’s full local birth certificate, attested by the Ministry of Foreign Affairs (email <birthregistrationenquiries@fco.gov.uk> if the local authorities will not provide a birth certificate)
     <% else %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -269,7 +269,7 @@
     * 5 working days if the child has a British passport
 
     The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
-  <% elsif calculator.registration_country == 'north-korea' and born_in_lower_risk_country %>
+  <% elsif calculator.registration_country == 'north-korea' and calculator.born_in_lower_risk_country? %>
     ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
   <% else %>
     It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -247,7 +247,7 @@
 
   ##Return of your documents
 
-  <% if reg_data_query.may_require_dna_tests?(calculator.country_of_birth) %>
+  <% if calculator.may_require_dna_tests? %>
     Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
 
     * at least <%= calculator.custom_waiting_time %> if the child doesn’t have a British passport

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -277,7 +277,7 @@
     They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
   <% end %>
 
-  <% if reg_data_query.oru_courier_variant?(calculator.registration_country) && !calculator.in_the_uk? %>
+  <% if calculator.oru_courier_variant? && !calculator.in_the_uk? %>
     <% case calculator.registration_country %>
       <% when 'cambodia' %>
         Your documents will be returned to the British Embassy in Phnom Penh after the birth has been registered.

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -300,7 +300,7 @@
       <% when 'uganda' %>
         Your documents will be returned to the British High Commission in Kampala after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>
-    <% unless reg_data_query.oru_courier_by_high_commission?(calculator.registration_country) %>
+    <% unless calculator.oru_courier_by_high_commission? %>
 
       You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   $!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
 
-  <% if calculator.registration_country == 'indonesia' and calculator.british_national_parent == 'father' and calculator.paternity_declaration? %>
+  <% if calculator.registration_country == 'indonesia' and calculator.british_national_father? and calculator.paternity_declaration? %>
     %You’ll need to get a court order to have the father named on the birth certificate before registering if you’re unmarried and only the father has British nationality.%
   <% end %>
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   $!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
 
-  <% if registration_country == 'indonesia' and calculator.british_national_parent == 'father' and paternity_declaration %>
+  <% if registration_country == 'indonesia' and calculator.british_national_parent == 'father' and calculator.paternity_declaration? %>
     %You’ll need to get a court order to have the father named on the birth certificate before registering if you’re unmarried and only the father has British nationality.%
   <% end %>
 
@@ -33,14 +33,14 @@
 
   ^Send English translations of all foreign documents. <%= translator_link_url ? "Use an [approved translator](#{translator_link_url}) and include their name and address with your application" : 'Use a professional translator and include their name and address with your application' %>. Don't send laminated documents.^
 
-  <% if calculator.country_of_birth == 'morocco' && paternity_declaration %>
+  <% if calculator.country_of_birth == 'morocco' && calculator.paternity_declaration? %>
     ^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^
   <% end %>
 
   You must send the original versions of:
 
   <% if reg_data_query.oru_documents_variant_for_birth?(calculator.country_of_birth) %>
-    <% if calculator.country_of_birth == 'united-arab-emirates' && paternity_declaration %>
+    <% if calculator.country_of_birth == 'united-arab-emirates' && calculator.paternity_declaration? %>
       - both English and Arabic versions of your child’s full local birth certificate, attested by the Ministry of Foreign Affairs (email <birthregistrationenquiries@fco.gov.uk> if the local authorities will not provide a birth certificate)
     <% else %>
       <% case calculator.country_of_birth %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -33,17 +33,17 @@
 
   ^Send English translations of all foreign documents. <%= translator_link_url ? "Use an [approved translator](#{translator_link_url}) and include their name and address with your application" : 'Use a professional translator and include their name and address with your application' %>. Don't send laminated documents.^
 
-  <% if country_of_birth == 'morocco' && paternity_declaration %>
+  <% if calculator.country_of_birth == 'morocco' && paternity_declaration %>
     ^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^
   <% end %>
 
   You must send the original versions of:
 
-  <% if reg_data_query.oru_documents_variant_for_birth?(country_of_birth) %>
-    <% if country_of_birth == 'united-arab-emirates' && paternity_declaration %>
+  <% if reg_data_query.oru_documents_variant_for_birth?(calculator.country_of_birth) %>
+    <% if calculator.country_of_birth == 'united-arab-emirates' && paternity_declaration %>
       - both English and Arabic versions of your child’s full local birth certificate, attested by the Ministry of Foreign Affairs (email <birthregistrationenquiries@fco.gov.uk> if the local authorities will not provide a birth certificate)
     <% else %>
-      <% case country_of_birth %>
+      <% case calculator.country_of_birth %>
       <% when 'oru_documents_variant_andorra' %>
         - the child’s full local birth certificate (‘declaració de naixement’) - it must have both parents’ names
       <% when 'belgium' %>
@@ -139,15 +139,15 @@
   - the photo page of the child’s British passport if they have one
   - the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
 
-  <% if country_of_birth.in?(%w(philippines sierra-leone uganda)) %>
+  <% if calculator.country_of_birth.in?(%w(philippines sierra-leone uganda)) %>
     If the child doesn't have a British passport you must also send the original copies of:
 
-    <% if country_of_birth == 'philippines' and british_national_parent.exclude?('mother') %>
+    <% if calculator.country_of_birth == 'philippines' and british_national_parent.exclude?('mother') %>
       - a Certificate of No Marriage ("Cenomar") issued by the National Statistics Office (NSO) or Philippine Statistics Authority (PSA) - if the Filipino mother is single
       - an Advisory on Marriage certificate issued by the NSO or PSA - if the Filipino mother is married
 
     <% end %>
-    <% case country_of_birth %>
+    <% case calculator.country_of_birth %>
     <% when 'philippines' %>
       - the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
       - health cards from the hospital, doctor or clinic
@@ -207,7 +207,7 @@
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
   <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: button_data } %>
 
-  <% if country_of_birth == 'venezuela' && same_country %>
+  <% if calculator.country_of_birth == 'venezuela' && same_country %>
 
     ##4. Go to the British embassy
 
@@ -247,7 +247,7 @@
 
   ##Return of your documents
 
-  <% if reg_data_query.may_require_dna_tests?(country_of_birth) %>
+  <% if reg_data_query.may_require_dna_tests?(calculator.country_of_birth) %>
     Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
 
     * at least <%= custom_waiting_time %> if the child doesn’t have a British passport

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -250,7 +250,7 @@
   <% if reg_data_query.may_require_dna_tests?(calculator.country_of_birth) %>
     Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
 
-    * at least <%= custom_waiting_time %> if the child doesn’t have a British passport
+    * at least <%= calculator.custom_waiting_time %> if the child doesn’t have a British passport
     * 5 working days if the child has a British passport
 
     The Overseas Registration Unit will contact you if they need:
@@ -262,10 +262,10 @@
     If this happens, it will take longer for the birth to be registered.
 
     ^You must pay all costs relating to DNA testing.^
-  <% elsif custom_waiting_time %>
+  <% elsif calculator.custom_waiting_time %>
     Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
 
-    * at least <%= custom_waiting_time %> if the child doesn’t have a British passport
+    * at least <%= calculator.custom_waiting_time %> if the child doesn’t have a British passport
     * 5 working days if the child has a British passport
 
     The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -215,7 +215,7 @@
 
     Staff at the embassy will check your application and send it to the Overseas Registration Unit in the UK.
 
-    <%= render partial: 'shared/overseas_passports_embassies.govspeak.erb', locals: { overseas_passports_embassies: overseas_passports_embassies } %>
+    <%= render partial: 'shared/overseas_passports_embassies.govspeak.erb', locals: { overseas_passports_embassies: calculator.overseas_passports_embassies } %>
   <% else %>
 
     ##4. Send your registration

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -204,7 +204,7 @@
   <%= render partial: 'fees.govspeak.erb',
              locals: { calculator: calculator } %>
 
-  <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
+  <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: calculator.document_return_fees } %>
   <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: button_data } %>
 
   <% if calculator.country_of_birth == 'venezuela' && calculator.same_country? %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -205,7 +205,7 @@
              locals: { calculator: calculator } %>
 
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: calculator.document_return_fees } %>
-  <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: button_data } %>
+  <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: { text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk/start" } } %>
 
   <% if calculator.country_of_birth == 'venezuela' && calculator.same_country? %>
 

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,15 +1,15 @@
 ---
-lib/smart_answer_flows/register-a-birth.rb: 18f9a1fe4fbbb360f0c532d5e4c46833
+lib/smart_answer_flows/register-a-birth.rb: ecd4500ead144c94294a25e9bb66b420
 test/data/register-a-birth-questions-and-responses.yml: c59cb1d0c11f3ad29f905b632f7c58bb
 test/data/register-a-birth-responses-and-expected-results.yml: 3ac4372034c86d8cc87665db59ff11d5
-lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb: a2bc6c611c6809b333ab42066a805f71
-lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb: a7c70e3191f23f7e747cb45587e4825f
-lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb: e07b86c2a892f42b0cab80b166af05df
-lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.govspeak.erb: 174d68aa0d7cf3922a9e6a1867676359
-lib/smart_answer_flows/register-a-birth/outcomes/no_embassy_result.govspeak.erb: ed56d500311fbe441649c92193f0e631
+lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb: 8c7e4d35431cb9a708504fec00558b02
+lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb: f259f0c518f6b418a683d6482874a451
+lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb: 756b38ed7b0dd5e4761f83496d43a222
+lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.govspeak.erb: fc8af38530de63f45eaa010aaf35c17d
+lib/smart_answer_flows/register-a-birth/outcomes/no_embassy_result.govspeak.erb: 23ec4444ac49bec78adc427c46e3e4c0
 lib/smart_answer_flows/register-a-birth/outcomes/no_registration_result.govspeak.erb: 7b60252b078e6aec6f5759e894ce4ffb
-lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb: e5ca7dae52d4d1bdded7ac60e7e0525e
-lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb: 81bd5b7d7c5acc0cba3350475f9e2930
+lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb: a161e34a4b4a5dfce17cda20d58f3a88
+lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb: 5e511c744f05a9d5ecd54ff809e181db
 lib/smart_answer_flows/register-a-birth/questions/childs_date_of_birth.govspeak.erb: e911daf1dc69ce85db372dc4ea3bdd50
 lib/smart_answer_flows/register-a-birth/questions/country_of_birth.govspeak.erb: 31c306c928e71eee86c60352f51ccf83
 lib/smart_answer_flows/register-a-birth/questions/have_you_adopted_the_child.govspeak.erb: 3a9d66656446a508c7232b26778dfa23
@@ -18,6 +18,7 @@ lib/smart_answer_flows/register-a-birth/questions/where_are_you_now.govspeak.erb
 lib/smart_answer_flows/register-a-birth/questions/which_country.govspeak.erb: 913b5637a2814cbd529affffc55b1f72
 lib/smart_answer_flows/register-a-birth/questions/who_has_british_nationality.govspeak.erb: 9a1a1acec4abc5a3f5199ab2eae0cd1c
 lib/smart_answer_flows/register-a-birth/register_a_birth.govspeak.erb: 05cf2d9426fc91f395fc524fdfdac800
+lib/smart_answer/calculators/register_a_birth_calculator.rb: e10654ca7fa77b91db3a9126efde0a43
 lib/data/rates/register_a_birth.yml: 8d678c61d06f614a67e8faa1933b0ff5
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -154,7 +154,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       assert_current_node :oru_result
       assert_equal 'Afghanistan', current_state.calculator.registration_country_name_lowercase_prefix
       assert_equal 'mother_and_father', current_state.calculator.british_national_parent
-      assert_state_variable :custom_waiting_time, '6 months'
+      assert_equal '6 months', current_state.calculator.custom_waiting_time
       assert_state_variable :translator_link_url, '/government/publications/afghanistan-list-of-lawyers'
     end
 
@@ -205,7 +205,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "another_country"
       add_response "pakistan"
       assert_current_node :oru_result
-      assert_state_variable :custom_waiting_time, '8 months'
+      assert_equal '8 months', current_state.calculator.custom_waiting_time
     end
   end # Afghanistan
   context "answer Pakistan" do
@@ -218,7 +218,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "yes"
       add_response "in_the_uk"
       assert_current_node :oru_result
-      assert_state_variable :custom_waiting_time, '6 months'
+      assert_equal '6 months', current_state.calculator.custom_waiting_time
     end
 
     should "give the oru result with phase-5-specific introduction if currently in Pakistan" do
@@ -265,7 +265,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
 
       assert_current_node :oru_result
       assert_equal 'father', current_state.calculator.british_national_parent
-      assert_state_variable :custom_waiting_time, '6 months'
+      assert_equal '6 months', current_state.calculator.custom_waiting_time
     end # Not married or CP
   end # Libya
 

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -154,7 +154,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "same_country"
       assert_current_node :oru_result
       assert_state_variable :registration_country_name_lowercase_prefix, "Afghanistan"
-      assert_state_variable :british_national_parent, 'mother_and_father'
+      assert_equal 'mother_and_father', current_state.calculator.british_national_parent
       assert_state_variable :custom_waiting_time, '6 months'
       assert_state_variable :translator_link_url, '/government/publications/afghanistan-list-of-lawyers'
     end
@@ -265,7 +265,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "same_country"
 
       assert_current_node :oru_result
-      assert_state_variable :british_national_parent, 'father'
+      assert_equal 'father', current_state.calculator.british_national_parent
       assert_state_variable :custom_waiting_time, '6 months'
     end # Not married or CP
   end # Libya
@@ -277,7 +277,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "yes"
       add_response "same_country"
       assert_current_node :oru_result
-      assert_state_variable :british_national_parent, 'father'
+      assert_equal 'father', current_state.calculator.british_national_parent
     end # Not married or CP
   end # Barbados
   context "answer united arab emirates" do
@@ -303,7 +303,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "yes"
       add_response "same_country"
       assert_current_node :oru_result
-      assert_state_variable :british_national_parent, 'father'
+      assert_equal 'father', current_state.calculator.british_national_parent
       assert_state_variable :translator_link_url, "/government/publications/united-arab-emirates-list-of-lawyers"
     end
   end # UAE

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -153,7 +153,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "yes"
       add_response "same_country"
       assert_current_node :oru_result
-      assert_equal "Afghanistan", current_state.calculator.registration_country_name_lowercase_prefix
+      assert_state_variable :registration_country_name_lowercase_prefix, "Afghanistan"
       assert_state_variable :british_national_parent, 'mother_and_father'
       assert_state_variable :custom_waiting_time, '6 months'
       assert_state_variable :translator_link_url, '/government/publications/afghanistan-list-of-lawyers'
@@ -318,7 +318,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'yes'
       add_response 'same_country'
       assert_equal 'guatemala', current_state.calculator.registration_country
-      assert_equal "Guatemala", current_state.calculator.registration_country_name_lowercase_prefix
+      assert_state_variable :registration_country_name_lowercase_prefix, "Guatemala"
     end
   end
 
@@ -331,7 +331,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'yes'
       add_response 'same_country'
       assert_equal 'laos', current_state.calculator.registration_country
-      assert_equal "Laos", current_state.calculator.registration_country_name_lowercase_prefix
+      assert_state_variable :registration_country_name_lowercase_prefix, "Laos"
     end
   end
   context "maldives, where you have to register in sri lanka" do

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -153,7 +153,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "yes"
       add_response "same_country"
       assert_current_node :oru_result
-      assert_state_variable :registration_country_name_lowercase_prefix, "Afghanistan"
+      assert_equal "Afghanistan", current_state.calculator.registration_country_name_lowercase_prefix
       assert_state_variable :british_national_parent, 'mother_and_father'
       assert_state_variable :custom_waiting_time, '6 months'
       assert_state_variable :translator_link_url, '/government/publications/afghanistan-list-of-lawyers'
@@ -318,7 +318,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'yes'
       add_response 'same_country'
       assert_equal 'guatemala', current_state.calculator.registration_country
-      assert_state_variable :registration_country_name_lowercase_prefix, "Guatemala"
+      assert_equal "Guatemala", current_state.calculator.registration_country_name_lowercase_prefix
     end
   end
 
@@ -331,7 +331,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'yes'
       add_response 'same_country'
       assert_equal 'laos', current_state.calculator.registration_country
-      assert_state_variable :registration_country_name_lowercase_prefix, "Laos"
+      assert_equal "Laos", current_state.calculator.registration_country_name_lowercase_prefix
     end
   end
   context "maldives, where you have to register in sri lanka" do

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -135,7 +135,6 @@ class RegisterABirthTest < ActiveSupport::TestCase
           should "give the oru result" do
             add_response 'in_the_uk'
             assert_equal 'spain', current_state.calculator.registration_country
-            assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk/start"
             assert_current_node :oru_result
             assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
           end

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -136,7 +136,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
             add_response 'in_the_uk'
             assert_equal 'spain', current_state.calculator.registration_country
             assert_current_node :oru_result
-            assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
+            assert_equal "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx", current_state.calculator.translator_link_url
           end
         end
       end # married
@@ -155,7 +155,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       assert_equal 'Afghanistan', current_state.calculator.registration_country_name_lowercase_prefix
       assert_equal 'mother_and_father', current_state.calculator.british_national_parent
       assert_equal '6 months', current_state.calculator.custom_waiting_time
-      assert_state_variable :translator_link_url, '/government/publications/afghanistan-list-of-lawyers'
+      assert_equal '/government/publications/afghanistan-list-of-lawyers', current_state.calculator.translator_link_url
     end
 
     should "give the no_birth_certificate_result if the child born outside of marriage" do
@@ -303,7 +303,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "same_country"
       assert_current_node :oru_result
       assert_equal 'father', current_state.calculator.british_national_parent
-      assert_state_variable :translator_link_url, "/government/publications/united-arab-emirates-list-of-lawyers"
+      assert_equal '/government/publications/united-arab-emirates-list-of-lawyers', current_state.calculator.translator_link_url
     end
   end # UAE
 
@@ -386,7 +386,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'yes'
       add_response 'same_country'
       assert_current_node :oru_result
-      assert_state_variable :translator_link_url, "/government/publications/netherlands-list-of-lawyers"
+      assert_equal '/government/publications/netherlands-list-of-lawyers', current_state.calculator.translator_link_url
     end
   end # Netherlands
   context "answer serbia" do
@@ -396,7 +396,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "yes"
       add_response "same_country"
       assert_current_node :oru_result
-      assert_state_variable :translator_link_url, "/government/publications/list-of-translators-and-interpreters-in-serbia"
+      assert_equal '/government/publications/list-of-translators-and-interpreters-in-serbia', current_state.calculator.translator_link_url
     end
   end # Serbia
   context "answer estonia" do
@@ -416,7 +416,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "yes"
       add_response "same_country"
       assert_current_node :oru_result
-      assert_state_variable :translator_link_url, "/government/publications/united-arab-emirates-list-of-lawyers"
+      assert_equal '/government/publications/united-arab-emirates-list-of-lawyers', current_state.calculator.translator_link_url
     end
   end # UAE
 
@@ -526,7 +526,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "no"
       add_response "same_country"
       assert_current_node :oru_result
-      assert_state_variable :translator_link_url, '/government/publications/democratic-republic-of-congo-list-of-lawyers'
+      assert_equal '/government/publications/democratic-republic-of-congo-list-of-lawyers', current_state.calculator.translator_link_url
     end
   end
 

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -56,7 +56,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'father'
       add_response 'yes'
       add_response 'same_country'
-      assert_state_variable :registration_country, 'spain'
+      assert_equal 'spain', current_state.calculator.registration_country
     end
   end # Andorra
 
@@ -82,7 +82,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'spain'
     end
     should "store this as the registration country" do
-      assert_state_variable :registration_country, 'spain'
+      assert_equal 'spain', current_state.calculator.registration_country
     end
     should "ask which parent has british nationality" do
       assert_current_node :who_has_british_nationality?
@@ -134,7 +134,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
         context "answer back in the UK" do
           should "give the oru result" do
             add_response 'in_the_uk'
-            assert_state_variable :registration_country, 'spain'
+            assert_equal 'spain', current_state.calculator.registration_country
             assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk/start"
             assert_current_node :oru_result
             assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
@@ -317,7 +317,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'father'
       add_response 'yes'
       add_response 'same_country'
-      assert_state_variable :registration_country, "guatemala"
+      assert_equal 'guatemala', current_state.calculator.registration_country
       assert_state_variable :registration_country_name_lowercase_prefix, "Guatemala"
     end
   end
@@ -330,7 +330,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'father'
       add_response 'yes'
       add_response 'same_country'
-      assert_state_variable :registration_country, "laos"
+      assert_equal 'laos', current_state.calculator.registration_country
       assert_state_variable :registration_country_name_lowercase_prefix, "Laos"
     end
   end
@@ -342,7 +342,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'father'
       add_response 'yes'
       add_response 'same_country'
-      assert_state_variable :registration_country, "sri-lanka"
+      assert_equal 'sri-lanka', current_state.calculator.registration_country
     end
   end
   context "Sri Lanka" do

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -37,7 +37,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
         should "ask where you are now and go to oru result" do
           add_response "same_country"
           assert_current_node :oru_result
-          assert current_state.send(:document_return_fees).present?
+          assert current_state.calculator.send(:document_return_fees).present?
         end
       end # not married/cp
     end # mother

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -153,7 +153,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "yes"
       add_response "same_country"
       assert_current_node :oru_result
-      assert_state_variable :registration_country_name_lowercase_prefix, "Afghanistan"
+      assert_equal 'Afghanistan', current_state.calculator.registration_country_name_lowercase_prefix
       assert_equal 'mother_and_father', current_state.calculator.british_national_parent
       assert_state_variable :custom_waiting_time, '6 months'
       assert_state_variable :translator_link_url, '/government/publications/afghanistan-list-of-lawyers'
@@ -318,7 +318,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'yes'
       add_response 'same_country'
       assert_equal 'guatemala', current_state.calculator.registration_country
-      assert_state_variable :registration_country_name_lowercase_prefix, "Guatemala"
+      assert_equal 'Guatemala', current_state.calculator.registration_country_name_lowercase_prefix
     end
   end
 
@@ -331,7 +331,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response 'yes'
       add_response 'same_country'
       assert_equal 'laos', current_state.calculator.registration_country
-      assert_state_variable :registration_country_name_lowercase_prefix, "Laos"
+      assert_equal 'Laos', current_state.calculator.registration_country_name_lowercase_prefix
     end
   end
   context "maldives, where you have to register in sri lanka" do


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/GPLhNzGq

Similar to #2561, this moves the flow towards the style described in the [refactoring documentation][1]. I've concentrated on moving logic out of the flow and into the calculator and presentational concerns into the templates. The idea is to change all the flows to use this approach so we can significantly simplify the DSL.

In this case, I haven't done much work on the calculator itself other than extracting methods from the flow into it. Also I haven't attempted to extract any domain concepts. Some of the logic could almost certainly be simplified. There is still quite a bit of work to do to move all the *tests* for this flow towards the [new-style approach][2].

Although the PR has a lot of commits, the vast majority of them are very small and only affect a few files.

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md
[2]: https://github.com/alphagov/smart-answers/blob/master/doc/new-style-testing.md
