### PR TITLE
Refactor state-pension-topup to new-style flow (with feedback addressed)

### DIFF
--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -18,6 +18,10 @@ module SmartAnswer::Calculators
       @gender ||= 'female'
     end
 
+    def valid_whole_number_weekly_amount?
+      weekly_amount.to_f % 1 == 0
+    end
+
     def lump_sum_and_age
       return [] if too_young?
       rows = []

--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -22,6 +22,10 @@ module SmartAnswer::Calculators
       weekly_amount.to_f % 1 == 0
     end
 
+    def valid_weekly_amount_in_range?
+      (1..25).include?(weekly_amount.to_f)
+    end
+
     def lump_sum_and_age
       return [] if too_young?
       rows = []

--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -13,8 +13,13 @@ module SmartAnswer::Calculators
     attr_accessor :gender
     attr_accessor :weekly_amount
 
+    def initialize(attributes = {})
+      super
+      @gender ||= 'female'
+    end
+
     def lump_sum_and_age
-      return [] if too_young?(date_of_birth, gender)
+      return [] if too_young?
       rows = []
       dob = leap_year_birthday?(date_of_birth) ? date_of_birth + 1.day : date_of_birth
       age = age_at_date(dob, TOPUP_START_DATE)
@@ -26,7 +31,7 @@ module SmartAnswer::Calculators
       rows
     end
 
-    def too_young?(date_of_birth, gender = 'female')
+    def too_young?
       case gender
       when 'female'
         date_of_birth > FEMALE_YOUNGEST_DOB

--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -11,6 +11,7 @@ module SmartAnswer::Calculators
 
     attr_accessor :date_of_birth
     attr_accessor :gender
+    attr_accessor :weekly_amount
 
     def lump_sum_and_age(dob, weekly_amount, gender)
       return [] if too_young?(dob, gender)

--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -13,10 +13,10 @@ module SmartAnswer::Calculators
     attr_accessor :gender
     attr_accessor :weekly_amount
 
-    def lump_sum_and_age(dob, weekly_amount, gender)
-      return [] if too_young?(dob, gender)
+    def lump_sum_and_age
+      return [] if too_young?(date_of_birth, gender)
       rows = []
-      dob = leap_year_birthday?(dob) ? dob + 1.day : dob
+      dob = leap_year_birthday?(date_of_birth) ? date_of_birth + 1.day : date_of_birth
       age = age_at_date(dob, TOPUP_START_DATE)
       (TOPUP_START_DATE.year..TOPUP_END_DATE.year).each do |_|
         break if birthday_after_topup_end?(dob, age)

--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -1,11 +1,15 @@
 module SmartAnswer::Calculators
   class StatePensionTopupCalculator
+    include ActiveModel::Model
+
     FEMALE_YOUNGEST_DOB = Date.parse('1953-04-05')
     MALE_YOUNGEST_DOB = Date.parse('1951-04-05')
     TOPUP_START_DATE = Date.parse('2015-10-12')
     TOPUP_END_DATE = Date.parse('2017-04-05')
     FEMALE_RETIREMENT_AGE = 62
     MALE_RETIREMENT_AGE = 65
+
+    attr_accessor :date_of_birth
 
     def lump_sum_and_age(dob, weekly_amount, gender)
       return [] if too_young?(dob, gender)

--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -10,6 +10,7 @@ module SmartAnswer::Calculators
     MALE_RETIREMENT_AGE = 65
 
     attr_accessor :date_of_birth
+    attr_accessor :gender
 
     def lump_sum_and_age(dob, weekly_amount, gender)
       return [] if too_young?(dob, gender)

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -48,8 +48,8 @@ module SmartAnswer
           calculator.weekly_amount = response
         end
 
-        calculate :integer_value do |response|
-          money = response.to_f
+        calculate :integer_value do
+          money = calculator.weekly_amount.to_f
           if (money % 1 != 0) || (money > 25 || money < 1)
             raise SmartAnswer::InvalidResponse
           end

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -10,11 +10,10 @@ module SmartAnswer
       date_question :dob_age? do
         date_of_birth_defaults
 
-        on_response do
+        on_response do |response|
           self.calculator = Calculators::StatePensionTopupCalculator.new
+          calculator.date_of_birth = response
         end
-
-        save_input_as :date_of_birth
 
         next_node_calculation(:too_young) do |response|
           calculator.too_young?(response)
@@ -37,7 +36,7 @@ module SmartAnswer
         save_input_as :gender
 
         next_node_calculation(:male_and_too_young) do |response|
-          calculator.too_young?(date_of_birth, response)
+          calculator.too_young?(calculator.date_of_birth, response)
         end
 
         next_node do
@@ -68,7 +67,7 @@ module SmartAnswer
       #A1
       outcome :outcome_topup_calculations do
         precalculate :amounts_vs_ages do
-          calculator.lump_sum_and_age(date_of_birth, weekly_amount, gender)
+          calculator.lump_sum_and_age(calculator.date_of_birth, weekly_amount, gender)
         end
       end
       #A2

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -53,8 +53,7 @@ module SmartAnswer
         end
 
         validate :error_outside_range do
-          money = calculator.weekly_amount.to_f
-          (1..25).include?(money)
+          calculator.valid_weekly_amount_in_range?
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -69,11 +69,7 @@ module SmartAnswer
       end
 
       #A1
-      outcome :outcome_topup_calculations do
-        precalculate :weekly_amount do
-          calculator.weekly_amount
-        end
-      end
+      outcome :outcome_topup_calculations
       #A2
       outcome :outcome_pension_age_not_reached
     end

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -15,8 +15,8 @@ module SmartAnswer
           calculator.date_of_birth = response
         end
 
-        next_node_calculation(:too_young) do |response|
-          calculator.too_young?(response)
+        next_node_calculation(:too_young) do
+          calculator.too_young?(calculator.date_of_birth)
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -49,8 +49,7 @@ module SmartAnswer
         end
 
         validate :error_not_whole_number do
