### PR TITLE
Refactor register-a-death to new-style flow

### DIFF
--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -36,5 +36,9 @@ module SmartAnswer::Calculators
     def responded_with_commonwealth_country?
       RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(country_of_death)
     end
+
+    def in_the_uk?
+      current_location == 'in_the_uk'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -35,6 +35,10 @@ module SmartAnswer::Calculators
       @country_name_query.definitive_article(country_of_death)
     end
 
+    def death_country_name_lowercase_prefix
+      @country_name_query.definitive_article(country_of_death)
+    end
+
     def country_has_no_embassy?
       %w(iran libya syria yemen).include?(country_of_death)
     end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -32,7 +32,7 @@ module SmartAnswer::Calculators
     end
 
     def registration_country_name_lowercase_prefix
-      @country_name_query.definitive_article(country_of_death)
+      @country_name_query.definitive_article(registration_country)
     end
 
     def death_country_name_lowercase_prefix

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -72,5 +72,17 @@ module SmartAnswer::Calculators
     def translator_link_url
       @translator_query.links[country_of_death]
     end
+
+    def overseas_passports_embassies
+      location = WorldLocation.find(registration_country)
+      raise InvalidResponse unless location
+      organisation = location.fco_organisation
+
+      if organisation
+        organisation.offices_with_service 'Births and Deaths registration service'
+      else
+        []
+      end
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -3,6 +3,7 @@ module SmartAnswer::Calculators
     include ActiveModel::Model
 
     attr_accessor :location_of_death
+    attr_accessor :death_location_type
 
     def died_in_uk?
       %w(england_wales scotland northern_ireland).include?(location_of_death)

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -4,6 +4,7 @@ module SmartAnswer::Calculators
 
     attr_accessor :location_of_death
     attr_accessor :death_location_type
+    attr_accessor :death_expected
 
     def died_in_uk?
       %w(england_wales scotland northern_ireland).include?(location_of_death)

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -3,5 +3,9 @@ module SmartAnswer::Calculators
     include ActiveModel::Model
 
     attr_accessor :location_of_death
+
+    def died_in_uk?
+      %w(england_wales scotland northern_ireland).include?(location_of_death)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -6,6 +6,7 @@ module SmartAnswer::Calculators
     attr_accessor :death_location_type
     attr_accessor :death_expected
     attr_accessor :country_of_death
+    attr_accessor :current_location
 
     def initialize(attributes = {})
       super

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -31,5 +31,9 @@ module SmartAnswer::Calculators
     def country_has_no_embassy?
       %w(iran libya syria yemen).include?(country_of_death)
     end
+
+    def responded_with_commonwealth_country?
+      RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(country_of_death)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -99,5 +99,9 @@ module SmartAnswer::Calculators
     def oru_documents_variant_for_death?
       @reg_data_query.oru_documents_variant_for_death?(country_of_death)
     end
+
+    def oru_courier_variant?
+      @reg_data_query.oru_courier_variant?(registration_country)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -8,5 +8,9 @@ module SmartAnswer::Calculators
     def died_in_uk?
       %w(england_wales scotland northern_ireland).include?(location_of_death)
     end
+
+    def died_at_home_or_in_hospital?
+      death_location_type == 'at_home_hospital'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -75,7 +75,6 @@ module SmartAnswer::Calculators
 
     def overseas_passports_embassies
       location = WorldLocation.find(registration_country)
-      raise InvalidResponse unless location
       organisation = location.fco_organisation
 
       if organisation

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -13,6 +13,7 @@ module SmartAnswer::Calculators
       super
       @reg_data_query = RegistrationsDataQuery.new
       @country_name_query = CountryNameFormatter.new
+      @translator_query = TranslatorLinks.new
     end
 
     def died_in_uk?
@@ -66,6 +67,10 @@ module SmartAnswer::Calculators
     def currently_in_north_korea?
       # TODO: current_country == 'north-korea'
       nil == 'north-korea'
+    end
+
+    def translator_link_url
+      @translator_query.links[country_of_death]
     end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -41,6 +41,14 @@ module SmartAnswer::Calculators
       current_location == 'in_the_uk'
     end
 
+    def same_country?
+      current_location == 'same_country'
+    end
+
+    def another_country?
+      current_location == 'another_country'
+    end
+
     def died_in_north_korea?
       country_of_death == 'north-korea'
     end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -40,5 +40,9 @@ module SmartAnswer::Calculators
     def in_the_uk?
       current_location == 'in_the_uk'
     end
+
+    def died_in_north_korea?
+      country_of_death == 'north-korea'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -7,6 +7,11 @@ module SmartAnswer::Calculators
     attr_accessor :death_expected
     attr_accessor :country_of_death
 
+    def initialize(attributes = {})
+      super
+      @reg_data_query = RegistrationsDataQuery.new
+    end
+
     def died_in_uk?
       %w(england_wales scotland northern_ireland).include?(location_of_death)
     end
@@ -17,6 +22,10 @@ module SmartAnswer::Calculators
 
     def death_expected?
       death_expected == 'yes'
+    end
+
+    def registration_country
+      @reg_data_query.registration_country_slug(country_of_death)
     end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -53,5 +53,10 @@ module SmartAnswer::Calculators
     def died_in_north_korea?
       country_of_death == 'north-korea'
     end
+
+    def currently_in_north_korea?
+      # TODO: current_country == 'north-korea'
+      nil == 'north-korea'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -12,6 +12,7 @@ module SmartAnswer::Calculators
     def initialize(attributes = {})
       super
       @reg_data_query = RegistrationsDataQuery.new
+      @country_name_query = CountryNameFormatter.new
     end
 
     def died_in_uk?
@@ -28,6 +29,10 @@ module SmartAnswer::Calculators
 
     def registration_country
       @reg_data_query.registration_country_slug(current_country || country_of_death)
+    end
+
+    def registration_country_name_lowercase_prefix
+      @country_name_query.definitive_article(country_of_death)
     end
 
     def country_has_no_embassy?

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -1,5 +1,7 @@
 module SmartAnswer::Calculators
   class RegisterADeathCalculator
     include ActiveModel::Model
+
+    attr_accessor :location_of_death
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -27,7 +27,7 @@ module SmartAnswer::Calculators
     end
 
     def registration_country
-      @reg_data_query.registration_country_slug(country_of_death)
+      @reg_data_query.registration_country_slug(current_country || country_of_death)
     end
 
     def country_has_no_embassy?

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -103,5 +103,9 @@ module SmartAnswer::Calculators
     def oru_courier_variant?
       @reg_data_query.oru_courier_variant?(registration_country)
     end
