### PR TITLE
Documentation improvements

### DIFF
--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -1,6 +1,6 @@
 # Flow
 
-The Ruby flow file defines a subclass of `SmartAnswer::Flow` that specifies metadata, and defines all the question nodes, the outcome nodes, and the rules to control flow between the nodes.
+At the heart of each Smart Answer is a subclass of `SmartAnswer::Flow`. Subclasses like this make a DSL available for [specifying metadata](#metadata), and [defining](#definition) all the [question nodes](#question-nodes), the [outcome nodes](#outcome-nodes), and the [rules](doc/next-node-rules.md) to control routing between the nodes.
 
 ## Naming
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -248,7 +248,7 @@ Each of these block types and the point at which they are executed is explained 
 ##### `precalculate(variable_name, &block)`
 
 * These blocks were intended to be used to store state variables that are needed to render a question or outcome node template.
-* These blocks execute before the question/outcome template is rendered and before the user response is parsed from the request path.
+* These blocks are the first to execute for a given question/outcome. They execute before the relevant template is rendered, so that the state variables that they define are available in question/outcome templates. They also execute before the user response is parsed from the request path.
 * The parsed response is *not* passed to the block, because it has not been received at the point the block is executed.
 * The block return value is stored on the state object as a state variable named `variable_name`.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -248,7 +248,8 @@ Each of these block types and the point at which they are executed is explained 
 ##### `precalculate(variable_name, &block)`
 
 * These blocks were intended to be used to store state variables that are needed to render a question or outcome node template.
-* It's simplest to think about these blocks executing before the user response is parsed from the request path.
+* These blocks execute before the question/outcome template is rendered and before the user response is parsed from the request path.
+* The parsed response is *not* passed to the block, because it has not been received at the point the block is executed.
 * The block return value is stored on the state object as a state variable named `variable_name`.
 
 > Note that due to an oversight in the implementation of `Flow#process`, it's not currently possible to use a `precalculate` block in the first question.
@@ -258,7 +259,7 @@ Each of these block types and the point at which they are executed is explained 
 ##### `on_response(&block)`
 
 * These blocks are intended to be used to store user responses on a `calculator` state variable. They are a [relatively new addition to the DSL][introduction-of-on-response-blocks].
-* These blocks are called  after the user response has been parsed from the request path and before any of the `next_node_calculation` blocks are executed.
+* These blocks are called after the question/outcome template has been rendered and after the user response has been parsed from the request path, but before any of the `next_node_calculation` blocks are executed.
 * The parsed response is passed to the block as the only argument and by convention is named `response`.
 * The block return value is not used and no state variable is stored.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -122,7 +122,7 @@ See [In-question blocks](#in-question-blocks) below for more information on the 
 
 The value of `self` inside the question node definition block (but outside other blocks) is the instance of the relevant question node. Thus in the example above, the calls to `#option` and `#next_node` are made on the instance of the question node.
 
-In the same way that there is a single instance of each flow class, there is only ever a single instance of each question definition in the system at any one time i.e. a flow instance has an invariant set of question node definition instances.
+In the same way that there is a single instance of each flow class, there is only ever a single instance of each question definition in the system at any one time i.e. a flow instance has a fixed set of question node definition instances.
 
 Since the same instance of a question definition is used across multiple requests, it's important that no request-specific state is stored on them.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -126,7 +126,7 @@ In the same way that there is a single instance of each flow class, there is onl
 
 Since the same instance of a question definition is used across multiple requests, it's important that no request-specific state is stored on them.
 
-The value of `self` inside the `next_node` blocks (or the other optional blocks) is an instance of `SmartAnswer::State` ([see below](#state)), i.e. *not* an instance of a question node.
+The value of `self` inside the `next_node` blocks (or the other [in-question blocks](#in-question-blocks)) is an instance of `SmartAnswer::State` ([see below](#state)), i.e. *not* an instance of a question node.
 
 ```ruby
 def define

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -229,7 +229,9 @@ All question definition blocks, must include a single `next_node` block. A numbe
 
 The value of `self` inside all these blocks is an instance of `SmartAnswer::State` ([see above](#state)). The code inside these blocks is executed at request time, not at flow definition time.
 
-All blocks of a particular type (within a single question) are executed at particular points in the request processing sequence i.e. all `on_response` blocks are executed before all `next_node_calculation` blocks. The order in which the blocks are defined only affects the order in which they are executed within the group of blocks of the same type i.e. when two `on_response` blocks are defined, the one defined first will be executed before the one defined second; however, even if a `next_node_calculation` block is defined before both of these `on_response` blocks, it will always be executed after both of them.
+All blocks of a particular type (within a single question) are executed at particular points in the request processing sequence e.g. all `on_response` blocks are executed before all `next_node_calculation` blocks.
+
+The order in which the blocks are defined only affects the order in which they are executed within the group of blocks of the same type e.g. when two `on_response` blocks are defined, the one defined first will be executed before the one defined second; however, even if a `next_node_calculation` block is defined before both of these `on_response` blocks, it will always be executed after both of them.
 
 The block types are executed in the following order:
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -225,7 +225,9 @@ second_state = first_state.transition_to(:third_node, 'second-response')
 
 #### In-question blocks
 
-All question definition blocks, must include a single `next_node` block. A number of other in-question blocks can optionally be defined by passing a block to any of the following methods on `SmartAnswer::Node` & `SmartAnswer::Question::Base`. The value of `self` inside all these blocks is an instance of `SmartAnswer::State` ([see above](#state)). The code inside these blocks is executed at request time, not at flow definition time.
+All question definition blocks, must include a single `next_node` block. A number of other in-question blocks can optionally be defined by passing a block to any of the following methods on `SmartAnswer::Node` & `SmartAnswer::Question::Base`: `precalculate`, `on_response`, `next_node_calculation`, `validate`, `next_node` & `calculate`. The `save_input_as` method is used in a similar way, but does not accept a block.
+
+The value of `self` inside all these blocks is an instance of `SmartAnswer::State` ([see above](#state)). The code inside these blocks is executed at request time, not at flow definition time.
 
 All blocks of a particular type (within a single question) are executed at particular points in the request processing sequence i.e. all `on_response` blocks are executed before all `next_node_calculation` blocks. The order in which the blocks are defined only affects the order in which they are executed within the group of blocks of the same type i.e. when two `on_response` blocks are defined, the one defined first will be executed before the one defined second; however, even if a `next_node_calculation` block is defined before both of these `on_response` blocks, it will always be executed after both of them.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -34,7 +34,7 @@ The flow is defined within the `define` instance method of the `Flow` subclass u
 > * It's confusing that blocks of code are not necessarily executed in the order that they appear in the flow definition.
 > * The code in the blocks is not easily unit-testable.
 
-Each flow is instantiated in the `FlowRegistry` via the `Flow.build` method which, in turn, instantiates the flow and invokes its `Flow#define` method.
+Each flow is instantiated in the [`FlowRegistry`][flow-registry] via the `Flow.build` method which, in turn, instantiates the flow and invokes its `Flow#define` method.
 
 Currently in production a single instance of each flow class is instantiated at application start-up (or strictly speaking on the first request) and cached in the `FlowRegistry` i.e. the same instance of a particular flow class is used to service all the user requests involving that Smart Answer. Thus it's important that no request-specific state is stored on the flow instance, otherwise this could leak into other user requests.
 
@@ -306,3 +306,4 @@ See the [documentation for outcome templates](doc/outcome-templates.md).
 [object-dup]: http://ruby-doc.org/core-2.3.0/Object.html#method-i-dup
 [local-variable-in-flow-definition]: https://github.com/alphagov/smart-answers/blob/20d2d9f524e912a3edcb9256ce2d790059538641/lib/smart_answer_flows/register-a-birth.rb#L9-L12
 [introduction-of-on-response-blocks]: https://github.com/alphagov/smart-answers/pull/2408
+[flow-registry]: https://github.com/alphagov/smart-answers/blob/cc6c5050bb78d0085cffe0a40630784724aa062a/lib/smart_answer/flow_registry.rb

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -61,9 +61,11 @@ end
 
 ### Arbitrary Ruby code
 
-Since the flow definition is just the body of a standard Ruby method, it's possible to write arbitrary Ruby code at any point within it.
+Since the flow definition is just the body of a standard Ruby method, it's possible to write arbitrary Ruby code at any point within it. Arbitrary Ruby code is pretty much anything other than calls to the DSL methods described in this document. The use of a local variable at the top-level of the `#define` method and used later within a block is an example of arbitrary Ruby code which is explained in more detail below.
 
 > It should be possible to implement the majority of flows *without* writing such arbitrary Ruby code. Any decision to introduce such arbitrary code should be very carefully considered, particularly regarding it's maintainability.
+
+> Some exceptions to the "no arbitrary Ruby" rule are: instantiating and storing a "calculator" object (in an `on_response` block), storing a response on the "calculator" object, and conditional logic within a `next_node` block. Although even the latter should be kept to a minimum by extracting predicate methods onto the "calculator" object.
 
 Since the flow definition is just the body of a `Flow` instance method (`#define`), the value of `self` at the "top-level" within the method is an instance of the flow.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -36,7 +36,7 @@ The flow is defined within the `define` instance method of the `Flow` subclass u
 
 Each flow is instantiated in the [`FlowRegistry`][flow-registry] via the `Flow.build` method which, in turn, instantiates the flow and invokes its `Flow#define` method.
 
-Currently in `development` & `production` environments (but not in `test`) a single instance of each flow class is instantiated at application start-up (or strictly speaking on the first request) and cached in the `FlowRegistry` i.e. the same instance of a particular flow class is used to service all the user requests involving that Smart Answer. Thus it's important that no request-specific state is stored on the flow instance, otherwise this could leak into other user requests.
+Currently when the app is running in the Rails `development` & `production` environments (but not in `test`) a single instance of each flow class is instantiated at application start-up (or strictly speaking on the first request) and cached in the `FlowRegistry` i.e. the same instance of a particular flow class is used to service all the user requests involving that Smart Answer. Thus it's important that no request-specific state is stored on the flow instance, otherwise this could leak into other user requests.
 
 It's important to understand this distinction between "flow definition time" and "request time" when trying to understand a flow definition. A number of the sections below refer to this distinction.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -281,10 +281,10 @@ Each of these block types and the point at which they are executed is explained 
 * The parsed response is passed to the block as the only argument and by convention is named `response`.
 * If the block return value is truth-y, then no action is taken.
 * If the block return value is false-y, then:
-  * A `SmartAnswer::InvalidResponse` exception is raised with the `message_key` set as the exception message.
-  * Although this exception is handled within the app, it prevents the transition to the next node.
-  * The `message_key` from the exception message is set on the built-in state variable, `error`.
-  * When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](doc/question-templates.md#-error_message-message-).
+  1. A `SmartAnswer::InvalidResponse` exception is raised with the `message_key` set as the exception message.
+  2. This exception is handled within the app and prevents the transition to the next node.
+  3. The `message_key` from the exception message is set on the built-in state variable, `error`.
+  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](doc/question-templates.md#-error_message-message-).
 
 > The use of these blocks is encouraged. However, they should call `valid_xxx?` methods on the `calculator` state variable and not rely on the `response` argument passed into the block.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -1,11 +1,308 @@
-# The flow definition
+# Flow
 
-The Ruby flow file defines a `Flow` class that contains all the questions, outcomes and rules to control flow between.
+The Ruby flow file defines a subclass of `SmartAnswer::Flow` that specifies metadata, and defines all the question nodes, the outcome nodes, and the rules to control flow between the nodes.
 
-The file should be named the same as the path that we want the Smart Answer to be accessible at on gov.uk. For example, if we want the Smart Answer to be accessible at www.gov.uk/example-smart-answer then:
+## Naming
 
-* The flow file should be 'example-smart-answer.rb'
-* The flow class should be `ExampleSmartAnswerFlow`
-* The flow name should be 'example-smart-answer'
+The flow filename should be based on the path where the Smart Answer is to be found on gov.uk. For example, for a Smart Answer at https://www.gov.uk/example-smart-answer, the flow file should be named `lib/smart_answer_flows/example-smart-answer.rb`. Similarly the template directory should be named `lib/smart_answer_flows/example-smart-answer/`.
 
-The `Flow` class contains a single `#define` method that defines the questions (see "Question types" below), rules (see "Defining next node rules" below) and outcomes (see "Outcome templates" below).
+The flow class should be a camel-case version of the flow filename with the suffix, `Flow` e.g. in the case above it would be `ExampleSmartAnswerFlow`. The class should inherit from `SmartAnswer::Flow` and be in the `SmartAnswer` namespace.
+
+For example:
+
+```ruby
+# lib/smart_answer_flows/example-smart-answer/example-smart-answer.rb
+module SmartAnswer
+  class ExampleSmartAnswerFlow < Flow
+    def define
+      # flow definition specified here
+    end
+  end
+end
+```
+
+> Note that much of the above does not follow standard Ruby or Rails conventions which isn't ideal. However, the plan is to move towards using such conventions as soon as possible.
+
+## Definition
+
+The flow is defined within the `define` instance method of the `Flow` subclass using a DSL to specify metadata, question nodes and outcome nodes.
+
+> Unfortunately this DSL is overly complex and makes it all too easy to create code which is very hard to follow. The DSL makes heavy use of Ruby's [`BasicObject#instance_eval`][instance-eval] & [`#instance_exec`][instance-exec]. This means that:
+>
+> * It's not obvious what variables are in scope within a given block of code.
+> * It's all too easy to write arbitrary custom code which can make each flow a bit of a special case. This doesn't help on the maintainability front.
+> * It's confusing that blocks of code are not necessarily executed in the order that they appear in the flow definition.
+> * The code in the blocks is not easily unit-testable.
+
+Each flow is instantiated in the `FlowRegistry` via the `Flow.build` method which, in turn, instantiates the flow and invokes its `Flow#define` method.
+
+Currently in production a single instance of each flow class is instantiated at application start-up (or strictly speaking on the first request) and cached in the `FlowRegistry` i.e. the same instance of a particular flow class is used to service all the user requests involving that Smart Answer. Thus it's important that no request-specific state is stored on the flow instance, otherwise this could leak into other user requests.
+
+It's important to understand this distinction between "flow definition time" and "request time" when trying to understand a flow definition. A number of the sections below refer to this distinction.
+
+### Metadata
+
+There are a number of methods on `SmartAnswer::Flow` which allow "metadata" for the flow to be specified:
+
+```ruby
+module SmartAnswer
+  class ExampleSmartAnswerFlow < Flow
+    def define
+      name 'example-smart-answer' # this is the path where the Smart Answer will be registered on gov.uk (via Panopticon)
+      content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207" # a UUID used by v2 of the Publishing API (?)
+      status :published # this indicates whether or not the flow should appear on gov.uk (i.e. production); those with `:draft` status will not appear
+      satisfies_need "123456" # may relate the Smart Answer to the original user need in the Need-o-tron app (?)
+
+      # question & outcome definitions specified here
+    end
+  end
+end
+```
+
+### Arbitrary Ruby code
+
+Since the flow definition is just the body of a standard Ruby method, it's possible to write arbitrary Ruby code at any point within it.
+
+> It should be possible to implement the majority of flows *without* writing such arbitrary Ruby code. Any decision to introduce such arbitrary code should be very carefully considered, particularly regarding it's maintainability.
+
+Since the flow definition is just the body of a `Flow` instance method (`#define`), the value of `self` at the "top-level" within the method is an instance of the flow.
+
+#### Local variables
+
+Some flows (e.g. [register-a-birth][local-variable-in-flow-definition]) define local variables towards the top of the flow definition. Standard Ruby scoping means that these are then available within question & outcome blocks, as well as within blocks nested inside these blocks. However, note that the value of the local variable is set at flow definition time and *not* at request time. Since a single flow instance is cached in the `FlowRegistry` at application start-up time, this means the local variable is _only assigned once_.
+
+### Start node
+
+Every flow has an implicit start node which represents the "landing page" i.e. the page which displays the "Start" button. There is no representation of this start node in the flow definition. Clicking the "Start" button on the "landing page" takes you to the page for the first question node (see below).
+
+Also see the documentation for [landing page templates](doc/landing-page-template.md).
+
+### Question nodes
+
+There is an implicit assumption that the question definition which appears first in the flow definition is the first question of the flow. All other "routing" between nodes is [done explicitly](doc/next-node-rules.md) in a single `next_node` block per question node.
+
+By convention, question nodes are usually listed roughly in the order that a user would visit them. Although this isn't always straightforward when there are multiple paths through the flow.
+
+Since all "routing" is done explicitly within `next_node` blocks, the order of the question definitions (other than the first one) is functionally unimportant.
+
+By convention, all question nodes are defined *before* any of the outcome nodes. However, again the order is functionally unimportant.
+
+Question nodes are defined by calls to one of the various [question-type methods](doc/question-types.md). Since the value of `self` at the "top-level" within the `#define` method is an instance of the flow, these question-type methods are defined on the `SmartAnswer::Flow` base class.
+
+For example:
+
+```ruby
+module SmartAnswer
+  class ExampleSmartAnswerFlow < Flow
+    def define
+      # metadata specified here
+
+      multiple_choice :question_key do
+        option :option_key_1
+        option :option_key_2
+
+        # optional blocks specified here
+
+        next_node do
+          # routing logic specified here
+        end
+      end
+    end
+  end
+end
+```
+
+See [In-question blocks](#in-question-blocks) below for more information on the optional blocks mentioned in a comment in the example.
+
+#### Scope
+
+The value of `self` inside the question node definition block (but outside other blocks) is the instance of the relevant question node. Thus in the example above, the calls to `#option` and `#next_node` are made on the instance of the question node.
+
+In the same way that there is a single instance of each flow class, there is only ever a single instance of each question definition in the system at any one time i.e. a flow instance has an invariant set of question node definition instances.
+
+Since the same instance of a question definition is used across multiple requests, it's important that no request-specific state is stored on them.
+
+The value of `self` inside the `next_node` blocks (or the other optional blocks) is an instance of `SmartAnswer::State` ([see below](#state)), i.e. *not* an instance of a question node.
+
+```ruby
+def define
+  # self = instance of SmartAnswer::Flow
+
+  value_question :question_key do
+    # self = instance of SmartAnswer::Question::Value
+
+    on_response do |response|
+      # self = instance of SmartAnswer::State
+    end
+
+    next_node do
+      # self = instance of SmartAnswer::State
+    end
+  end
+end
+```
+
+#### Execution
+
+The code inside the question node definition block (but outside other blocks) is executed at _flow definition time_, not at request time. However, the code inside the `next_node` blocks (or the other optional blocks) is executed at _request time_, not at flow definition time.
+
+```ruby
+def define
+  # executed at flow definition time
+
+  value_question :question_key do
+    # executed at flow definition time
+
+    on_response do |response|
+      # executed at request time
+    end
+
+    next_node do
+      # executed at request time
+    end
+  end
+end
+```
+
+#### State
+
+The state object is intended to store all request-specific state, keeping that away from the instance of the flow which is reused across multiple requests. `SmartAnswer::State` inherits from `OpenStruct` and uses [`BasicObject#method_missing`][method-missing]
+to allow arbitrary "state variables" to be written and read.
+
+Since the request path only includes the user's responses and *not* the question keys, and the app is stateless, *every* request has to be processed by walking through the question definition nodes starting at the first one. As a request is processed, the state is duplicated using [`Object#dup`][object-dup] in each "transition" to a new node.
+
+It's important to note that `Object#dup` does not do a "deep" copy. Thus any "state variables" set on the state which are references to other objects will continue to reference the same instances of those other object - those objects will *not* themselves be duplicated. The *only* exceptions to this are two built-in state variables, `responses` & `path` ([see below](#built-in-state-variables)) which are themselves duplicated using `Object#dup` in `State#initialize_copy`.
+
+> Since a new instance of the state is created for each request, it's not obvious why the state is duplicated in this way. I know that in the past there have been problems with state leaking between requests, so perhaps this was a mistaken attempt at preventing such leakage.
+
+It's possible to [view the state](doc/viewing-state.md) when you're running the app in the development environment.
+
+##### Built-in state variables
+
+* `current_node` - symbol key for the node being processed
+* `path` - array of symbol keys for nodes previously processed
+* `responses` - user responses parsed from request path; usually strings (?)
+* `response` - always `nil` (?)
+* `error` - key for validation error message to display; usually a string (?)
+
+> Note that some of the application code (e.g. illegal multiple choice response) erroneously sets the error key to the validation error message *string*. Since this string is not the *key* to an error message, the default error message is displayed.
+
+#### In-question blocks
+
+All question definition blocks, must include a single `next_node` block. A number of other in-question blocks can optionally be defined by passing a block to any of the following methods on `SmartAnswer::Node` & `SmartAnswer::Question::Base`. The value of `self` inside all these blocks is an instance of `SmartAnswer::State` ([see above](#state)). The code inside these blocks is executed at request time, not at flow definition time.
+
+All blocks of a particular type (within a single question) are executed at particular points in the request processing sequence i.e. all `on_response` blocks are executed before all `next_node_calculation` blocks. The order in which the blocks are defined only affects the order in which they are executed within the group of blocks of the same type i.e. when two `on_response` blocks are defined, the one defined first will be executed before the one defined second; however, even if a `next_node_calculation` block is defined before both of these `on_response` blocks, it will always be executed after both of them.
+
+The block types are executed in the following order:
+
+* [`precalculate`](#precalculatevariable_name-block)
+* [`on_response`](#on_responseblock)
+* [`next_node_calculation`](#next_node_calculationvariable_name-block)
+* [`validate`](#validatemessage_key-block)
+* [`next_node`](#next_nodeblock)
+* [`save_input_as`](#save_input_asvariable_name)
+* [`calculate`](#calculatevariable_name-block)
+
+Each of these block types and the point at which they are executed is explained in more detail below:
+
+##### `precalculate(variable_name, &block)`
+
+* These blocks were intended to be used to store state variables that are needed to render a question or outcome node template.
+* It's simplest to think about these blocks executing before the user response is parsed from the request path.
+* The block return value is stored on the state object as a state variable named `variable_name`.
+
+> Note that due to an oversight in the implementation of `Flow#process`, it's not currently possible to use a `precalculate` block in the first question.
+
+> The use of these blocks is deprecated and should never be necessary. Define methods on a `calculator` object instead.
+
+##### `on_response(&block)`
+
+* These blocks are intended to be used to store user responses on a `calculator` state variable. They are a [relatively new addition to the DSL][introduction-of-on-response-blocks].
+* These blocks are called  after the user response has been parsed from the request path and before any of the `next_node_calculation` blocks are executed.
+* The parsed response is passed to the block as the only argument and by convention is named `response`.
+* The block return value is not used and no state variable is stored.
+
+> The use of these blocks is encouraged; however, they should only ever be used to store a single, `calculator` state variable (in the first question definition); otherwise they should only be used to store user responses on that `calculator` object.
+
+##### `next_node_calculation(variable_name, &block)`
+
+* These blocks were intended to be used to store state variables that are needed in the `next_node` block.
+* These blocks are executed after all the `on_response` blocks have been executed and before any of the `validate` blocks are executed.
+* The parsed response is passed to the block as the only argument and by convention is named `response`.
+* The block return value is stored on the state object as a state variable named `variable_name`.
+
+> The use of these blocks is deprecated and should never be necessary. Define methods on a `calculator` object instead.
+
+##### `validate(message_key, &block)`
+
+* These blocks are intended to be used to validate the user response.
+* These blocks are executed after all the `next_node_calculation` blocks have been executed and before the `next_node` block is executed.
+* The parsed response is passed to the block as the only argument and by convention is named `response`.
+* If the block return value is truth-y, then no action is taken.
+* If the block return value is false-y, then:
+  * A `SmartAnswer::InvalidResponse` exception is raised with the `message_key` set as the exception message.
+  * Although this exception is handled within the app, it prevents the transition to the next node.
+  * The `message_key` from the exception message is set on the built-in state variable, `error`.
+  * When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](doc/question-templates.md#-error_message-message-).
+
+> The use of these blocks is encouraged. However, they should call `valid_xxx?` methods on the `calculator` state variable and not rely on the `response` argument passed into the block.
+
+##### `next_node(&block)`
+
+* There must only be one of these blocks per question definition.
+* This block is intended to determine which node comes next based on the user responses so far.
+* These blocks are executed after all the `validate` blocks have been executed and before any `save_input_as` blocks are executed.
+* The built-in state variables, `path`, `current_node` & `responses`, are updated if this block returns successfully.
+* The block return value must be the result of calling the `#question` or `#outcome` methods passing in the key of the next node - see the [next node documentation](doc/next-node-rules.md) for more details.
+
+> The use of this block type is *required*. However, it should call methods on the `calculator` state variable and not rely on the `response` argument passed into the block.
+
+##### `save_input_as(variable_name)`
+
+* Although you can call this method multiple times within a single question, only the last call will actually have any effect.
+* This method is intended to allow you to store the response to the current question for use in blocks in *subsequent* nodes.
+* The response is stored after the `next_node` block has been executed and before any `calculate` blocks are executed.
+* The response is stored on the state object as a state variable named `variable_name`.
+
+> The use of these blocks is deprecated and should never be necessary; `on_response` blocks should be used instead.
+
+##### `calculate(variable_name, &block)`
+
+* These blocks were intended to be used to store state variables that are needed in subsequent questions or outcomes.
+* These blocks are executed after `save_input_as` has executed and before any of the `precalculate` blocks on the *next* node are executed.
+* The parsed response is passed to the block as the only argument and by convention is named `response`.
+* The block return value is stored on the state object as a state variable named `variable_name`.
+
+> The use of these blocks is deprecated and should never be necessary. Define methods on a `calculator` object instead.
+
+#### Further information
+
+See the [documentation on storing data](doc/storing-data.md).
+
+#### Templates
+
+See the [documentation for question templates](doc/question-templates.md).
+
+### Outcome nodes
+
+These are very similar to question nodes, however, only the following methods are available within the node definition:
+
+* [`precalculate`](#precalculatevariable_name-block)
+* [`on_response`](#on_responseblock)
+* [`next_node_calculation`](#next_node_calculationvariable_name-block)
+* [`calculate`](#calculatevariable_name-block)
+
+Having said that, no response is usually processed by an outcome node and so it only makes any sense to use `precalculate` blocks. Furthermore if any attempt is made to process a response when the current node is an outcome node (e.g. by hacking the URL path), an exception will be raised.
+
+> The use of `precalculate` blocks in an outcome node definition is deprecated and should never be necessary; it should always be possible to call methods on the `calculator` state variable from within the templates instead.
+
+#### Templates
+
+See the [documentation for outcome templates](doc/outcome-templates.md).
+
+[instance-eval]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-instance_eval
+[instance-exec]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-instance_exec
+[method-missing]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-method_missing
+[object-dup]: http://ruby-doc.org/core-2.3.0/Object.html#method-i-dup
+[local-variable-in-flow-definition]: https://github.com/alphagov/smart-answers/blob/20d2d9f524e912a3edcb9256ce2d790059538641/lib/smart_answer_flows/register-a-birth.rb#L9-L12
+[introduction-of-on-response-blocks]: https://github.com/alphagov/smart-answers/pull/2408

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -36,7 +36,7 @@ The flow is defined within the `define` instance method of the `Flow` subclass u
 
 Each flow is instantiated in the [`FlowRegistry`][flow-registry] via the `Flow.build` method which, in turn, instantiates the flow and invokes its `Flow#define` method.
 
-Currently in production a single instance of each flow class is instantiated at application start-up (or strictly speaking on the first request) and cached in the `FlowRegistry` i.e. the same instance of a particular flow class is used to service all the user requests involving that Smart Answer. Thus it's important that no request-specific state is stored on the flow instance, otherwise this could leak into other user requests.
+Currently in `development` & `production` environments (but not in `test`) a single instance of each flow class is instantiated at application start-up (or strictly speaking on the first request) and cached in the `FlowRegistry` i.e. the same instance of a particular flow class is used to service all the user requests involving that Smart Answer. Thus it's important that no request-specific state is stored on the flow instance, otherwise this could leak into other user requests.
 
 It's important to understand this distinction between "flow definition time" and "request time" when trying to understand a flow definition. A number of the sections below refer to this distinction.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -97,6 +97,8 @@ For example:
 module SmartAnswer
   class ExampleSmartAnswerFlow < Flow
     def define
+      # self = instance of SmartAnswer::Flow
+
       # metadata specified here
 
       multiple_choice :question_key do

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -1,6 +1,6 @@
 # Flow
 
-At the heart of each Smart Answer is a subclass of `SmartAnswer::Flow`. Subclasses like this make a DSL available for [specifying metadata](#metadata), and [defining](#definition) all the [question nodes](#question-nodes), the [outcome nodes](#outcome-nodes), and the [rules](doc/next-node-rules.md) to control routing between the nodes.
+At the heart of each Smart Answer is a subclass of `SmartAnswer::Flow`. Subclasses like this make a DSL available for [specifying metadata](#metadata), and [defining](#definition) all the [question nodes](#question-nodes), the [outcome nodes](#outcome-nodes), and the [rules](next-node-rules.md) to control routing between the nodes.
 
 ## Naming
 
@@ -77,11 +77,11 @@ Some flows (e.g. [register-a-birth][local-variable-in-flow-definition]) define l
 
 Every flow has an implicit start node which represents the "landing page" i.e. the page which displays the "Start" button. There is no representation of this start node in the flow definition. Clicking the "Start" button on the "landing page" takes you to the page for the first question node (see below).
 
-Also see the documentation for [landing page templates](doc/landing-page-template.md).
+Also see the documentation for [landing page templates](landing-page-template.md).
 
 ### Question nodes
 
-There is an implicit assumption that the question definition which appears first in the flow definition is the first question of the flow. All other "routing" between nodes is [done explicitly](doc/next-node-rules.md) in a single `next_node` block per question node.
+There is an implicit assumption that the question definition which appears first in the flow definition is the first question of the flow. All other "routing" between nodes is [done explicitly](next-node-rules.md) in a single `next_node` block per question node.
 
 By convention, question nodes are usually listed roughly in the order that a user would visit them. Although this isn't always straightforward when there are multiple paths through the flow.
 
@@ -89,7 +89,7 @@ Since all "routing" is done explicitly within `next_node` blocks, the order of t
 
 By convention, all question nodes are defined *before* any of the outcome nodes. However, again the order is functionally unimportant.
 
-Question nodes are defined by calls to one of the various [question-type methods](doc/question-types.md). Since the value of `self` at the "top-level" within the `#define` method is an instance of the flow, these question-type methods are defined on the `SmartAnswer::Flow` base class.
+Question nodes are defined by calls to one of the various [question-type methods](question-types.md). Since the value of `self` at the "top-level" within the `#define` method is an instance of the flow, these question-type methods are defined on the `SmartAnswer::Flow` base class.
 
 For example:
 
@@ -202,7 +202,7 @@ new_state.example_state_variable.equal?(state.example_state_variable)
 
 > Since a new instance of the state is created for each request, it's not obvious _why_ the state is duplicated in this way. I know that in the past there have been problems with state leaking between requests, so perhaps this was a mistaken attempt at preventing such leakage.
 
-It's possible to [view the state](doc/viewing-state.md) when you're running the app in the development environment.
+It's possible to [view the state](viewing-state.md) when you're running the app in the development environment.
 
 ##### Built-in state variables
 
@@ -284,7 +284,7 @@ Each of these block types and the point at which they are executed is explained 
   1. A `SmartAnswer::InvalidResponse` exception is raised with the `message_key` set as the exception message.
   2. This exception is handled within the app and prevents the transition to the next node.
   3. The `message_key` from the exception message is set on the built-in state variable, `error`.
-  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](doc/question-templates.md#-error_message-message-).
+  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](question-templates.md#error_messagemessage).
 
 > The use of these blocks is encouraged. However, they should call `valid_xxx?` methods on the `calculator` state variable and not rely on the `response` argument passed into the block.
 
@@ -294,7 +294,7 @@ Each of these block types and the point at which they are executed is explained 
 * This block is intended to determine which node comes next based on the user responses so far.
 * These blocks are executed after all the `validate` blocks have been executed and before any `save_input_as` blocks are executed.
 * The built-in state variables, `path`, `current_node` & `responses`, are updated if this block returns successfully.
-* The block return value must be the result of calling the `#question` or `#outcome` methods passing in the key of the next node - see the [next node documentation](doc/next-node-rules.md) for more details.
+* The block return value must be the result of calling the `#question` or `#outcome` methods passing in the key of the next node - see the [next node documentation](next-node-rules.md) for more details.
 
 > The use of this block type is *required*. However, it should call methods on the `calculator` state variable and not rely on the `response` argument passed into the block.
 
@@ -318,11 +318,11 @@ Each of these block types and the point at which they are executed is explained 
 
 #### Further information
 
-See the [documentation on storing data](doc/storing-data.md).
+See the [documentation on storing data](storing-data.md).
 
 #### Templates
 
-See the [documentation for question templates](doc/question-templates.md).
+See the [documentation for question templates](question-templates.md).
 
 ### Outcome nodes
 
@@ -339,7 +339,7 @@ Having said that, no response is usually processed by an outcome node and so it 
 
 #### Templates
 
-See the [documentation for outcome templates](doc/outcome-templates.md).
+See the [documentation for outcome templates](outcome-templates.md).
 
 [instance-eval]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-instance_eval
 [instance-exec]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-instance_exec

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -326,16 +326,16 @@ See the [documentation for question templates](question-templates.md).
 
 ### Outcome nodes
 
-These are very similar to question nodes, however, only the following methods are available within the node definition:
+These are very similar to question nodes. However, it only makes sense to use `precalculate` blocks, because there should never be a response associated with an outcome node. Having said that, the following methods are all _technically_ available within the node definition, because they are instance methods on `SmartAnswer::Outcome` (or its superclasses):
 
 * [`precalculate`](#precalculatevariable_name-block)
 * [`on_response`](#on_responseblock)
 * [`next_node_calculation`](#next_node_calculationvariable_name-block)
 * [`calculate`](#calculatevariable_name-block)
 
-Having said that, no response is usually processed by an outcome node and so it only makes any sense to use `precalculate` blocks. Furthermore if any attempt is made to process a response when the current node is an outcome node (e.g. by hacking the URL path), an exception will be raised.
+If any attempt is made to process a response when the current node is an outcome node (e.g. by hacking the URL path), an exception will be raised.
 
-> The use of `precalculate` blocks in an outcome node definition is deprecated and should never be necessary; it should always be possible to call methods on the `calculator` state variable from within the templates instead.
+> Even the use of `precalculate` blocks in an outcome node definition is deprecated and should never be necessary; it should always be possible to call methods on the `calculator` state variable from within the templates instead.
 
 #### Templates
 

--- a/doc/landing-page-template.md
+++ b/doc/landing-page-template.md
@@ -2,7 +2,29 @@
 
 Landing page templates live in `lib/smart_answer_flows/<flow-name>/<flow-name-with-underscores>.govspeak.erb`.
 
-The templates can contain content for the `title`, `meta_description`, `body` and `post_body`, all of which are optional.
+## Content types
+
+The templates can contain content for any of the following keys:
+
+### `title(text)`
+
+* `text` argument is a String
+* Used as the heading (currently "h1")
+
+### `meta_description(text)`
+
+* `text` argument is a String
+* Used as the content for the [meta description tag][meta-description]
+
+### `body(govspeak)`
+
+* `govspeak` argument is a String in [Govspeak][] format
+* Used to generate the main content (appearing above the start button)
+
+### `post_body(govspeak)`
+
+* `govspeak` argument is a String in [Govspeak][] format
+* Used to generate supplementary content (appearing below the start button)
 
 ## Example
 
@@ -19,3 +41,6 @@ The templates can contain content for the `title`, `meta_description`, `body` an
   Use this tool to look up the additional code (Meursing code) for import or export of goods containing certain types of milk and sugars covered Regulation (EC) No. 1216/09.
 <% end %>
 ```
+
+[Govspeak]: https://github.com/alphagov/govspeak
+[meta-description]: https://moz.com/learn/seo/meta-description

--- a/doc/outcome-templates.md
+++ b/doc/outcome-templates.md
@@ -2,7 +2,24 @@
 
 Outcome templates live in `lib/smart_answer_flows/<flow-name>/outcomes/<outcome-name>.govspeak.erb`.
 
-The templates can contain content for the `title`, `body` and `next_steps`, all of which are optional.
+## Content types
+
+The templates can contain content for any of the following keys:
+
+### `title(text)`
+
+* `text` argument is a String
+* Used as the heading (currently "h1")
+
+### `body(govspeak)`
+
+* `govspeak` argument is a String in [Govspeak][] format
+* Used as the main text
+
+### `next_steps(govspeak)`
+
+* `govspeak` argument is a String in [Govspeak][] format
+* Used to generate "next steps" content (at top of a right-hand sidebar)
 
 ## Example
 

--- a/doc/question-templates.md
+++ b/doc/question-templates.md
@@ -14,7 +14,7 @@ The templates can contain content for any of the following keys:
 
 ### `options(hash)`
 
-* Valid for multiple choice & checkbox question types
+* Valid for [multiple choice](question-types.md#multiple_choice) & [checkbox question](question-types.md#checkbox_question) types
 * `hash` argument is a `Hash` of option keys (strings) and text values (also strings)
 * Used to "translate" options keys for multiple choice & checkbox questions into human-friendly text
 
@@ -35,7 +35,7 @@ The templates can contain content for any of the following keys:
 
 ### `suffix_label(text)`
 
-* Valid for value & money questions
+* Valid for [value questions](question-types.md#value_question) & [money questions](question-types.md#money_question)
 * `text` argument is a String
 * Used as the label (following the input control)
 

--- a/doc/question-templates.md
+++ b/doc/question-templates.md
@@ -43,7 +43,7 @@ The templates can contain content for any of the following keys:
 
 * Valid for all question types
 * `govspeak` argument is a String in [Govspeak][] format
-* Used to generate the main content (appearing above the input control)
+* Used to generate the main content (appearing above the input control, e.g. text input element)
 
 ### `post_body(govspeak)`
 

--- a/doc/question-templates.md
+++ b/doc/question-templates.md
@@ -15,7 +15,7 @@ The templates can contain content for any of the following keys:
 ### `options(hash)`
 
 * Valid for multiple choice & checkbox question types
-* `hash` argument is a `Hash` of option key Strings versus option text Strings
+* `hash` argument is a `Hash` of option keys (strings) and text values (also strings)
 * Used to "translate" options keys for multiple choice & checkbox questions into human-friendly text
 
 ### `hint(text)`

--- a/doc/question-templates.md
+++ b/doc/question-templates.md
@@ -2,9 +2,67 @@
 
 Question templates live in `lib/smart_answer_flows/<flow-name>/questions/<question-name>.govspeak.erb`.
 
-The templates can contain content for the `title`, `hint`, `suffix_label`, `body` and `post_body`, all of which are optional.
+## Content types
 
-The templates can contain the options for multiple choice questions.
+The templates can contain content for any of the following keys:
+
+### `title(text)`
+
+* Valid for all question types
+* `text` argument is a String
+* Used as the heading (currently "h2")
+
+### `options(hash)`
+
+* Valid for multiple choice & checkbox question types
+* `hash` argument is a `Hash` of option key Strings versus option text Strings
+* Used to "translate" options keys for multiple choice & checkbox questions into human-friendly text
+
+### `hint(text)`
+
+* Valid for all question types
+* `text` argument is a String
+* Used as a "hint" paragraph
+* Also used to generate a label for value & postcode questions
+
+> I'm not convinced the `hint` key should be overloaded by the value & postcode question types - the `label` key would seem more appropriate.
+
+### `label(text)`
+
+* Valid for value questions
+* `text` argument is a String
+* Used as a label (preceding the input control)
+
+### `suffix_label(text)`
+
+* Valid for value & money questions
+* `text` argument is a String
+* Used as the label (following the input control)
+
+### `body(govspeak)`
+
+* Valid for all question types
+* `govspeak` argument is a String in [Govspeak][] format
+* Used to generate the main content (appearing above the input control)
+
+### `post_body(govspeak)`
+
+* Valid for all question types
+* `govspeak` argument is a String in [Govspeak][] format
+* Used to generate supplementary content (appearing below the input control)
+
+### `error_message(message)`
+
+* Valid for all question types
+* `message` argument is a String
+* Error message for the default validation error key
+
+### `error_xxx(message)`
+
+* Valid for all question types
+* `message` argument is a String
+* Error message for a custom validation error key
+* Any key can be used, but by convention the `error_` prefix is used
 
 ## Example
 
@@ -23,3 +81,5 @@ The templates can contain the options for multiple choice questions.
   The values represent % by weight
 <% end %>
 ```
+
+[Govspeak]: https://github.com/alphagov/govspeak

--- a/doc/question-types.md
+++ b/doc/question-types.md
@@ -1,11 +1,11 @@
 # Question types
 
-* `checkbox_question`
+## `checkbox_question`
   * User input: Choose zero to many options from a list of options.
   * Validation: Must be in the list of options.
   * Response: String containing comma-separated list of chosen options.
 
-* `country_select`
+## `country_select`
   * Options:
     * `exclude_countries`: Optional. Array of countries to exclude from the list.
     * `include_uk`: Optional. Boolean indicating whether to include 'united-kingdom' in the list.
@@ -14,32 +14,32 @@
   * Validation: Must be in the list of countries.
   * Response: String containing the chosen country.
 
-* `date_question`
+## `date_question`
   * User input: Choose a single date.
   * Validation: Must be a valid date.
   * Response: `Date` object.
 
-* `money_question`
+## `money_question`
   * User input: Enter a money amount.
   * Validation: Must be a number.
   * Response: `Money` object.
 
-* `multiple_choice`
+## `multiple_choice`
   * User input: Choose a single option from a list of options.
   * Validation: Must be in the list of options.
   * Response: String containing the chosen option.
 
-* `postcode_question`
+## `postcode_question`
   * User input: Enter a postcode.
   * Validation: Must be a valid postcode.
   * Response: String containing a normalised postcode (e.g. "wc2b6nh" becomes "WC2B 6NH").
 
-* `salary_question`
+## `salary_question`
   * User input: Enter an Amount and associated Period.
   * Validation: Amount must be a valid `Money` object and Period must be one of 'year', 'month' or 'week'.
   * Response: `Salary` object.
 
-* `value_question`
+## `value_question`
   * Options:
     * `parse`: Optional. One of `Integer`, `:to_i`, `Float` or `:to_f`
   * User input: Enter any text.


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/XMu0U6Qc

This is an attempt to improve the documentation, particularly around the flow definition e.g. the scope of variables within the various blocks, the execution order of those same blocks, and hence the availability of variables within templates.

I've focussed on documenting the *current* behaviour of the app. However, where appropriate, I've also tried to highlight the following:

* peculiarities of the current behaviour
* things that are deprecated/encouraged (as we try to [move towards the new-style of flow][refactoring])

Note that where I have ascribed an intention to the current behaviour of the app, this is essentially guesswork, because neither @chrisroos nor I were involved in building the app in the first place.

I was slightly hesitant to write this documentation, because the flow definition DSL is a moving target as we [move towards the new-style of flow][refactoring]. The aim is for it to be much simpler/intuitive and not need as much documentation!

It's probably best to review this pull request by viewing the final versions of the affected pages, rather than the diffs:

* [flow-definition](https://github.com/alphagov/smart-answers/blob/improve-flow-definition-documentation/doc/flow-definition.md)
* [landing-page-template](https://github.com/alphagov/smart-answers/blob/improve-flow-definition-documentation/doc/landing-page-template.md)
* [question-templates](https://github.com/alphagov/smart-answers/blob/improve-flow-definition-documentation/doc/question-templates.md)
* [outcome-templates](https://github.com/alphagov/smart-answers/blob/improve-flow-definition-documentation/doc/outcome-templates.md)

## External changes

None. This only includes changes to documentation.

[refactoring]: https://github.com/alphagov/smart-answers/blob/improve-flow-definition-documentation/doc/refactoring.md