-          money = calculator.weekly_amount.to_f
-          money % 1 == 0
+          calculator.valid_whole_number_weekly_amount?
         end
 
         validate :error_outside_range do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -33,7 +33,9 @@ module SmartAnswer
         option :male
         option :female
 
-        save_input_as :gender
+        on_response do |response|
+          calculator.gender = response
+        end
 
         next_node_calculation(:male_and_too_young) do |response|
           calculator.too_young?(calculator.date_of_birth, response)
@@ -67,7 +69,7 @@ module SmartAnswer
       #A1
       outcome :outcome_topup_calculations do
         precalculate :amounts_vs_ages do
-          calculator.lump_sum_and_age(calculator.date_of_birth, weekly_amount, gender)
+          calculator.lump_sum_and_age(calculator.date_of_birth, weekly_amount, calculator.gender)
         end
       end
       #A2

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -16,7 +16,7 @@ module SmartAnswer
         end
 
         next_node_calculation(:too_young) do
-          calculator.too_young?(calculator.date_of_birth)
+          calculator.too_young?
         end
 
         next_node do
@@ -38,7 +38,7 @@ module SmartAnswer
         end
 
         next_node_calculation(:male_and_too_young) do
-          calculator.too_young?(calculator.date_of_birth, calculator.gender)
+          calculator.too_young?
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -50,7 +50,7 @@ module SmartAnswer
 
         validate do
           money = calculator.weekly_amount.to_f
-          !(money % 1 != 0) && !(money > 25 || money < 1)
+          (money % 1 == 0) && (money <= 25 && money >= 1)
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -50,7 +50,7 @@ module SmartAnswer
 
         validate do
           money = calculator.weekly_amount.to_f
-          !((money % 1 != 0) || (money > 25 || money < 1))
+          !(money % 1 != 0) && !(money > 25 || money < 1)
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -48,9 +48,14 @@ module SmartAnswer
           calculator.weekly_amount = response
         end
 
-        validate do
+        validate :error_not_whole_number do
           money = calculator.weekly_amount.to_f
-          (money % 1 == 0) && (1..25).include?(money)
+          money % 1 == 0
+        end
+
+        validate :error_outside_range do
+          money = calculator.weekly_amount.to_f
+          (1..25).include?(money)
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -52,7 +52,9 @@ module SmartAnswer
 
       #Q3
       money_question :how_much_extra_per_week? do
-        save_input_as :weekly_amount
+        on_response do |response|
+          calculator.weekly_amount = response
+        end
 
         calculate :integer_value do |response|
           money = response.to_f
@@ -68,8 +70,12 @@ module SmartAnswer
 
       #A1
       outcome :outcome_topup_calculations do
+        precalculate :weekly_amount do
+          calculator.weekly_amount
+        end
+
         precalculate :amounts_vs_ages do
-          calculator.lump_sum_and_age(calculator.date_of_birth, weekly_amount, calculator.gender)
+          calculator.lump_sum_and_age(calculator.date_of_birth, calculator.weekly_amount, calculator.gender)
         end
       end
       #A2

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -50,7 +50,7 @@ module SmartAnswer
 
         validate do
           money = calculator.weekly_amount.to_f
-          (money % 1 == 0) && (money >= 1 && money <= 25)
+          (money % 1 == 0) && (1..25).include?(money)
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -6,11 +6,13 @@ module SmartAnswer
       status :published
       satisfies_need "100865"
 
-      calculator = Calculators::StatePensionTopupCalculator.new
-
       #Q1
       date_question :dob_age? do
         date_of_birth_defaults
+
+        on_response do
+          self.calculator = Calculators::StatePensionTopupCalculator.new
+        end
 
         save_input_as :date_of_birth
 

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -33,12 +33,8 @@ module SmartAnswer
           calculator.gender = response
         end
 
-        next_node_calculation(:male_and_too_young) do
-          calculator.too_young?
-        end
-
         next_node do
-          if male_and_too_young
+          if calculator.too_young?
             outcome :outcome_pension_age_not_reached
           else
             question :how_much_extra_per_week?

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -73,10 +73,6 @@ module SmartAnswer
         precalculate :weekly_amount do
           calculator.weekly_amount
         end
-
-        precalculate :amounts_vs_ages do
-          calculator.lump_sum_and_age
-        end
       end
       #A2
       outcome :outcome_pension_age_not_reached

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -75,7 +75,7 @@ module SmartAnswer
         end
 
         precalculate :amounts_vs_ages do
-          calculator.lump_sum_and_age(calculator.date_of_birth, calculator.weekly_amount, calculator.gender)
+          calculator.lump_sum_and_age
         end
       end
       #A2

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -50,7 +50,7 @@ module SmartAnswer
 
         validate do
           money = calculator.weekly_amount.to_f
-          (money % 1 == 0) && (money <= 25 && money >= 1)
+          (money % 1 == 0) && (money >= 1 && money <= 25)
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -15,12 +15,8 @@ module SmartAnswer
           calculator.date_of_birth = response
         end
 
-        next_node_calculation(:too_young) do
-          calculator.too_young?
-        end
-
         next_node do
-          if too_young
+          if calculator.too_young?
             outcome :outcome_pension_age_not_reached
           else
             question :gender?

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -48,11 +48,9 @@ module SmartAnswer
           calculator.weekly_amount = response
         end
 
-        calculate :integer_value do
+        validate do
           money = calculator.weekly_amount.to_f
-          if (money % 1 != 0) || (money > 25 || money < 1)
-            raise SmartAnswer::InvalidResponse
-          end
+          !((money % 1 != 0) || (money > 25 || money < 1))
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -37,8 +37,8 @@ module SmartAnswer
           calculator.gender = response
         end
 
-        next_node_calculation(:male_and_too_young) do |response|
-          calculator.too_young?(calculator.date_of_birth, response)
+        next_node_calculation(:male_and_too_young) do
+          calculator.too_young?(calculator.date_of_birth, calculator.gender)
         end
 
         next_node do