+
+    def oru_courier_by_high_commission?
+      @reg_data_query.oru_courier_by_high_commission?(registration_country)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -87,5 +87,13 @@ module SmartAnswer::Calculators
     def document_return_fees
       @reg_data_query.document_return_fees
     end
+
+    def fee_for_registering_a_death
+      @reg_data_query.register_a_death_fees.register_a_death
+    end
+
+    def fee_for_copy_of_death_registration_certificate
+      @reg_data_query.register_a_death_fees.copy_of_death_registration_certificate
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -27,5 +27,9 @@ module SmartAnswer::Calculators
     def registration_country
       @reg_data_query.registration_country_slug(country_of_death)
     end
+
+    def country_has_no_embassy?
+      %w(iran libya syria yemen).include?(country_of_death)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -7,6 +7,7 @@ module SmartAnswer::Calculators
     attr_accessor :death_expected
     attr_accessor :country_of_death
     attr_accessor :current_location
+    attr_accessor :current_country
 
     def initialize(attributes = {})
       super

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -95,5 +95,9 @@ module SmartAnswer::Calculators
     def fee_for_copy_of_death_registration_certificate
       @reg_data_query.register_a_death_fees.copy_of_death_registration_certificate
     end
+
+    def oru_documents_variant_for_death?
+      @reg_data_query.oru_documents_variant_for_death?(country_of_death)
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -83,5 +83,9 @@ module SmartAnswer::Calculators
         []
       end
     end
+
+    def document_return_fees
+      @reg_data_query.document_return_fees
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -13,5 +13,9 @@ module SmartAnswer::Calculators
     def died_at_home_or_in_hospital?
       death_location_type == 'at_home_hospital'
     end
+
+    def death_expected?
+      death_expected == 'yes'
+    end
   end
 end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -1,0 +1,5 @@
+module SmartAnswer::Calculators
+  class RegisterADeathCalculator
+    include ActiveModel::Model
+  end
+end

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -2,6 +2,8 @@ module SmartAnswer::Calculators
   class RegisterADeathCalculator
     include ActiveModel::Model
 
+    EXCLUDE_COUNTRIES = %w(holy-see british-antarctic-territory)
+
     attr_accessor :location_of_death
     attr_accessor :death_location_type
     attr_accessor :death_expected

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -5,6 +5,7 @@ module SmartAnswer::Calculators
     attr_accessor :location_of_death
     attr_accessor :death_location_type
     attr_accessor :death_expected
+    attr_accessor :country_of_death
 
     def died_in_uk?
       %w(england_wales scotland northern_ireland).include?(location_of_death)

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -13,6 +13,10 @@ module SmartAnswer
 
       # Q1
       multiple_choice :where_did_the_death_happen? do
+        on_response do
+          self.calculator = Calculators::RegisterADeathCalculator.new
+        end
+
         save_input_as :where_death_happened
         option :england_wales
         option :scotland

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -115,11 +115,7 @@ module SmartAnswer
 
       outcome :uk_result
 
-      outcome :oru_result do
-        precalculate :reg_data_query do
-          Calculators::RegistrationsDataQuery.new
-        end
-      end
+      outcome :oru_result
 
       outcome :north_korea_result
     end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -99,22 +99,22 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        calculate :another_country do |response|
-          response == 'another_country'
+        calculate :another_country do
+          calculator.current_location == 'another_country'
         end
 
-        calculate :in_the_uk do |response|
-          response == 'in_the_uk'
+        calculate :in_the_uk do
+          calculator.current_location == 'in_the_uk'
         end
 
         next_node_calculation(:died_in_north_korea) {
           calculator.country_of_death == 'north-korea'
         }
 
-        next_node do |response|
-          if response == 'same_country' && died_in_north_korea
+        next_node do
+          if calculator.current_location == 'same_country' && died_in_north_korea
             outcome :north_korea_result
-          elsif response == 'another_country'
+          elsif calculator.current_location == 'another_country'
             question :which_country_are_you_in_now?
           else
             outcome :oru_result

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -95,6 +95,10 @@ module SmartAnswer
         option :another_country
         option :in_the_uk
 
+        on_response do |response|
+          calculator.current_location = response
+        end
+
         calculate :another_country do |response|
           response == 'another_country'
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -78,10 +78,6 @@ module SmartAnswer
           registration_country_name_lowercase_prefix
         end
 
-        next_node_calculation :country_has_no_embassy do
-          %w(iran libya syria yemen).include?(calculator.country_of_death)
-        end
-
         next_node_calculation :responded_with_commonwealth_country do
           Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(calculator.country_of_death)
         end
@@ -89,7 +85,7 @@ module SmartAnswer
         next_node do
           if responded_with_commonwealth_country
             outcome :commonwealth_result
-          elsif country_has_no_embassy
+          elsif calculator.country_has_no_embassy?
             outcome :no_embassy_result
           else
             question :where_are_you_now?

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -23,8 +23,8 @@ module SmartAnswer
         option :northern_ireland
         option :overseas
 
-        next_node do |response|
-          case response
+        next_node do
+          case calculator.location_of_death
           when 'england_wales', 'scotland', 'northern_ireland'
             question :did_the_person_die_at_home_hospital?
           when 'overseas'

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -117,7 +117,7 @@ module SmartAnswer
         end
 
         calculate :registration_country do
-          reg_data_query.registration_country_slug(calculator.current_country)
+          calculator.registration_country
         end
 
         calculate :registration_country_name_lowercase_prefix do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -69,10 +69,6 @@ module SmartAnswer
           calculator.registration_country
         end
 
-        calculate :registration_country_name_lowercase_prefix do
-          calculator.registration_country_name_lowercase_prefix
-        end
-
         next_node do
           if calculator.responded_with_commonwealth_country?
             outcome :commonwealth_result
@@ -113,10 +109,6 @@ module SmartAnswer
 
         calculate :registration_country do
           calculator.registration_country
-        end
-
-        calculate :registration_country_name_lowercase_prefix do
-          calculator.registration_country_name_lowercase_prefix
         end
 
         next_node do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -100,9 +100,9 @@ module SmartAnswer
         end
 
         next_node do
-          if calculator.current_location == 'same_country' && calculator.died_in_north_korea?
+          if calculator.same_country? && calculator.died_in_north_korea?
             outcome :north_korea_result
