### PR TITLE
Update documentation to include on_response blocks (with feedback addressed)

### DIFF
--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -8,4 +8,4 @@ The file should be named the same as the path that we want the Smart Answer to b
 * The flow class should be `ExampleSmartAnswerFlow`
 * The flow name should be 'example-smart-answer'
 
-The `Flow` class contains a single `#define` method that defines the questions (see "Question types" below), rules (see "Defining next node rules" below) and outcomes (see "Outcome templates" below).
+The `Flow` class contains a single `#define` method that defines the questions (see [Question types](doc/question-types.md)), rules (see [Next node rules](doc/next-node-rules.md)) and outcomes (see [Outcome templates](doc/outcome-templates.md)).

--- a/doc/refactoring.md
+++ b/doc/refactoring.md
@@ -4,15 +4,15 @@ Some Smart Answer flows contain a mix of concerns: routing logic, policy/calcula
 
 These concerns should really be split. Routing belongs in the flow, policy/calculator logic belongs in the calculator and presentation belongs in the ERB templates. You might think of the flow as the Controller, the calculator as the Model and the ERB template as the View in an MVC architecture.
 
-We've refactored a small number of these Smart Answers and have a rough set of steps that we follow:
+We've refactored a number of these Smart Answers and have a rough set of steps that we follow:
 
 * Remove unused code from the flow, e.g. unused `save_input_as`, `precalculate` or `calculate` blocks. See commit [fe4014d7c007108f3daa07f1c5dd749f5de683a0](https://github.com/alphagov/smart-answers/commit/fe4014d7c007108f3daa07f1c5dd749f5de683a0) for an example.
 
 * Include `ActiveModel::Model` in the calculator so that it's easy to instantiate it with a number of attributes set. See commit [f78671a062339ae97abb5cb267b55536233316c9](https://github.com/alphagov/smart-answers/commit/f78671a062339ae97abb5cb267b55536233316c9) for an example.
 
-* Instantiate the calculator in a `next_node_calculation` block in the first question. See commit [6114c5fc55bfdaff52501e2a19dead35ebb42f13](https://github.com/alphagov/smart-answers/commit/6114c5fc55bfdaff52501e2a19dead35ebb42f13) for an example.
+* Instantiate the calculator in a `on_response` block in the first question. See commit [0df6fd7df9a00ec882edf249eeaaa68a291633c5](https://github.com/alphagov/smart-answers/commit/0df6fd7df9a00ec882edf249eeaaa68a291633c5) for an example.
 
-* Save the responses to questions on the calculator object rather than using `save_input_as`. See commit [64c60baf42e726fa234e579a04c36bc0da0fa3fc](https://github.com/alphagov/smart-answers/commit/64c60baf42e726fa234e579a04c36bc0da0fa3fc) for an example.
+* Save the responses to questions on the calculator object using an `on_response` block rather than using `save_input_as`. See commit [b17128fb92b89941238a7e94b0c1abebe4351a83](https://github.com/alphagov/smart-answers/commit/b17128fb92b89941238a7e94b0c1abebe4351a83) for an example.
 
 * Extract magic numbers into intention-revealing variables/constants. See commit [2e1f2ad117813cf0b8741ffbff6c711f5d838947](https://github.com/alphagov/smart-answers/commit/2e1f2ad117813cf0b8741ffbff6c711f5d838947) for an example.
 

--- a/doc/refactoring.md
+++ b/doc/refactoring.md
@@ -22,7 +22,7 @@ We've refactored a number of these Smart Answers and have a rough set of steps t
 
 * Move presentation from the flow/calculator to the ERB templates. See commit [a23e4c7ab8ed6b3ae4c53212d7cd4102fbeb1f37](https://github.com/alphagov/smart-answers/commit/a23e4c7ab8ed6b3ae4c53212d7cd4102fbeb1f37) for an example.
 
-* Define `calculate` blocks as late as possible. If something is only required by a single outcome then use a `precalculate` block in that outcome rather than defining it in a `calculate` block earlier in the flow. See commit [c98c60ddfeed70c6d60b89329f0e8fe3e030a171](https://github.com/alphagov/smart-answers/commit/c98c60ddfeed70c6d60b89329f0e8fe3e030a171) for an example.
+* Define `calculate` blocks as late as possible. If something is only required by a single outcome then use a `precalculate` block in that outcome rather than defining it in a `calculate` block earlier in the flow. See commit [c98c60ddfeed70c6d60b89329f0e8fe3e030a171](https://github.com/alphagov/smart-answers/commit/c98c60ddfeed70c6d60b89329f0e8fe3e030a171) for an example. However, eventually we shouldn't need *any* `calculate` blocks.
 
 [Pull request 2068][pr-2068] is a great example of incrementally applying the steps above to refactor the calculate-statutory-sick-pay Smart Answer. Pull requests [2095][pr-2095] and [1856][pr-1856] apply a similar refactoring to check-uk-visa and minimum-wage respectively.
 

--- a/doc/refactoring.md
+++ b/doc/refactoring.md
@@ -12,7 +12,24 @@ We've refactored a number of these Smart Answers and have a rough set of steps t
 
 * Instantiate the calculator in a `on_response` block in the first question. See commit [0df6fd7df9a00ec882edf249eeaaa68a291633c5](https://github.com/alphagov/smart-answers/commit/0df6fd7df9a00ec882edf249eeaaa68a291633c5) for an example.
 
+```ruby
+value_question :first_question? do
+  on_response do |response|
+    self.calculator = ExampleCalculator.new
+    calculator.first_response = response
+  end
+end
+```
+
 * Save the responses to questions on the calculator object using an `on_response` block rather than using `save_input_as`. See commit [b17128fb92b89941238a7e94b0c1abebe4351a83](https://github.com/alphagov/smart-answers/commit/b17128fb92b89941238a7e94b0c1abebe4351a83) for an example.
+
+```ruby
+value_question :subsequent_question? do
+  on_response do |response|
+    calculator.subsequent_response = response
+  end
+end
+```
 
 * Extract magic numbers into intention-revealing variables/constants. See commit [2e1f2ad117813cf0b8741ffbff6c711f5d838947](https://github.com/alphagov/smart-answers/commit/2e1f2ad117813cf0b8741ffbff6c711f5d838947) for an example.
 

--- a/doc/storing-data.md
+++ b/doc/storing-data.md
@@ -19,7 +19,41 @@ __NOTE.__ `precalculate` blocks are not evaluated in the first question. This is
   * The `calculate` block
   * All subsequent questions and outcomes
 
-__NOTE.__ `on_response` blocks are not named, because they don't automatically store a value in a state variable. In fact doing so is actively discouraged apart from when storing a calculator object in the first question of a flow.
+__NOTE.__ `on_response` blocks are not named, because they don't automatically store a value in a state variable. In fact doing so is actively discouraged apart from when storing a calculator object in the first question of a flow:
+
+```ruby
+multiple_choice :question_1? do
+  option :option_1
+  option :option_2
+
+  on_response do |response|
+    self.calculator = ExampleCalculator.new
+    calculator.question_1_response = response
+  end
+
+  next_node do
+    if calculator.question_1_response == 'option_1'
+      outcome :outcome_1
+    else
+      outcome :outcome_2
+    end
+  end
+end
+
+value_question :question_2? do
+  on_response do |response|
+    calculator.question_2_response = response
+  end
+
+  next_node do
+    if calculator.question_1_response == 'option_1' && calculator.question_2_response == 'London'
+      outcome :outcome_1
+    else
+      outcome :outcome_2
+    end
+  end
+end
+```
 
 * `next_node_calculation` values are available in:
   * The `validate` block

--- a/doc/storing-data.md
+++ b/doc/storing-data.md
@@ -2,17 +2,6 @@
 
 You can use the `on_response`, `precalculate`, `next_node_calculation`, `save_input_as` and `calculate` methods to store data for later use. These values are stored in the state and are available in the rest of the flow and in the ERB templates.
 
-* `on_response` values are available in:
-  * The `precalculate` block
-  * The question template
-  * The `next_node_calculation` block
-  * The `validate` block
-  * The `next_node` block
-  * The `calculate` block
-  * All subsequent questions and outcomes
-
-__NOTE.__ `on_response` blocks are not named, because they don't automatically store a value in a state variable. In fact doing so is actively discouraged apart from when storing a calculator object in the first question of a flow.
-
 * `precalculate` values are available in:
   * The question template
   * The `next_node_calculation` block
@@ -22,6 +11,15 @@ __NOTE.__ `on_response` blocks are not named, because they don't automatically s
   * All subsequent questions and outcomes
 
 __NOTE.__ `precalculate` blocks are not evaluated in the first question. This is because they're evaluated during the transition of one question to the next.
+
+* `on_response` values are available in:
+  * The `next_node_calculation` block
+  * The `validate` block
+  * The `next_node` block
+  * The `calculate` block
+  * All subsequent questions and outcomes
+
+__NOTE.__ `on_response` blocks are not named, because they don't automatically store a value in a state variable. In fact doing so is actively discouraged apart from when storing a calculator object in the first question of a flow.
 
 * `next_node_calculation` values are available in:
   * The `validate` block
@@ -61,11 +59,21 @@ multiple_choice :question_2? do
     'q2-precalculated-answer'
   end
 
+  on_response do |response|
+    # response                => 'q2_option'
+    # responses               => ['q1_option']
+    # q1_calculated_answer    => 'q1-calculated-answer'
+    # q2_precalculated_answer => 'q2_precalculated_answer'
+
+    self.q2_saved_response = response
+  end
+
   next_node_calculation :q2_next_node_calculated_answer do |response|
     # response                => 'q2_option'
     # responses               => ['q1_option']
     # q1_calculated_answer    => 'q1-calculated-answer'
     # q2_precalculated_answer => 'q2-precalculated-answer'
+    # q2_saved_response       => 'q2_option'
 
     'q2-next-node-calculated-answer'
   end
@@ -75,6 +83,7 @@ multiple_choice :question_2? do
     # responses                      => ['q1_option']
     # q1_calculated_answer           => 'q1-calculated-answer'
     # q2_precalculated_answer        => 'q2-precalculated-answer'
+    # q2_saved_response              => 'q2_option'
     # q2_next_node_calculated_answer => 'q2-next-node-calculated-answer'
   end
 
@@ -83,6 +92,7 @@ multiple_choice :question_2? do
     # responses                      => ['q1_option']
     # q1_calculated_answer           => 'q1-calculated-answer'
     # q2_precalculated_answer        => 'q2-precalculated-answer'
+    # q2_saved_response              => 'q2_option'
     # q2_next_node_calculated_answer => 'q2-next-node-calculated-answer'
   end
 
@@ -94,6 +104,7 @@ multiple_choice :question_2? do
     # q1_calculated_answer           => 'q1-calculated-answer'
     # q2_answer                      => 'q2_option'
     # q2_precalculated_answer        => 'q2-precalculated-answer'
+    # q2_saved_response              => 'q2_option'
     # q2_next_node_calculated_answer => 'q2-next-node-calculated-answer'
   end
 end

--- a/doc/storing-data.md
+++ b/doc/storing-data.md
@@ -1,6 +1,17 @@
 # Storing data for later use
 
-You can use the `precalculate`, `next_node_calculation`, `save_input_as` and `calculate` methods to store data for later use. These values are stored in the state and are available in the rest of the flow and in the ERB templates.
+You can use the `on_response`, `precalculate`, `next_node_calculation`, `save_input_as` and `calculate` methods to store data for later use. These values are stored in the state and are available in the rest of the flow and in the ERB templates.
+
+* `on_response` values are available in:
+  * The `precalculate` block
+  * The question template
+  * The `next_node_calculation` block
+  * The `validate` block
+  * The `next_node` block
+  * The `calculate` block
+  * All subsequent questions and outcomes
+
+__NOTE.__ `on_response` blocks are not named, because they don't automatically store a value in a state variable. In fact doing so is actively discouraged apart from when storing a calculator object in the first question of a flow.
 
 * `precalculate` values are available in:
   * The question template

--- a/doc/storing-data.md
+++ b/doc/storing-data.md
@@ -33,7 +33,7 @@ multiple_choice :question_1? do
 
   next_node do
     question :question_2?
-  end:
+  end
 
   calculate :q1_calculated_answer do
     'q1-calculated-answer'


### PR DESCRIPTION
## Description

Supersedes #2608.

Trello card: https://trello.com/c/kWO8Z3i1

In #2408 we introduced `on_response` blocks with the idea of using them to build and store a calculator object in a `calculator` state variable, and to manually store the response to each question on the calculator. This is instead of using `save_input_as` which stores the response as a state variable. This is because in moving towards [new-style flows][1], we're trying to move away from storing any "state variables" other than a single calculator object.

Note that this PR is *not* an attempt to address the action in [this Trello card][2] from the benefit-cap-calculator retrospective. I plan to address that action separately. The idea of this PR is simply to bring the existing documentation up-to-date with the existence of the `on_response` method.

## External changes

None. This only changes documentation.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md
[2]: https://trello.com/c/XMu0U6Qc