--- a/lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <% content_for :body do %>
-  To top up your pension by <%= format_money(weekly_amount) %> per week, you’ll need to make a lump sum payment of either:
+  To top up your pension by <%= format_money(calculator.weekly_amount) %> per week, you’ll need to make a lump sum payment of either:
 
   <% calculator.lump_sum_and_age.each do |amount_and_age| %>
     - <%= number_to_currency(amount_and_age[:amount], precision: 0) %> when you're <%= amount_and_age[:age] %>

--- a/lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb
@@ -6,7 +6,7 @@
 <% content_for :body do %>
   To top up your pension by <%= format_money(weekly_amount) %> per week, you’ll need to make a lump sum payment of either:
 
-  <% amounts_vs_ages.each do |amount_and_age| %>
+  <% calculator.lump_sum_and_age.each do |amount_and_age| %>
     - <%= number_to_currency(amount_and_age[:amount], precision: 0) %> when you're <%= amount_and_age[:age] %>
   <% end %>
 

--- a/lib/smart_answer_flows/state-pension-topup/questions/how_much_extra_per_week.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-topup/questions/how_much_extra_per_week.govspeak.erb
@@ -6,6 +6,10 @@
   Enter a number between 1 and 25.
 <% end %>
 
-<% content_for :error_message do %>
-  Enter an amount in whole pounds between 1 and 25.
+<% content_for :error_not_whole_number do %>
+  Enter an amount in whole pounds.
+<% end %>
+
+<% content_for :error_outside_range do %>
+  Enter an amount in pounds between 1 and 25.
 <% end %>

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -1,14 +1,14 @@
 ---
-lib/smart_answer_flows/state-pension-topup.rb: 39e5b5366441d664e3a3cd416986ee8e
+lib/smart_answer_flows/state-pension-topup.rb: 55503f016500699b4e8308b0bd5de50f
 test/data/state-pension-topup-questions-and-responses.yml: f4f609a6e989f166616a05435c6993aa
 test/data/state-pension-topup-responses-and-expected-results.yml: 1207c6118839a3b13810038c57a20d4a
 lib/smart_answer_flows/state-pension-topup/outcomes/outcome_pension_age_not_reached.govspeak.erb: 558d49584fe1ece4d36427740d381273
-lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb: 421d026a06ca1c7dcb56e2712189211a
+lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb: 8148fcbf7595e725ff8fb4315c3f3b22
 lib/smart_answer_flows/state-pension-topup/questions/date_of_lump_sum_payment.govspeak.erb: bc785eb5fa3ee27edfaf9f223694942b
 lib/smart_answer_flows/state-pension-topup/questions/dob_age.govspeak.erb: a98e10bf8b60c21f65d307a56046f4d3
 lib/smart_answer_flows/state-pension-topup/questions/gender.govspeak.erb: f388163b3d7abb9c78bfe8265b2f2856
-lib/smart_answer_flows/state-pension-topup/questions/how_much_extra_per_week.govspeak.erb: fcbf62d8db40dde727445b1742e7b958
+lib/smart_answer_flows/state-pension-topup/questions/how_much_extra_per_week.govspeak.erb: 76492f1bf67bbfae095c80e7a8cbe465
 lib/smart_answer_flows/state-pension-topup/state_pension_topup.govspeak.erb: 4abd6d43b9288c4da91ace7460d09132
-lib/smart_answer/calculators/state_pension_topup_calculator.rb: 9ff8cf2d08e8f49f618f2ac12e6df880
+lib/smart_answer/calculators/state_pension_topup_calculator.rb: fe836ff394a90f6a5a52d6d207b2d198
 lib/smart_answer/calculators/state_pension_topup_data_query.rb: 62717af09ad451e49dbb9e1a4d5422bc
 lib/data/pension_top_up_data.yml: 8fb3111dcf367687e4035e1dcc8d003b

--- a/test/integration/smart_answer_flows/state_pension_topup_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_topup_test.rb
@@ -46,11 +46,11 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
           assert_current_node :outcome_topup_calculations
           assert_equal 10.0, current_state.calculator.weekly_amount
           assert_equal Date.parse("1950-02-02"), current_state.calculator.date_of_birth
-          assert_state_variable :amounts_vs_ages, [
+          assert_equal [
             { amount: SmartAnswer::Money.new(8900), age: 65 },
             { amount: SmartAnswer::Money.new(8710), age: 66 },
             { amount: SmartAnswer::Money.new(8470), age: 67 }
-          ]
+          ], current_state.calculator.lump_sum_and_age
         end
       end
     end
@@ -63,7 +63,7 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
     end
     should "qualify for top up" do
       assert_current_node :outcome_topup_calculations
-      assert current_state.amounts_vs_ages.present?
+      assert current_state.calculator.lump_sum_and_age.present?
     end
   end
   context "Man turns 65 on 6 April 2016 = DOB 6/4/1951 = not old enough" do
@@ -83,7 +83,7 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
     end
     should "qualify for top up" do
       assert_current_node :outcome_topup_calculations
-      assert current_state.amounts_vs_ages.present?
+      assert current_state.calculator.lump_sum_and_age.present?
     end
   end
   context "Woman turns 63 on 6 April 2016 = DOB 6/4/1953 = not old enough" do
@@ -102,11 +102,11 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
     end
     should "show three rates, two of them being the max age rate (100 => 127)" do
       assert_current_node :outcome_topup_calculations
-      assert_state_variable :amounts_vs_ages, [
+      assert_equal [
         { amount: SmartAnswer::Money.new(137), age: 99 },
         { amount: SmartAnswer::Money.new(127), age: 100 },
         { amount: SmartAnswer::Money.new(127), age: 101 }
-      ]
+      ], current_state.calculator.lump_sum_and_age
       assert_equal "male", current_state.calculator.gender
     end
   end