-          elsif calculator.current_location == 'another_country'
+          elsif calculator.another_country?
             question :which_country_are_you_in_now?
           else
             outcome :oru_result

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -99,10 +99,6 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        calculate :in_the_uk do
-          calculator.current_location == 'in_the_uk'
-        end
-
         next_node_calculation(:died_in_north_korea) {
           calculator.country_of_death == 'north-korea'
         }

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -112,6 +112,10 @@ module SmartAnswer
 
       # Q6
       country_select :which_country_are_you_in_now?, exclude_countries: exclude_countries do
+        on_response do |response|
+          calculator.current_country = response
+        end
+
         calculate :registration_country do |response|
           reg_data_query.registration_country_slug(response)
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -24,10 +24,9 @@ module SmartAnswer
         option :overseas
 
         next_node do
-          case calculator.location_of_death
-          when 'england_wales', 'scotland', 'northern_ireland'
+          if calculator.died_in_uk?
             question :did_the_person_die_at_home_hospital?
-          when 'overseas'
+          else
             question :which_country?
           end
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -60,7 +60,7 @@ module SmartAnswer
         save_input_as :country_of_death
 
         calculate :registration_country do |response|
-          reg_data_query.registration_country_slug(response) || response
+          reg_data_query.registration_country_slug(response)
         end
 
         calculate :registration_country_name_lowercase_prefix do
@@ -122,7 +122,7 @@ module SmartAnswer
       # Q6
       country_select :which_country_are_you_in_now?, exclude_countries: exclude_countries do
         calculate :registration_country do |response|
-          reg_data_query.registration_country_slug(response) || response
+          reg_data_query.registration_country_slug(response)
         end
 
         calculate :registration_country_name_lowercase_prefix do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -6,7 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "101006"
 
-      country_name_query = Calculators::CountryNameFormatter.new
       reg_data_query = Calculators::RegistrationsDataQuery.new
       translator_query = Calculators::TranslatorLinks.new
       exclude_countries = %w(holy-see british-antarctic-territory)
@@ -121,7 +120,7 @@ module SmartAnswer
         end
 
         calculate :registration_country_name_lowercase_prefix do
-          country_name_query.definitive_article(registration_country)
+          calculator.registration_country_name_lowercase_prefix
         end
 
         next_node do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -75,7 +75,7 @@ module SmartAnswer
         end
 
         calculate :death_country_name_lowercase_prefix do
-          registration_country_name_lowercase_prefix
+          calculator.death_country_name_lowercase_prefix
         end
 
         next_node do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -99,12 +99,8 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        next_node_calculation(:died_in_north_korea) {
-          calculator.country_of_death == 'north-korea'
-        }
-
         next_node do
-          if calculator.current_location == 'same_country' && died_in_north_korea
+          if calculator.current_location == 'same_country' && calculator.died_in_north_korea?
             outcome :north_korea_result
           elsif calculator.current_location == 'another_country'
             question :which_country_are_you_in_now?

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -41,9 +41,6 @@ module SmartAnswer
           calculator.death_location_type = response
         end
 
-        calculate :died_at_home_hospital do |response|
-          response == 'at_home_hospital'
-        end
         next_node do
           question :was_death_expected?
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -117,10 +117,6 @@ module SmartAnswer
       outcome :uk_result
 
       outcome :oru_result do
-        precalculate :translator_link_url do
-          calculator.translator_link_url
-        end
-
         precalculate :reg_data_query do
           Calculators::RegistrationsDataQuery.new
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -99,10 +99,6 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        calculate :another_country do
-          calculator.current_location == 'another_country'
-        end
-
         calculate :in_the_uk do
           calculator.current_location == 'in_the_uk'
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -130,18 +130,6 @@ module SmartAnswer
         precalculate :reg_data_query do
           Calculators::RegistrationsDataQuery.new
         end
-
-        precalculate :overseas_passports_embassies do
-          location = WorldLocation.find(calculator.registration_country)
-          raise InvalidResponse unless location
-          organisation = location.fco_organisation
-
-          if organisation
-            organisation.offices_with_service 'Births and Deaths registration service'
-          else
-            []
-          end
-        end
       end
     end
   end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -78,12 +78,8 @@ module SmartAnswer
           registration_country_name_lowercase_prefix
         end
 
-        next_node_calculation :responded_with_commonwealth_country do
-          Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(calculator.country_of_death)
-        end
-
         next_node do
-          if responded_with_commonwealth_country
+          if calculator.responded_with_commonwealth_country?
             outcome :commonwealth_result
           elsif calculator.country_has_no_embassy?
             outcome :no_embassy_result

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -7,7 +7,6 @@ module SmartAnswer
       satisfies_need "101006"
 
       reg_data_query = Calculators::RegistrationsDataQuery.new
-      translator_query = Calculators::TranslatorLinks.new
       exclude_countries = %w(holy-see british-antarctic-territory)
 
       # Q1
@@ -119,7 +118,7 @@ module SmartAnswer
 
       outcome :oru_result do
         precalculate :translator_link_url do
-          translator_query.links[calculator.country_of_death]
+          calculator.translator_link_url
         end
 
         precalculate :reg_data_query do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -6,7 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "101006"
 
-      reg_data_query = Calculators::RegistrationsDataQuery.new
       exclude_countries = %w(holy-see british-antarctic-territory)
 
       # Q1
@@ -119,10 +118,6 @@ module SmartAnswer
       outcome :oru_result do
         precalculate :reg_data_query do
           Calculators::RegistrationsDataQuery.new
-        end
-
-        precalculate :document_return_fees do
-          reg_data_query.document_return_fees
         end
       end
 

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -6,8 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "101006"
 
-      exclude_countries = %w(holy-see british-antarctic-territory)
-
       # Q1
       multiple_choice :where_did_the_death_happen? do
         on_response do |response|
@@ -58,7 +56,7 @@ module SmartAnswer
       end
 
       # Q4
-      country_select :which_country?, exclude_countries: exclude_countries do
+      country_select :which_country?, exclude_countries: Calculators::RegisterADeathCalculator::EXCLUDE_COUNTRIES do
         on_response do |response|
           calculator.country_of_death = response
         end
@@ -96,7 +94,7 @@ module SmartAnswer
       end
 
       # Q6