@@ -126,11 +126,11 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
     end
     should "go to calculations outcome and show 3 rates" do
       assert_current_node :outcome_topup_calculations
-      assert_state_variable :amounts_vs_ages, [
+      assert_equal [
         { amount: SmartAnswer::Money.new(694), age: 74 },
         { amount: SmartAnswer::Money.new(674), age: 75 },
         { amount: SmartAnswer::Money.new(646), age: 76 }
-      ]
+      ], current_state.calculator.lump_sum_and_age
     end
   end
 end

--- a/test/integration/smart_answer_flows/state_pension_topup_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_topup_test.rb
@@ -107,7 +107,7 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
         { amount: SmartAnswer::Money.new(127), age: 100 },
         { amount: SmartAnswer::Money.new(127), age: 101 }
       ]
-      assert_state_variable :gender, "male"
+      assert_equal "male", current_state.calculator.gender
     end
   end
   context "Woman who is 62 on 6 April 2016 = DOB 7/4/1953 = new rules (A2)" do

--- a/test/integration/smart_answer_flows/state_pension_topup_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_topup_test.rb
@@ -44,7 +44,7 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
         end
         should "bring you to results outcome" do
           assert_current_node :outcome_topup_calculations
-          assert_state_variable :weekly_amount, 10.0
+          assert_equal 10.0, current_state.calculator.weekly_amount
           assert_equal Date.parse("1950-02-02"), current_state.calculator.date_of_birth
           assert_state_variable :amounts_vs_ages, [
             { amount: SmartAnswer::Money.new(8900), age: 65 },

--- a/test/integration/smart_answer_flows/state_pension_topup_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_topup_test.rb
@@ -45,7 +45,7 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
         should "bring you to results outcome" do
           assert_current_node :outcome_topup_calculations
           assert_state_variable :weekly_amount, 10.0
-          assert_state_variable :date_of_birth, Date.parse("1950-02-02")
+          assert_equal Date.parse("1950-02-02"), current_state.calculator.date_of_birth
           assert_state_variable :amounts_vs_ages, [
             { amount: SmartAnswer::Money.new(8900), age: 65 },
             { amount: SmartAnswer::Money.new(8710), age: 66 },

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -32,60 +32,64 @@ module SmartAnswer::Calculators
     end
 
     context "lump_sum_and_age" do
-      should "show 2 rates for male ages 85 and 86" do
-        @calculator.date_of_birth = Date.parse('1930-04-06')
-        @calculator.weekly_amount = 10
-        @calculator.gender = 'male'
-        assert_equal [{ amount: 3940.0, age: 85 }, { amount: 3660.0, age: 86 }], @calculator.lump_sum_and_age
+      context "when male" do
+        should "show 2 rates for male ages 85 and 86" do
+          @calculator.date_of_birth = Date.parse('1930-04-06')
+          @calculator.weekly_amount = 10
+          @calculator.gender = 'male'
+          assert_equal [{ amount: 3940.0, age: 85 }, { amount: 3660.0, age: 86 }], @calculator.lump_sum_and_age
+        end
+
+        should "show two rates for a man born on 1951-04-05 who wants to top up his pension by £1 a week" do
+          @calculator.date_of_birth = Date.parse('1951-04-05')
+          @calculator.weekly_amount = 1
+          @calculator.gender = 'male'
+          expectation = [
+            { amount: 890.0, age: 65 },
+            { amount: 871.0, age: 66 },
+          ]
+          assert_equal expectation, @calculator.lump_sum_and_age
+        end
+
+        should "show no rates for men born on 1951-04-06 or after because they're too young to qualify" do
+          @calculator.date_of_birth = Date.parse('1953-04-06')
+          @calculator.weekly_amount = 1
+          @calculator.gender = 'male'
+          assert_equal [], @calculator.lump_sum_and_age
+        end
       end
 
-      should "show two rates for a man born on 1951-04-05 who wants to top up his pension by £1 a week" do
-        @calculator.date_of_birth = Date.parse('1951-04-05')
-        @calculator.weekly_amount = 1
-        @calculator.gender = 'male'
-        expectation = [
-          { amount: 890.0, age: 65 },
-          { amount: 871.0, age: 66 },
-        ]
-        assert_equal expectation, @calculator.lump_sum_and_age
-      end
+      context "when female" do
+        should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do
+          @calculator.date_of_birth = Date.parse('1953-04-05')
+          @calculator.weekly_amount = 1
+          @calculator.gender = 'female'
+          expectation = [
+            { amount: 956.0, age: 62 },
+            { amount: 934.0, age: 63 },
+            { amount: 913.0, age: 64 },
+          ]
+          assert_equal expectation, @calculator.lump_sum_and_age
+        end
 
-      should "show no rates for men born on 1951-04-06 or after because they're too young to qualify" do
-        @calculator.date_of_birth = Date.parse('1953-04-06')
-        @calculator.weekly_amount = 1
-        @calculator.gender = 'male'
-        assert_equal [], @calculator.lump_sum_and_age
-      end
+        should "show three rates for a woman born on 1952-10-13 who wants to top up her pension by £1 a week" do
+          @calculator.date_of_birth = Date.parse('1952-10-13')
+          @calculator.weekly_amount = 1
+          @calculator.gender = 'female'
+          expectation = [
+            { amount: 956.0, age: 62 },
+            { amount: 934.0, age: 63 },
+            { amount: 913.0, age: 64 },
+          ]
+          assert_equal expectation, @calculator.lump_sum_and_age
+        end
 
-      should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do
-        @calculator.date_of_birth = Date.parse('1953-04-05')
-        @calculator.weekly_amount = 1
-        @calculator.gender = 'female'
-        expectation = [
-          { amount: 956.0, age: 62 },
-          { amount: 934.0, age: 63 },
-          { amount: 913.0, age: 64 },
-        ]
-        assert_equal expectation, @calculator.lump_sum_and_age
-      end
-
-      should "show three rates for a woman born on 1952-10-13 who wants to top up her pension by £1 a week" do
-        @calculator.date_of_birth = Date.parse('1952-10-13')
-        @calculator.weekly_amount = 1
-        @calculator.gender = 'female'
-        expectation = [
-          { amount: 956.0, age: 62 },
-          { amount: 934.0, age: 63 },
-          { amount: 913.0, age: 64 },
-        ]
-        assert_equal expectation, @calculator.lump_sum_and_age
-      end
-
-      should "show no rates for women born on 1953-04-06 or after because they're too young to qualify" do
-        @calculator.date_of_birth = Date.parse('1953-04-06')
-        @calculator.weekly_amount = 1
-        @calculator.gender = 'female'
-        assert_equal [], @calculator.lump_sum_and_age
+        should "show no rates for women born on 1953-04-06 or after because they're too young to qualify" do
+          @calculator.date_of_birth = Date.parse('1953-04-06')
+          @calculator.weekly_amount = 1
+          @calculator.gender = 'female'
+          assert_equal [], @calculator.lump_sum_and_age
+        end
       end
     end
 

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -37,10 +37,14 @@ module SmartAnswer::Calculators
           @calculator.gender = "male"
         end
 
-        should "show 2 rates for male ages 85 and 86" do
+        should "show two rates for male ages 85 and 86" do
           @calculator.date_of_birth = Date.parse('1930-04-06')
           @calculator.weekly_amount = 10
-          assert_equal [{ amount: 3940.0, age: 85 }, { amount: 3660.0, age: 86 }], @calculator.lump_sum_and_age
+          expectation = [
+            { amount: 3940.0, age: 85 },
+            { amount: 3660.0, age: 86 }
+          ]
+          assert_equal expectation, @calculator.lump_sum_and_age
         end
 
         should "show two rates for a man born on 1951-04-05 who wants to top up his pension by £1 a week" do

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -132,5 +132,17 @@ module SmartAnswer::Calculators
         end
       end
     end
+
+    context 'valid_whole_number_weekly_amount?' do
+      should 'be true if weekly_amount is whole number of pounds' do
+        @calculator.weekly_amount = SmartAnswer::Money.new(12.00)
+        assert @calculator.valid_whole_number_weekly_amount?
+      end
+
+      should 'be false if weekly_amount is not whole number of pounds' do
+        @calculator.weekly_amount = SmartAnswer::Money.new(12.50)
+        refute @calculator.valid_whole_number_weekly_amount?
+      end
+    end
   end
 end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -2,11 +2,11 @@ require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
   class StatePensionTopupCalculatorTest < ActiveSupport::TestCase
-    context "lump_sum_amount" do
-      setup do
-        @calculator = StatePensionTopupCalculator.new
-      end
+    setup do
+      @calculator = StatePensionTopupCalculator.new
+    end
 
+    context "lump_sum_amount" do
       should "be 8010 for age of 69" do
         assert_equal 8010, @calculator.send(:lump_sum_amount, 69, 10)
       end
@@ -22,10 +22,6 @@ module SmartAnswer::Calculators
     end
 
     context "age_at_date" do
-      setup do
-        @calculator = StatePensionTopupCalculator.new
-      end
-
       should "Show age of 64" do
         assert_equal 64, @calculator.send(:age_at_date, Date.parse('1951-04-06'), Date.parse('2015-10-12'))
       end
@@ -36,10 +32,6 @@ module SmartAnswer::Calculators
     end
 
     context "lump_sum_and_age (male)" do
-      setup do
-        @calculator = StatePensionTopupCalculator.new
-      end
-
       should "Show 2 rates for ages 85 and 86" do
         @calculator.date_of_birth = Date.parse('1930-04-06')
         @calculator.weekly_amount = 10
@@ -49,10 +41,6 @@ module SmartAnswer::Calculators
     end
 
     context "lump_sum_and_age" do
-      setup do
-        @calculator = StatePensionTopupCalculator.new
-      end
-
       should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do
         @calculator.date_of_birth = Date.parse('1953-04-05')
         @calculator.weekly_amount = 1
@@ -104,10 +92,6 @@ module SmartAnswer::Calculators
     end
 
     context 'too_young?' do
-      setup do
-        @calculator = StatePensionTopupCalculator.new
-      end
-
       context 'when gender is female' do
         setup do
           @threshold_date = StatePensionTopupCalculator::FEMALE_YOUNGEST_DOB

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -2,7 +2,7 @@ require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
   class StatePensionTopupCalculatorTest < ActiveSupport::TestCase
-    context "checking lump sum amount" do
+    context "lump_sum_amount" do
       setup do
         @calculator = StatePensionTopupCalculator.new
       end
@@ -21,7 +21,7 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "check lump sum amount and age" do
+    context "age_at_date" do
       setup do
         @calculator = StatePensionTopupCalculator.new
       end
@@ -35,7 +35,7 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "check return value for lump sum amount and age male" do
+    context "lump_sum_and_age (male)" do
       setup do
         @calculator = StatePensionTopupCalculator.new
       end
@@ -48,7 +48,7 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "check return value for lump sum amount and age" do
+    context "lump_sum_and_age" do
       setup do
         @calculator = StatePensionTopupCalculator.new
       end
@@ -103,7 +103,7 @@ module SmartAnswer::Calculators
       end
     end
 
-    context '#too_young?' do
+    context 'too_young?' do
       setup do
         @calculator = StatePensionTopupCalculator.new
       end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -37,7 +37,7 @@ module SmartAnswer::Calculators
           @calculator.gender = "male"
         end
 
-        should "show two rates for male ages 85 and 86" do
+        should "show two rates for ages 85 and 86" do
           @calculator.date_of_birth = Date.parse('1930-04-06')
           @calculator.weekly_amount = 10
           expectation = [
@@ -47,7 +47,7 @@ module SmartAnswer::Calculators
           assert_equal expectation, @calculator.lump_sum_and_age
         end
 
-        should "show two rates for a man born on 1951-04-05 who wants to top up his pension by £1 a week" do
+        should "show two rates when born on 1951-04-05 and with top-up of £1 a week" do
           @calculator.date_of_birth = Date.parse('1951-04-05')
           @calculator.weekly_amount = 1
           expectation = [
@@ -57,7 +57,7 @@ module SmartAnswer::Calculators
           assert_equal expectation, @calculator.lump_sum_and_age
         end
 
-        should "show no rates for men born on 1951-04-06 or after because they're too young to qualify" do
+        should "show no rates when born on 1951-04-06 or after (too young to qualify)" do
           @calculator.date_of_birth = Date.parse('1953-04-06')
           assert_equal [], @calculator.lump_sum_and_age
         end
@@ -68,7 +68,7 @@ module SmartAnswer::Calculators
           @calculator.gender = "female"
         end
 
-        should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do
+        should "show three rates when born on 1953-04-05 and with top-up of £1 a week" do
           @calculator.date_of_birth = Date.parse('1953-04-05')
           @calculator.weekly_amount = 1
           expectation = [
@@ -79,7 +79,7 @@ module SmartAnswer::Calculators
           assert_equal expectation, @calculator.lump_sum_and_age
         end
 
-        should "show three rates for a woman born on 1952-10-13 who wants to top up her pension by £1 a week" do
+        should "show three rates when born on 1952-10-13 and with top-up of £1 a week" do
           @calculator.date_of_birth = Date.parse('1952-10-13')
           @calculator.weekly_amount = 1
           expectation = [
@@ -90,7 +90,7 @@ module SmartAnswer::Calculators
           assert_equal expectation, @calculator.lump_sum_and_age
         end
 
-        should "show no rates for women born on 1953-04-06 or after because they're too young to qualify" do
+        should "show no rates when born on 1953-04-06 or after (too young to qualify)" do
           @calculator.date_of_birth = Date.parse('1953-04-06')
           assert_equal [], @calculator.lump_sum_and_age
         end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -100,29 +100,35 @@ module SmartAnswer::Calculators
     context 'too_young?' do
       context 'when gender is female' do
         setup do
+          @calculator.gender = "female"
           @threshold_date = StatePensionTopupCalculator::FEMALE_YOUNGEST_DOB
         end
 
         should 'be true if date of birth is after threshold date' do
-          assert @calculator.too_young?(@threshold_date + 1, 'female')
+          @calculator.date_of_birth = @threshold_date + 1
+          assert @calculator.too_young?
         end
 
         should 'be false if date of birth is on threshold date' do
-          refute @calculator.too_young?(@threshold_date, 'female')
+          @calculator.date_of_birth = @threshold_date
+          refute @calculator.too_young?
         end
       end
 
       context 'when gender is male' do
         setup do
+          @calculator.gender = "male"
           @threshold_date = StatePensionTopupCalculator::MALE_YOUNGEST_DOB
         end
 
         should 'be true if date of birth is after threshold date' do
-          assert @calculator.too_young?(@threshold_date + 1, 'male')
+          @calculator.date_of_birth = @threshold_date + 1
+          assert @calculator.too_young?
         end
 
         should 'be false if date of birth is on threshold date' do
-          refute @calculator.too_young?(@threshold_date, 'male')
+          @calculator.date_of_birth = @threshold_date
+          refute @calculator.too_young?
         end
       end
     end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -39,6 +39,24 @@ module SmartAnswer::Calculators
         assert_equal [{ amount: 3940.0, age: 85 }, { amount: 3660.0, age: 86 }], @calculator.lump_sum_and_age
       end
 
+      should "show two rates for a man born on 1951-04-05 who wants to top up his pension by £1 a week" do
+        @calculator.date_of_birth = Date.parse('1951-04-05')
+        @calculator.weekly_amount = 1
+        @calculator.gender = 'male'
+        expectation = [
+          { amount: 890.0, age: 65 },
+          { amount: 871.0, age: 66 },
+        ]
+        assert_equal expectation, @calculator.lump_sum_and_age
+      end
+
+      should "show no rates for men born on 1951-04-06 or after because they're too young to qualify" do
+        @calculator.date_of_birth = Date.parse('1953-04-06')
+        @calculator.weekly_amount = 1
+        @calculator.gender = 'male'
+        assert_equal [], @calculator.lump_sum_and_age
+      end
+
       should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do
         @calculator.date_of_birth = Date.parse('1953-04-05')
         @calculator.weekly_amount = 1
@@ -63,28 +81,10 @@ module SmartAnswer::Calculators
         assert_equal expectation, @calculator.lump_sum_and_age
       end
 
-      should "show two rates for a man born on 1951-04-05 who wants to top up his pension by £1 a week" do
-        @calculator.date_of_birth = Date.parse('1951-04-05')
-        @calculator.weekly_amount = 1
-        @calculator.gender = 'male'
-        expectation = [
-          { amount: 890.0, age: 65 },
-          { amount: 871.0, age: 66 },
-        ]
-        assert_equal expectation, @calculator.lump_sum_and_age
-      end
-
       should "show no rates for women born on 1953-04-06 or after because they're too young to qualify" do
         @calculator.date_of_birth = Date.parse('1953-04-06')
         @calculator.weekly_amount = 1
         @calculator.gender = 'female'
-        assert_equal [], @calculator.lump_sum_and_age
-      end
-
-      should "show no rates for men born on 1951-04-06 or after because they're too young to qualify" do
-        @calculator.date_of_birth = Date.parse('1953-04-06')
-        @calculator.weekly_amount = 1
-        @calculator.gender = 'male'
         assert_equal [], @calculator.lump_sum_and_age
       end
     end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -33,17 +33,19 @@ module SmartAnswer::Calculators
 
     context "lump_sum_and_age" do
       context "when male" do
+        setup do
+          @calculator.gender = "male"
+        end
+
         should "show 2 rates for male ages 85 and 86" do
           @calculator.date_of_birth = Date.parse('1930-04-06')
           @calculator.weekly_amount = 10
-          @calculator.gender = 'male'
           assert_equal [{ amount: 3940.0, age: 85 }, { amount: 3660.0, age: 86 }], @calculator.lump_sum_and_age
         end
 
         should "show two rates for a man born on 1951-04-05 who wants to top up his pension by £1 a week" do
           @calculator.date_of_birth = Date.parse('1951-04-05')
           @calculator.weekly_amount = 1
-          @calculator.gender = 'male'
           expectation = [
             { amount: 890.0, age: 65 },
             { amount: 871.0, age: 66 },
@@ -54,16 +56,18 @@ module SmartAnswer::Calculators
         should "show no rates for men born on 1951-04-06 or after because they're too young to qualify" do
           @calculator.date_of_birth = Date.parse('1953-04-06')
           @calculator.weekly_amount = 1
-          @calculator.gender = 'male'
           assert_equal [], @calculator.lump_sum_and_age
         end
       end
 
       context "when female" do
+        setup do
+          @calculator.gender = "female"
+        end
+
         should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do
           @calculator.date_of_birth = Date.parse('1953-04-05')
           @calculator.weekly_amount = 1
-          @calculator.gender = 'female'
           expectation = [
             { amount: 956.0, age: 62 },
             { amount: 934.0, age: 63 },
@@ -75,7 +79,6 @@ module SmartAnswer::Calculators
         should "show three rates for a woman born on 1952-10-13 who wants to top up her pension by £1 a week" do
           @calculator.date_of_birth = Date.parse('1952-10-13')
           @calculator.weekly_amount = 1
-          @calculator.gender = 'female'
           expectation = [
             { amount: 956.0, age: 62 },
             { amount: 934.0, age: 63 },
@@ -87,7 +90,6 @@ module SmartAnswer::Calculators
         should "show no rates for women born on 1953-04-06 or after because they're too young to qualify" do
           @calculator.date_of_birth = Date.parse('1953-04-06')
           @calculator.weekly_amount = 1
-          @calculator.gender = 'female'
           assert_equal [], @calculator.lump_sum_and_age
         end
       end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -41,7 +41,10 @@ module SmartAnswer::Calculators
       end
 
       should "Show 2 rates for ages 85 and 86" do
-        assert_equal [{ amount: 3940.0, age: 85 }, { amount: 3660.0, age: 86 }], @calculator.lump_sum_and_age(Date.parse('1930-04-06'), 10, 'male')
+        @calculator.date_of_birth = Date.parse('1930-04-06')
+        @calculator.weekly_amount = 10
+        @calculator.gender = 'male'
+        assert_equal [{ amount: 3940.0, age: 85 }, { amount: 3660.0, age: 86 }], @calculator.lump_sum_and_age
       end
     end
 
@@ -51,37 +54,52 @@ module SmartAnswer::Calculators
       end
 
       should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do
+        @calculator.date_of_birth = Date.parse('1953-04-05')
+        @calculator.weekly_amount = 1
+        @calculator.gender = 'female'
         expectation = [
           { amount: 956.0, age: 62 },
           { amount: 934.0, age: 63 },
           { amount: 913.0, age: 64 },
         ]
-        assert_equal expectation, @calculator.lump_sum_and_age(Date.parse('1953-04-05'), 1, 'female')
+        assert_equal expectation, @calculator.lump_sum_and_age
       end
 
       should "show three rates for a woman born on 1952-10-13 who wants to top up her pension by £1 a week" do
+        @calculator.date_of_birth = Date.parse('1952-10-13')
+        @calculator.weekly_amount = 1
+        @calculator.gender = 'female'
         expectation = [
           { amount: 956.0, age: 62 },
           { amount: 934.0, age: 63 },
           { amount: 913.0, age: 64 },
         ]
-        assert_equal expectation, @calculator.lump_sum_and_age(Date.parse('1952-10-13'), 1, 'female')
+        assert_equal expectation, @calculator.lump_sum_and_age
       end
 
       should "show two rates for a man born on 1951-04-05 who wants to top up his pension by £1 a week" do
+        @calculator.date_of_birth = Date.parse('1951-04-05')
+        @calculator.weekly_amount = 1
+        @calculator.gender = 'male'
         expectation = [
           { amount: 890.0, age: 65 },
           { amount: 871.0, age: 66 },
         ]
-        assert_equal expectation, @calculator.lump_sum_and_age(Date.parse('1951-04-05'), 1, 'male')
+        assert_equal expectation, @calculator.lump_sum_and_age
       end
 
       should "show no rates for women born on 1953-04-06 or after because they're too young to qualify" do
-        assert_equal [], @calculator.lump_sum_and_age(Date.parse('1953-04-06'), 1, 'female')
+        @calculator.date_of_birth = Date.parse('1953-04-06')
+        @calculator.weekly_amount = 1
+        @calculator.gender = 'female'
+        assert_equal [], @calculator.lump_sum_and_age
       end
 
       should "show no rates for men born on 1951-04-06 or after because they're too young to qualify" do
-        assert_equal [], @calculator.lump_sum_and_age(Date.parse('1951-04-06'), 1, 'male')
+        @calculator.date_of_birth = Date.parse('1953-04-06')
+        @calculator.weekly_amount = 1
+        @calculator.gender = 'male'
+        assert_equal [], @calculator.lump_sum_and_age
       end
     end
 

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -144,5 +144,22 @@ module SmartAnswer::Calculators
         refute @calculator.valid_whole_number_weekly_amount?
       end
     end
+
+    context 'valid_weekly_amount_in_range?' do
+      should 'be true if weekly_amount is between 1 and 25 inclusive' do
+        @calculator.weekly_amount = SmartAnswer::Money.new(12.50)
+        assert @calculator.valid_weekly_amount_in_range?
+      end
+
+      should 'be false if weekly_amount is less than 1' do
+        @calculator.weekly_amount = SmartAnswer::Money.new(0.99)
+        refute @calculator.valid_weekly_amount_in_range?
+      end
+
+      should 'be false if weekly_amount is more than 25' do
+        @calculator.weekly_amount = SmartAnswer::Money.new(25.01)
+        refute @calculator.valid_weekly_amount_in_range?
+      end
+    end
   end
 end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -55,7 +55,6 @@ module SmartAnswer::Calculators
 
         should "show no rates for men born on 1951-04-06 or after because they're too young to qualify" do
           @calculator.date_of_birth = Date.parse('1953-04-06')
-          @calculator.weekly_amount = 1
           assert_equal [], @calculator.lump_sum_and_age
         end
       end
@@ -89,7 +88,6 @@ module SmartAnswer::Calculators
 
         should "show no rates for women born on 1953-04-06 or after because they're too young to qualify" do
           @calculator.date_of_birth = Date.parse('1953-04-06')
-          @calculator.weekly_amount = 1
           assert_equal [], @calculator.lump_sum_and_age
         end
       end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -31,16 +31,14 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "lump_sum_and_age (male)" do
-      should "Show 2 rates for ages 85 and 86" do
+    context "lump_sum_and_age" do
+      should "show 2 rates for male ages 85 and 86" do
         @calculator.date_of_birth = Date.parse('1930-04-06')
         @calculator.weekly_amount = 10
         @calculator.gender = 'male'
         assert_equal [{ amount: 3940.0, age: 85 }, { amount: 3660.0, age: 86 }], @calculator.lump_sum_and_age
       end
-    end
 
-    context "lump_sum_and_age" do
       should "show three rates for a woman born on 1953-04-05 who wants to top up her pension by £1 a week" do
         @calculator.date_of_birth = Date.parse('1953-04-05')
         @calculator.weekly_amount = 1

--- a/test/unit/smart_answer_flows/state_pension_topup_flow_test.rb
+++ b/test/unit/smart_answer_flows/state_pension_topup_flow_test.rb
@@ -15,6 +15,7 @@ module SmartAnswer
     context 'when answering how_much_extra_per_week? question' do
       setup do
         @calculator.stubs(:valid_whole_number_weekly_amount?).returns(true)
+        @calculator.stubs(:valid_weekly_amount_in_range?).returns(true)
         setup_states_for_question(:how_much_extra_per_week?,
           responding_with: '12',
           initial_state: { calculator: @calculator })
@@ -41,6 +42,21 @@ module SmartAnswer
               initial_state: { calculator: @calculator })
           end
           assert_equal 'error_not_whole_number', e.message
+        end
+      end
+
+      context 'responding with an amount which is outside the range' do
+        setup do
+          @calculator.stubs(:valid_weekly_amount_in_range?).returns(false)
+        end
+
+        should 'raise an exception' do
+          e = assert_raise(SmartAnswer::InvalidResponse) do
+            setup_states_for_question(:how_much_extra_per_week?,
+              responding_with: '26',
+              initial_state: { calculator: @calculator })
+          end
+          assert_equal 'error_outside_range', e.message
         end
       end
     end

--- a/test/unit/smart_answer_flows/state_pension_topup_flow_test.rb
+++ b/test/unit/smart_answer_flows/state_pension_topup_flow_test.rb
@@ -1,0 +1,48 @@
+require_relative '../../test_helper'
+require_relative 'flow_unit_test_helper'
+
+require 'smart_answer_flows/state-pension-topup'
+
+module SmartAnswer
+  class StatePensionTopupFlowTest < ActiveSupport::TestCase
+    include FlowUnitTestHelper
+
+    setup do
+      @calculator = Calculators::StatePensionTopupCalculator.new
+      @flow = StatePensionTopupFlow.build
+    end
+
+    context 'when answering how_much_extra_per_week? question' do
+      setup do
+        @calculator.stubs(:valid_whole_number_weekly_amount?).returns(true)
+        setup_states_for_question(:how_much_extra_per_week?,
+          responding_with: '12',
+          initial_state: { calculator: @calculator })
+      end
+
+      should 'store parsed response on calculator as weekly_amount' do
+        assert_equal Money.new(12), @calculator.weekly_amount
+      end
+
+      should 'go to outcome_topup_calculations outcome' do
+        assert_equal :outcome_topup_calculations, @new_state.current_node
+        assert_node_exists :outcome_topup_calculations
+      end
+
+      context 'responding with an amount which is not a whole number' do
+        setup do
+          @calculator.stubs(:valid_whole_number_weekly_amount?).returns(false)
+        end
+
+        should 'raise an exception' do
+          e = assert_raise(SmartAnswer::InvalidResponse) do
+            setup_states_for_question(:how_much_extra_per_week?,
+              responding_with: '12.5',
+              initial_state: { calculator: @calculator })
+          end
+          assert_equal 'error_not_whole_number', e.message
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Supersedes #2602.

Similar to #2561, this moves the flow towards the style described in the [refactoring documentation][1]. I've concentrated on moving logic out of the flow and into the calculator and presentational concerns into the templates. The idea is to change all the flows to use this approach so we can significantly simplify the DSL.

I done some work on the calculator itself, but I haven't attempted to e.g. extract domain concepts, and some of the logic could possibly be simplified. Since some of the logic in the calculator was quite complicated, I ended up adding quite a few unit tests to check I wasn't breaking anything. However, there is still quite a bit of work to do to move all the tests for this flow towards the [new-style approach][2].

The logic in the calculator would also be considerably improved if we extracted domain concepts i.e. make the code more intention revealing as opposed to just procedural. However, I'm going to stop at this point, because the PR already has a *lot* of commits.

Although the PR has a lot of commits, the vast majority of them are very small and only affect a few files.

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md
[2]: https://github.com/alphagov/smart-answers/blob/master/doc/new-style-testing.md