-      country_select :which_country_are_you_in_now?, exclude_countries: exclude_countries do
+      country_select :which_country_are_you_in_now?, exclude_countries: Calculators::RegisterADeathCalculator::EXCLUDE_COUNTRIES do
         on_response do |response|
           calculator.current_country = response
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -13,11 +13,11 @@ module SmartAnswer
 
       # Q1
       multiple_choice :where_did_the_death_happen? do
-        on_response do
+        on_response do |response|
           self.calculator = Calculators::RegisterADeathCalculator.new
+          calculator.location_of_death = response
         end
 
-        save_input_as :where_death_happened
         option :england_wales
         option :scotland
         option :northern_ireland

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -55,10 +55,6 @@ module SmartAnswer
           calculator.death_expected = response
         end
 
-        calculate :death_expected do |response|
-          response == 'yes'
-        end
-
         next_node do
           outcome :uk_result
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -51,6 +51,10 @@ module SmartAnswer
         option :yes
         option :no
 
+        on_response do |response|
+          calculator.death_expected = response
+        end
+
         calculate :death_expected do |response|
           response == 'yes'
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -65,10 +65,6 @@ module SmartAnswer
           calculator.country_of_death = response
         end
 
-        calculate :registration_country do
-          calculator.registration_country
-        end
-
         next_node do
           if calculator.responded_with_commonwealth_country?
             outcome :commonwealth_result
@@ -105,10 +101,6 @@ module SmartAnswer
       country_select :which_country_are_you_in_now?, exclude_countries: exclude_countries do
         on_response do |response|
           calculator.current_country = response
-        end
-
-        calculate :registration_country do
-          calculator.registration_country
         end
 
         next_node do
@@ -149,7 +141,7 @@ module SmartAnswer
         end
 
         precalculate :overseas_passports_embassies do
-          location = WorldLocation.find(registration_country)
+          location = WorldLocation.find(calculator.registration_country)
           raise InvalidResponse unless location
           organisation = location.fco_organisation
 

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -66,8 +66,8 @@ module SmartAnswer
           calculator.country_of_death = response
         end
 
-        calculate :registration_country do |response|
-          reg_data_query.registration_country_slug(response)
+        calculate :registration_country do
+          reg_data_query.registration_country_slug(calculator.country_of_death)
         end
 
         calculate :registration_country_name_lowercase_prefix do
@@ -78,12 +78,12 @@ module SmartAnswer
           registration_country_name_lowercase_prefix
         end
 
-        next_node_calculation :country_has_no_embassy do |response|
-          %w(iran libya syria yemen).include?(response)
+        next_node_calculation :country_has_no_embassy do
+          %w(iran libya syria yemen).include?(calculator.country_of_death)
         end
 
-        next_node_calculation :responded_with_commonwealth_country do |response|
-          Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(response)
+        next_node_calculation :responded_with_commonwealth_country do
+          Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(calculator.country_of_death)
         end
 
         next_node do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -116,8 +116,8 @@ module SmartAnswer
           calculator.current_country = response
         end
 
-        calculate :registration_country do |response|
-          reg_data_query.registration_country_slug(response)
+        calculate :registration_country do
+          reg_data_query.registration_country_slug(calculator.current_country)
         end
 
         calculate :registration_country_name_lowercase_prefix do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -59,16 +59,16 @@ module SmartAnswer
       country_select :which_country?, exclude_countries: exclude_countries do
         save_input_as :country_of_death
 
-        calculate :current_location do |response|
+        calculate :registration_country do |response|
           reg_data_query.registration_country_slug(response) || response
         end
 
-        calculate :current_location_name_lowercase_prefix do
+        calculate :registration_country_name_lowercase_prefix do
           country_name_query.definitive_article(country_of_death)
         end
 
         calculate :death_country_name_lowercase_prefix do
-          current_location_name_lowercase_prefix
+          registration_country_name_lowercase_prefix
         end
 
         next_node_calculation :country_has_no_embassy do |response|
@@ -121,12 +121,12 @@ module SmartAnswer
 
       # Q6
       country_select :which_country_are_you_in_now?, exclude_countries: exclude_countries do
-        calculate :current_location do |response|
+        calculate :registration_country do |response|
           reg_data_query.registration_country_slug(response) || response
         end
 
-        calculate :current_location_name_lowercase_prefix do
-          country_name_query.definitive_article(current_location)
+        calculate :registration_country_name_lowercase_prefix do
+          country_name_query.definitive_article(registration_country)
         end
 
         next_node_calculation(:currently_in_north_korea) {
@@ -171,7 +171,7 @@ module SmartAnswer
         end
 
         precalculate :overseas_passports_embassies do
-          location = WorldLocation.find(current_location)
+          location = WorldLocation.find(registration_country)
           raise InvalidResponse unless location
           organisation = location.fco_organisation
 

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -36,6 +36,11 @@ module SmartAnswer
       multiple_choice :did_the_person_die_at_home_hospital? do
         option :at_home_hospital
         option :elsewhere
+
+        on_response do |response|
+          calculator.death_location_type = response
+        end
+
         calculate :died_at_home_hospital do |response|
           response == 'at_home_hospital'
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -71,7 +71,7 @@ module SmartAnswer
         end
 
         calculate :registration_country_name_lowercase_prefix do
-          country_name_query.definitive_article(calculator.country_of_death)
+          calculator.registration_country_name_lowercase_prefix
         end
 
         calculate :death_country_name_lowercase_prefix do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -121,11 +121,7 @@ module SmartAnswer
         end
       end
 
-      outcome :north_korea_result do
-        precalculate :reg_data_query do
-          Calculators::RegistrationsDataQuery.new
-        end
-      end
+      outcome :north_korea_result
     end
   end
 end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -67,7 +67,7 @@ module SmartAnswer
         end
 
         calculate :registration_country do
-          reg_data_query.registration_country_slug(calculator.country_of_death)
+          calculator.registration_country
         end
 
         calculate :registration_country_name_lowercase_prefix do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -62,14 +62,16 @@ module SmartAnswer
 
       # Q4
       country_select :which_country?, exclude_countries: exclude_countries do
-        save_input_as :country_of_death
+        on_response do |response|
+          calculator.country_of_death = response
+        end
 
         calculate :registration_country do |response|
           reg_data_query.registration_country_slug(response)
         end
 
         calculate :registration_country_name_lowercase_prefix do
-          country_name_query.definitive_article(country_of_death)
+          country_name_query.definitive_article(calculator.country_of_death)
         end
 
         calculate :death_country_name_lowercase_prefix do
@@ -110,7 +112,7 @@ module SmartAnswer
         end
 
         next_node_calculation(:died_in_north_korea) {
-          country_of_death == 'north-korea'
+          calculator.country_of_death == 'north-korea'
         }
 
         next_node do |response|
@@ -158,7 +160,7 @@ module SmartAnswer
         end
 
         precalculate :translator_link_url do
-          translator_query.links[country_of_death]
+          translator_query.links[calculator.country_of_death]
         end
 
         precalculate :reg_data_query do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -124,12 +124,8 @@ module SmartAnswer
           country_name_query.definitive_article(registration_country)
         end
 
-        next_node_calculation(:currently_in_north_korea) {
-          response == 'north-korea'
-        }
-
         next_node do
-          if currently_in_north_korea
+          if calculator.currently_in_north_korea?
             outcome :north_korea_result
           else
             outcome :oru_result

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -118,10 +118,6 @@ module SmartAnswer
       outcome :uk_result
 
       outcome :oru_result do
-        precalculate :button_data do
-          { text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start" }
-        end
-
         precalculate :translator_link_url do
           translator_query.links[calculator.country_of_death]
         end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -73,10 +73,6 @@ module SmartAnswer
           calculator.registration_country_name_lowercase_prefix
         end
 
-        calculate :death_country_name_lowercase_prefix do
-          calculator.death_country_name_lowercase_prefix
-        end
-
         next_node do
           if calculator.responded_with_commonwealth_country?
             outcome :commonwealth_result

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -112,11 +112,8 @@ module SmartAnswer
 
       outcome :commonwealth_result
       outcome :no_embassy_result
-
       outcome :uk_result
-
       outcome :oru_result
-
       outcome :north_korea_result
     end
   end

--- a/lib/smart_answer_flows/register-a-death/outcomes/_fees.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/_fees.govspeak.erb
@@ -1,4 +1,4 @@
 Service | Fee
 -|-
-Register a death | <%= format_money(reg_data_query.register_a_death_fees.register_a_death) %>
-Copy of a death registration certificate | <%= format_money(reg_data_query.register_a_death_fees.copy_of_death_registration_certificate) %>
+Register a death | <%= format_money(calculator.fee_for_registering_a_death) %>
+Copy of a death registration certificate | <%= format_money(calculator.fee_for_copy_of_death_registration_certificate) %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb
@@ -1,4 +1,4 @@
-<% case current_location %>
+<% case registration_country %>
 <% when 'cambodia' %>
   Your documents will be returned to the British Embassy in Phnom Penh after the death has been registered.
 <% when 'north-korea' %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb
@@ -1,4 +1,4 @@
-<% case registration_country %>
+<% case calculator.registration_country %>
 <% when 'cambodia' %>
   Your documents will be returned to the British Embassy in Phnom Penh after the death has been registered.
 <% when 'north-korea' %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!You must register the death according to the regulations in <%= death_country_name_lowercase_prefix %>. You will be given a local death certificate.$!
+  $!You must register the death according to the regulations in <%= calculator.death_country_name_lowercase_prefix %>. You will be given a local death certificate.$!
 
-  You can't register the death with the UK authorities. The death certificate you are given in <%= death_country_name_lowercase_prefix %> will be accepted and recognised in the UK.
+  You can't register the death with the UK authorities. The death certificate you are given in <%= calculator.death_country_name_lowercase_prefix %> will be accepted and recognised in the UK.
 <% end %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/no_embassy_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/no_embassy_result.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
-  $!You must register the death according to the regulations in <%= death_country_name_lowercase_prefix %>. You will be given a local death certificate.$!
+  $!You must register the death according to the regulations in <%= calculator.death_country_name_lowercase_prefix %>. You will be given a local death certificate.$!
 
   You can’t currently register the death with the UK authorities.
 
-  The local death certificate, with a [certified translation](/certifying-a-document), should be acceptable for all purposes in the UK. You can apply for registration at any time in the future - check [travel advice](/foreign-travel-advice) to find out if consular services have reopened in <%= death_country_name_lowercase_prefix %>.
+  The local death certificate, with a [certified translation](/certifying-a-document), should be acceptable for all purposes in the UK. You can apply for registration at any time in the future - check [travel advice](/foreign-travel-advice) to find out if consular services have reopened in <%= calculator.death_country_name_lowercase_prefix %>.
 <% end %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
@@ -5,7 +5,7 @@
 
   ##Register the death with the UK authorities
 
-  You can also apply to register the death with the British embassy in <%= current_location_name_lowercase_prefix %>.
+  You can also apply to register the death with the British embassy in <%= registration_country_name_lowercase_prefix %>.
 
   You don’t have to do this, but it means:
 

--- a/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
@@ -48,5 +48,5 @@
 
   Your documents will be returned to the British Embassy in Pyongyang after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
-  <%= render partial: 'shared/overseas_passports_embassies.govspeak.erb', locals: { overseas_passports_embassies: overseas_passports_embassies } %>
+  <%= render partial: 'shared/overseas_passports_embassies.govspeak.erb', locals: { overseas_passports_embassies: calculator.overseas_passports_embassies } %>
 <% end %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
@@ -5,7 +5,7 @@
 
   ##Register the death with the UK authorities
 
-  You can also apply to register the death with the British embassy in <%= registration_country_name_lowercase_prefix %>.
+  You can also apply to register the death with the British embassy in <%= calculator.registration_country_name_lowercase_prefix %>.
 
   You don’t have to do this, but it means:
 

--- a/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
@@ -32,7 +32,7 @@
   ##Cost
 
   <%= render partial: 'fees.govspeak.erb',
-             locals: { reg_data_query: reg_data_query } %>
+             locals: { calculator: calculator } %>
 
   You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 

--- a/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!You must register the death according to the regulations in <%= death_country_name_lowercase_prefix %>. You will be given a local death certificate.$!
+  $!You must register the death according to the regulations in <%= calculator.death_country_name_lowercase_prefix %>. You will be given a local death certificate.$!
 
   This local death certificate will be accepted in the UK (it may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English).
 

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -94,7 +94,7 @@
 
   They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
 
-  <% if reg_data_query.oru_courier_variant?(calculator.registration_country) %>
+  <% if calculator.oru_courier_variant? %>
     <% case calculator.registration_country %>
     <% when 'cambodia' %>
       Your documents will be returned to the British Embassy in Phnom Penh after the death has been registered.

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -24,7 +24,7 @@
 
   You must provide:
 
-  <% if reg_data_query.oru_documents_variant_for_death?(calculator.country_of_death) %>
+  <% if calculator.oru_documents_variant_for_death? %>
     <% if calculator.country_of_death == 'poland' %>
       - the full local death certificate ('zupelny')
     <% elsif calculator.country_of_death == 'papua-new-guinea' %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -58,7 +58,7 @@
              locals: { reg_data_query: reg_data_query } %>
 
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
-  <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: button_data } %>
+  <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: { text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start" } } %>
 
 
   ###4. Send your registration

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -46,7 +46,7 @@
 
   ###3. Pay
 
-  <% if !in_the_uk && current_location == 'algeria' %>
+  <% if !in_the_uk && registration_country == 'algeria' %>
     Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
   <% else %>
     Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
@@ -94,8 +94,8 @@
 
   They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
 
-  <% if reg_data_query.oru_courier_variant?(current_location) %>
-    <% case current_location %>
+  <% if reg_data_query.oru_courier_variant?(registration_country) %>
+    <% case registration_country %>
     <% when 'cambodia' %>
       Your documents will be returned to the British Embassy in Phnom Penh after the death has been registered.
     <% when 'cameroon' %>
@@ -118,7 +118,7 @@
       Your documents will be returned to the British High Commission in Kampala after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>
 
-    <% unless reg_data_query.oru_courier_by_high_commission?(current_location) %>
+    <% unless reg_data_query.oru_courier_by_high_commission?(registration_country) %>
       You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>
   <% else %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -118,7 +118,7 @@
       Your documents will be returned to the British High Commission in Kampala after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>
 
-    <% unless reg_data_query.oru_courier_by_high_commission?(calculator.registration_country) %>
+    <% unless calculator.oru_courier_by_high_commission? %>
       You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>
   <% else %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -55,7 +55,7 @@
   The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
   <%= render partial: 'fees.govspeak.erb',
-             locals: { reg_data_query: reg_data_query } %>
+             locals: { calculator: calculator } %>
 
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: calculator.document_return_fees } %>
   <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: { text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start" } } %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -24,10 +24,10 @@
 
   You must provide:
 
-  <% if reg_data_query.oru_documents_variant_for_death?(country_of_death) %>
-    <% if country_of_death == 'poland' %>
+  <% if reg_data_query.oru_documents_variant_for_death?(calculator.country_of_death) %>
+    <% if calculator.country_of_death == 'poland' %>
       - the full local death certificate ('zupelny')
-    <% elsif country_of_death == 'papua-new-guinea' %>
+    <% elsif calculator.country_of_death == 'papua-new-guinea' %>
       - the hospital medical death record
     <% end %>
   <% else %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -46,7 +46,7 @@
 
   ###3. Pay
 
-  <% if !in_the_uk && registration_country == 'algeria' %>
+  <% if !calculator.in_the_uk? && registration_country == 'algeria' %>
     Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
   <% else %>
     Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
@@ -68,7 +68,7 @@
   Post your registration form and documents by secure post to:
 
 
-  <% if in_the_uk %>
+  <% if calculator.in_the_uk? %>
     $A
     Overseas Registration Unit
     Foreign and Commonwealth Office

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -20,7 +20,7 @@
 
   ###1. Documents
 
-  ^Send English translations of all foreign documents. <% if translator_link_url %>Use an [approved translator](<%= translator_link_url %>) and include their name and address with your application<% else %>Use a professional translator and include their name and address with your application<% end %>. Don't send laminated documents.^
+  ^Send English translations of all foreign documents. <% if calculator.translator_link_url %>Use an [approved translator](<%= calculator.translator_link_url %>) and include their name and address with your application<% else %>Use a professional translator and include their name and address with your application<% end %>. Don't send laminated documents.^
 
   You must provide:
 

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -57,7 +57,7 @@
   <%= render partial: 'fees.govspeak.erb',
              locals: { reg_data_query: reg_data_query } %>
 
-  <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
+  <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: calculator.document_return_fees } %>
   <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: { text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start" } } %>
 
 

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -46,7 +46,7 @@
 
   ###3. Pay
 
-  <% if !calculator.in_the_uk? && registration_country == 'algeria' %>
+  <% if !calculator.in_the_uk? && calculator.registration_country == 'algeria' %>
     Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
   <% else %>
     Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
@@ -94,8 +94,8 @@
 
   They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
 
-  <% if reg_data_query.oru_courier_variant?(registration_country) %>
-    <% case registration_country %>
+  <% if reg_data_query.oru_courier_variant?(calculator.registration_country) %>
+    <% case calculator.registration_country %>
     <% when 'cambodia' %>
       Your documents will be returned to the British Embassy in Phnom Penh after the death has been registered.
     <% when 'cameroon' %>
@@ -118,7 +118,7 @@
       Your documents will be returned to the British High Commission in Kampala after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>
 
-    <% unless reg_data_query.oru_courier_by_high_commission?(registration_country) %>
+    <% unless reg_data_query.oru_courier_by_high_commission?(calculator.registration_country) %>
       You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
     <% end %>
   <% else %>

--- a/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  <% case where_death_happened %>
+  <% case calculator.location_of_death %>
   <% when 'england_wales' %>
     You should register the death within 5 days.
 

--- a/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
@@ -27,7 +27,7 @@
       - the person making arrangements with the funeral directors
     <% end %>
 
-    <% if death_expected %>
+    <% if calculator.death_expected? %>
       What you need to do
       --------
 
@@ -78,7 +78,7 @@
 
     You should also take supporting documents that show your name and address (eg a utility bill) but you can still register a death without them.
 
-    <% if death_expected %>
+    <% if calculator.death_expected? %>
       Documents you’ll get
       --------
 

--- a/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
@@ -14,7 +14,7 @@
 
     You can register the death if you’re:
 
-    <% if died_at_home_hospital %>
+    <% if calculator.died_at_home_or_in_hospital? %>
       - a relative
       - someone present at the death
       - an administrator from the hospital

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,14 +1,14 @@
 ---
-lib/smart_answer_flows/register-a-death.rb: 560ad77a9daa6fa486f967a70cd91f50
+lib/smart_answer_flows/register-a-death.rb: 1f7655d6cb1d3ae6df56f1c8e051f0cc
 test/data/register-a-death-questions-and-responses.yml: bae21b0a8be1bbaa2dd6febd505382d6
 test/data/register-a-death-responses-and-expected-results.yml: 9a00fab73baeba1d3d1be0013c405a3f
-lib/smart_answer_flows/register-a-death/outcomes/_fees.govspeak.erb: ea6d04bee0f4148fc2fa587df3cc8363
-lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb: 30e012cdde5aa7f4de5856a5db47a54c
-lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.erb: f343aa2ce9258acca94c986109618ca4
-lib/smart_answer_flows/register-a-death/outcomes/no_embassy_result.govspeak.erb: fabd0de7b88ffeb54783f87cfd4a3582
-lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb: 5b2162fe6d3c2cb9a50bfd41efb89095
-lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb: 3572cdae4bfd39c27cc8e542c4bf80d2
-lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb: 662da9367c5992191471f8722b3c2636
+lib/smart_answer_flows/register-a-death/outcomes/_fees.govspeak.erb: 295a443bf733cdeb0fcd70282af042cc
+lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb: 5a3909331b2a97a9dac6a13d02e860a9
+lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.erb: a04c0907f44a14d715689ce9182959de
+lib/smart_answer_flows/register-a-death/outcomes/no_embassy_result.govspeak.erb: 5a7be7180708c2cc38fb612cee1c8a41
+lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb: a6b37c903518230e682a1b852a60d103
+lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb: c0fe9e576c22269ebc678aef577faaca
+lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb: aed4dc1d27dc52b74bdf182e62df8705
 lib/smart_answer_flows/register-a-death/questions/did_the_person_die_at_home_hospital.govspeak.erb: 3405db8cb8b24782fc49981c2fce12e7
 lib/smart_answer_flows/register-a-death/questions/was_death_expected.govspeak.erb: 132d4a52801b619af05519a69f2767dd
 lib/smart_answer_flows/register-a-death/questions/where_are_you_now.govspeak.erb: b11b29b04cec875529be3714b5fba89e
@@ -16,6 +16,7 @@ lib/smart_answer_flows/register-a-death/questions/where_did_the_death_happen.gov
 lib/smart_answer_flows/register-a-death/questions/which_country.govspeak.erb: e816742682e96117df80d67faff13fc8
 lib/smart_answer_flows/register-a-death/questions/which_country_are_you_in_now.govspeak.erb: 9c9399d1588c7d5e01ebf1bf5efa31a1
 lib/smart_answer_flows/register-a-death/register_a_death.govspeak.erb: 1820ba3a5f3ed47816c7f151217be439
+lib/smart_answer/calculators/register_a_death_calculator.rb: 8483d0017c4a653602ff3dc09233ddc4
 lib/data/rates/register_a_death.yml: f24583d68edd4b06242b5a92e08e25c3
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -239,7 +239,6 @@ class RegisterADeathTest < ActiveSupport::TestCase
       end
       should "give the ORU result and be done" do
         assert_current_node :oru_result
-        assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start"
         assert_state_variable :translator_link_url, "/government/publications/italy-list-of-lawyers"
       end
     end # Answer Italy
@@ -252,7 +251,6 @@ class RegisterADeathTest < ActiveSupport::TestCase
       end
       should "give the oru result and be done" do
         assert_current_node :oru_result
-        assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start"
         assert_state_variable :translator_link_url, "/government/publications/spain-list-of-lawyers"
       end
     end # Answer Andorra, now in France
@@ -273,7 +271,6 @@ class RegisterADeathTest < ActiveSupport::TestCase
         should "give the ORU result with a translators link" do
           add_response 'in_the_uk'
           assert_current_node :oru_result
-          assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start"
           assert_state_variable :translator_link_url, "/government/publications/afghanistan-list-of-lawyers"
         end
       end
@@ -288,7 +285,6 @@ class RegisterADeathTest < ActiveSupport::TestCase
         should "give the ORU result with a translator link and a standard payment method" do
           add_response 'in_the_uk'
           assert_current_node :oru_result
-          assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start"
           assert_state_variable :translator_link_url, "/government/publications/algeria-list-of-lawyers"
         end
       end
@@ -298,7 +294,6 @@ class RegisterADeathTest < ActiveSupport::TestCase
           add_response 'another_country'
           add_response 'algeria'
           assert_current_node :oru_result
-          assert_state_variable :button_data, text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start"
           assert_state_variable :translator_link_url, "/government/publications/algeria-list-of-lawyers"
         end
       end

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -378,7 +378,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
       end
       should "give oru_result" do
         assert_current_node :oru_result
-        assert_state_variable :death_country_name_lowercase_prefix, 'Egypt'
+        assert_equal 'Egypt', current_state.calculator.death_country_name_lowercase_prefix
         assert_state_variable :registration_country_name_lowercase_prefix, 'Belgium'
         assert_state_variable :registration_country, 'belgium'
       end

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -199,7 +199,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         should "give the embassy result and be done" do
           assert_current_node :oru_result
           assert_equal "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx", current_state.calculator.translator_link_url
-          assert current_state.send(:document_return_fees).present?
+          assert current_state.calculator.document_return_fees.present?
         end
       end # Answer embassy
       context "answer ORU office in the uk" do

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -180,7 +180,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'australia'
       end
       should "give the commonwealth result" do
-        assert_state_variable :current_location_name_lowercase_prefix, "Australia"
+        assert_state_variable :registration_country_name_lowercase_prefix, "Australia"
         assert_current_node :commonwealth_result
       end
     end # Australia (commonwealth country)
@@ -189,7 +189,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'spain'
       end
       should "ask where you are now" do
-        assert_state_variable :current_location_name_lowercase_prefix, "Spain"
+        assert_state_variable :registration_country_name_lowercase_prefix, "Spain"
         assert_current_node :where_are_you_now?
       end
       context "answer same country" do
@@ -218,7 +218,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'morocco'
       end
       should "ask where are you now" do
-        assert_state_variable :current_location_name_lowercase_prefix, "Morocco"
+        assert_state_variable :registration_country_name_lowercase_prefix, "Morocco"
         assert_current_node :where_are_you_now?
       end
       context "answer ORU office in the uk" do
@@ -379,8 +379,8 @@ class RegisterADeathTest < ActiveSupport::TestCase
       should "give oru_result" do
         assert_current_node :oru_result
         assert_state_variable :death_country_name_lowercase_prefix, 'Egypt'
-        assert_state_variable :current_location_name_lowercase_prefix, 'Belgium'
-        assert_state_variable :current_location, 'belgium'
+        assert_state_variable :registration_country_name_lowercase_prefix, 'Belgium'
+        assert_state_variable :registration_country, 'belgium'
       end
     end # Death in Egypt user in Belgium
 

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -180,7 +180,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'australia'
       end
       should "give the commonwealth result" do
-        assert_state_variable :registration_country_name_lowercase_prefix, "Australia"
+        assert_equal "Australia", current_state.calculator.registration_country_name_lowercase_prefix
         assert_current_node :commonwealth_result
       end
     end # Australia (commonwealth country)
@@ -189,7 +189,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'spain'
       end
       should "ask where you are now" do
-        assert_state_variable :registration_country_name_lowercase_prefix, "Spain"
+        assert_equal "Spain", current_state.calculator.registration_country_name_lowercase_prefix
         assert_current_node :where_are_you_now?
       end
       context "answer same country" do
@@ -218,7 +218,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'morocco'
       end
       should "ask where are you now" do
-        assert_state_variable :registration_country_name_lowercase_prefix, "Morocco"
+        assert_equal "Morocco", current_state.calculator.registration_country_name_lowercase_prefix
         assert_current_node :where_are_you_now?
       end
       context "answer ORU office in the uk" do
@@ -379,7 +379,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
       should "give oru_result" do
         assert_current_node :oru_result
         assert_equal 'Egypt', current_state.calculator.death_country_name_lowercase_prefix
-        assert_state_variable :registration_country_name_lowercase_prefix, 'Belgium'
+        assert_equal "Belgium", current_state.calculator.registration_country_name_lowercase_prefix
         assert_state_variable :registration_country, 'belgium'
       end
     end # Death in Egypt user in Belgium

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -380,7 +380,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         assert_current_node :oru_result
         assert_equal 'Egypt', current_state.calculator.death_country_name_lowercase_prefix
         assert_equal "Belgium", current_state.calculator.registration_country_name_lowercase_prefix
-        assert_state_variable :registration_country, 'belgium'
+        assert_equal 'belgium', current_state.calculator.registration_country
       end
     end # Death in Egypt user in Belgium
 

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -198,7 +198,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         end
         should "give the embassy result and be done" do
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
+          assert_equal "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx", current_state.calculator.translator_link_url
           assert current_state.send(:document_return_fees).present?
         end
       end # Answer embassy
@@ -208,7 +208,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         end
         should "give the ORU result and be done" do
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx"
+          assert_equal "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx", current_state.calculator.translator_link_url
         end
       end # Answer ORU
     end # Answer Spain
@@ -227,7 +227,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         end
         should "give the ORU result and be done" do
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "/government/publications/morocco-list-of-lawyers"
+          assert_equal "/government/publications/morocco-list-of-lawyers", current_state.calculator.translator_link_url
         end
       end # Answer ORU
     end # Morocco
@@ -239,7 +239,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
       end
       should "give the ORU result and be done" do
         assert_current_node :oru_result
-        assert_state_variable :translator_link_url, "/government/publications/italy-list-of-lawyers"
+        assert_equal "/government/publications/italy-list-of-lawyers", current_state.calculator.translator_link_url
       end
     end # Answer Italy
 
@@ -251,7 +251,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
       end
       should "give the oru result and be done" do
         assert_current_node :oru_result
-        assert_state_variable :translator_link_url, "/government/publications/spain-list-of-lawyers"
+        assert_equal "/government/publications/spain-list-of-lawyers", current_state.calculator.translator_link_url
       end
     end # Answer Andorra, now in France
 
@@ -264,14 +264,14 @@ class RegisterADeathTest < ActiveSupport::TestCase
           add_response 'same_country'
 
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "/government/publications/afghanistan-list-of-lawyers"
+          assert_equal "/government/publications/afghanistan-list-of-lawyers", current_state.calculator.translator_link_url
         end
       end
       context "now back in the UK" do
         should "give the ORU result with a translators link" do
           add_response 'in_the_uk'
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "/government/publications/afghanistan-list-of-lawyers"
+          assert_equal "/government/publications/afghanistan-list-of-lawyers", current_state.calculator.translator_link_url
         end
       end
     end # Answer Afghanistan
@@ -285,7 +285,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         should "give the ORU result with a translator link and a standard payment method" do
           add_response 'in_the_uk'
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "/government/publications/algeria-list-of-lawyers"
+          assert_equal "/government/publications/algeria-list-of-lawyers", current_state.calculator.translator_link_url
         end
       end
 
@@ -294,7 +294,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
           add_response 'another_country'
           add_response 'algeria'
           assert_current_node :oru_result
-          assert_state_variable :translator_link_url, "/government/publications/algeria-list-of-lawyers"
+          assert_equal "/government/publications/algeria-list-of-lawyers", current_state.calculator.translator_link_url
         end
       end
     end # Answer Algeria
@@ -345,7 +345,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'in_the_uk'
       end
       should "give the embassy result and be done" do
-        assert_state_variable :translator_link_url, "/government/publications/list-of-translators-and-interpreters-in-serbia"
+        assert_equal "/government/publications/list-of-translators-and-interpreters-in-serbia", current_state.calculator.translator_link_url
       end
     end # Answer Serbia
     context "answer Pakistan, user in the UK" do
@@ -362,7 +362,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'st-kitts-and-nevis'
       end
       should "give the embassy result and be done" do
-        assert_state_variable :translator_link_url, nil
+        assert_nil current_state.calculator.translator_link_url
       end
     end # Answer Dominica
     context "answer death in Egypt, user in Belgium" do


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/jjPO9Leq

Similar to #2619, this moves the flow towards the style described in the [refactoring documentation][1]. I've concentrated on moving logic out of the flow and into the calculator and presentational concerns into the templates. The idea is to change all the flows to use this approach so we can significantly simplify the DSL.

In this case, I haven't done much work on the calculator itself other than extracting methods from the flow into it. Also I haven't attempted to extract any domain concepts. Some of the logic could almost certainly be simplified. There is still quite a bit of work to do to move all the *tests* for this flow towards the [new-style approach][2].

In extracting logic into the new calculator class, I've tried to keep things as similar as possible to the calculator class for `register-a-birth`. In fact this refactoring has made it clear that there is quite a bit of duplication between the two which could almost certainly be removed.

Although the PR has a lot of commits, the vast majority of them are very small and only affect a few files. Also because of the similarities between this flow and `register-a-birth`, I've tried to structure the commits in a similar way as when I refactored `register-a-birth`.

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md
[2]: https://github.com/alphagov/smart-answers/blob/master/doc/new-style-testing.md
