### PR TITLE
Consistently display overseas-passport courier info

### DIFF
--- a/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
@@ -36,7 +36,9 @@
   <%= render partial: 'cost/payment_instructions.govspeak.erb', locals: { calculator: calculator } %>
 
 <% elsif calculator.replacing? and calculator.ips_number == '1' and calculator.ips_docs_number == '1' %>
-  You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+  You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+  The courier fee pays for your passport to be sent back to you securely.
 
   <% case calculator.child_or_adult %>
   <% when 'adult' %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
@@ -17,7 +17,9 @@
 
   You must pay in cash. In addition to the passport fee you’ll need to pay any local administration fees which apply from the office where you make your application.
 <% elsif calculator.current_location == 'tunisia' %>
-    You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+    You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+    The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
   <% case calculator.child_or_adult %>
   <% when 'adult' %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
@@ -103,7 +103,9 @@
 
       The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% when '3' %>
-      You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+      You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+      The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% end %>
   <% end %>
 

--- a/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
@@ -99,7 +99,9 @@
 
       The courier fee pays for your passport and supporting documents to be sent back to you securely.
     <% when '2' %>
-      You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+      You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+      The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% when '3' %>
       You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% end %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
@@ -84,7 +84,9 @@
 
       The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
     <% when '3' %>
-      You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+      You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+      The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
     <% end %>
   <% elsif %w(pitcairn-island).include?(calculator.current_location) %>
     You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.

--- a/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
@@ -89,7 +89,9 @@
       The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
     <% end %>
   <% elsif %w(pitcairn-island).include?(calculator.current_location) %>
-    You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+    You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+    The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
   <% else %>
     <% case calculator.ips_number %>
     <% when '1' %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
@@ -95,7 +95,9 @@
   <% else %>
     <% case calculator.ips_number %>
     <% when '1' %>
-      You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+      You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+      The courier fee pays for your passport and supporting documents to be sent back to you securely.
     <% when '2' %>
       You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% when '3' %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb
@@ -80,7 +80,9 @@
   <% if uk_visa_application_centre_countries.include?(calculator.current_location) %>
     <% case calculator.ips_number %>
     <% when '2' %>
-      You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+      You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+      The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
     <% when '3' %>
       You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
     <% end %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb
@@ -18,7 +18,9 @@
   ## Cost
 
   <% if calculator.replacing? and calculator.ips_number == '1' and calculator.ips_docs_number == '1' %>
-    You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+    You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+    The courier fee pays for your passport to be sent back to you securely.
 
     <% case calculator.child_or_adult %>
     <% when 'adult' %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb
@@ -36,7 +36,9 @@
   <% else %>
     <% case calculator.ips_number %>
     <% when '1' %>
-      You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+      You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+      The courier fee pays for your passport and supporting documents to be sent back to you securely.
     <% when '2' %>
       You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% when '3' %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb
@@ -40,7 +40,9 @@
 
       The courier fee pays for your passport and supporting documents to be sent back to you securely.
     <% when '2' %>
-      You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+      You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+      The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% when '3' %>
       You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% end %>

--- a/lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb
@@ -44,7 +44,9 @@
 
       The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% when '3' %>
-      You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+      You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+      The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
     <% end %>
 
     <%= render partial: 'cost/child_or_adult_passport.govspeak.erb', locals: { calculator: calculator } %>

--- a/test/artefacts/overseas-passports/afghanistan/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/afghanistan/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/afghanistan/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/afghanistan/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/afghanistan/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/afghanistan/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/afghanistan/replacing/child.txt
+++ b/test/artefacts/overseas-passports/afghanistan/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/algeria/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/algeria/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/algeria/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/algeria/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/algeria/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/algeria/replacing/child.txt
+++ b/test/artefacts/overseas-passports/algeria/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/american-samoa/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/american-samoa/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/american-samoa/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/american-samoa/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/american-samoa/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/american-samoa/replacing/child.txt
+++ b/test/artefacts/overseas-passports/american-samoa/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/benin/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/benin/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/benin/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/benin/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/benin/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/benin/replacing/child.txt
+++ b/test/artefacts/overseas-passports/benin/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/burundi/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/burundi/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/burundi/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/burundi/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/burundi/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/burundi/replacing/child.txt
+++ b/test/artefacts/overseas-passports/burundi/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cambodia/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/cambodia/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cambodia/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/cambodia/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/cambodia/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cambodia/replacing/child.txt
+++ b/test/artefacts/overseas-passports/cambodia/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cuba/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/cuba/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cuba/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/cuba/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/cuba/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/cuba/replacing/child.txt
+++ b/test/artefacts/overseas-passports/cuba/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/falkland-islands/replacing/child.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/france/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/france/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/france/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/france/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/france/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/france/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/france/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/france/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/france/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/france/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/france/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/france/replacing/child.txt
+++ b/test/artefacts/overseas-passports/france/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/georgia/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/georgia/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/georgia/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/georgia/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/georgia/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/georgia/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/georgia/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/georgia/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/georgia/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/georgia/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/georgia/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/georgia/replacing/child.txt
+++ b/test/artefacts/overseas-passports/georgia/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/hong-kong/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/hong-kong/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/hong-kong/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/hong-kong/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/hong-kong/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/hong-kong/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/hong-kong/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/hong-kong/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/hong-kong/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/hong-kong/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/hong-kong/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/hong-kong/replacing/child.txt
+++ b/test/artefacts/overseas-passports/hong-kong/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/laos/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/laos/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/laos/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/laos/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/laos/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/laos/replacing/child.txt
+++ b/test/artefacts/overseas-passports/laos/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/nigeria/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/nigeria/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/nigeria/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/nigeria/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/nigeria/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/nigeria/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/nigeria/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/nigeria/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/nigeria/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/nigeria/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/nigeria/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/nigeria/replacing/child.txt
+++ b/test/artefacts/overseas-passports/nigeria/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pakistan/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/pakistan/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pakistan/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/pakistan/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/pakistan/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/pakistan/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pakistan/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/pakistan/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pakistan/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/pakistan/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/pakistan/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pakistan/replacing/child.txt
+++ b/test/artefacts/overseas-passports/pakistan/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/pitcairn-island/replacing/child.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/russia/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/russia/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/russia/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/russia/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/russia/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/russia/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/russia/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/russia/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/russia/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/russia/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/russia/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/russia/replacing/child.txt
+++ b/test/artefacts/overseas-passports/russia/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/south-sudan/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/south-sudan/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/south-sudan/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/south-sudan/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/south-sudan/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/south-sudan/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/south-sudan/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/south-sudan/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/south-sudan/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/south-sudan/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/south-sudan/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/south-sudan/replacing/child.txt
+++ b/test/artefacts/overseas-passports/south-sudan/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-martin/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-martin/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-martin/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-martin/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/st-martin/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/st-martin/replacing/child.txt
+++ b/test/artefacts/overseas-passports/st-martin/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book any travel until you have a valid passport. If you need to travel m
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/replacing/child.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/replacing/child.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+You’ll have to pay a fee for your passport and a courier fee of £9.70.
+
+The courier fee pays for your passport to be sent back to you securely.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/timor-leste/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/timor-leste/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/timor-leste/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/timor-leste/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/timor-leste/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/timor-leste/replacing/child.txt
+++ b/test/artefacts/overseas-passports/timor-leste/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/tunisia/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/tunisia/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/tunisia/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/tunisia/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/tunisia/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/tunisia/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/tunisia/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/tunisia/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/tunisia/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/tunisia/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/tunisia/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/tunisia/replacing/child.txt
+++ b/test/artefacts/overseas-passports/tunisia/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £21.57. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £21.57.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/venezuela/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/venezuela/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/venezuela/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/venezuela/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/venezuela/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/venezuela/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/venezuela/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/venezuela/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/venezuela/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/venezuela/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/venezuela/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/venezuela/replacing/child.txt
+++ b/test/artefacts/overseas-passports/venezuela/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £23.01.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/western-sahara/applying/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/western-sahara/applying/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/western-sahara/applying/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/western-sahara/applying/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_new/adult.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_new/child.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_old/adult/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_old/adult/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_old/child/afghanistan.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_old/child/south-africa.txt
@@ -15,7 +15,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/western-sahara/replacing/adult.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/artefacts/overseas-passports/western-sahara/replacing/child.txt
+++ b/test/artefacts/overseas-passports/western-sahara/replacing/child.txt
@@ -17,7 +17,9 @@ Don’t book travel until you have a valid passport. If you need to travel more 
 
 ## Cost
 
-You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
 
 | Passport type | Passport fee | Total to pay (including courier fee) |
 |---------------|--------------|--------------------------------------|

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/overseas-passports.rb: 6d3c353334c76e2fc60e6bbd2c9e63b5
 test/data/overseas-passports-questions-and-responses.yml: b7573a445ef22c10860c73861d376f54
 test/data/overseas-passports-responses-and-expected-results.yml: 46fb4bc9856021dc285eb2846465c918
-lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb: 5859739850185dd6b3debbd3fa1e805f
+lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb: 839c3312a6404b18de70eaeb8a100c97
 lib/smart_answer_flows/overseas-passports/outcomes/_getting_your_passport.govspeak.erb: 5b0bb88724dcd306f821543584d1d140
 lib/smart_answer_flows/overseas-passports/outcomes/_how_long.govspeak.erb: 4534bc621bd3d7af0ef7edf2fa50d6a1
 lib/smart_answer_flows/overseas-passports/outcomes/_how_to_apply.govspeak.erb: 7c2c5e04da62da72c90b54460df7f618
@@ -20,7 +20,7 @@ lib/smart_answer_flows/overseas-passports/outcomes/getting_your_passport/_contac
 lib/smart_answer_flows/overseas-passports/outcomes/getting_your_passport/_id_apply_renew_old_replace.govspeak.erb: a59de939591dba0a00deb469b0ff5f51
 lib/smart_answer_flows/overseas-passports/outcomes/getting_your_passport/_id_renew_new.govspeak.erb: 5dedbcae3a018d10f2ce06d143baec67
 lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result.govspeak.erb: dff26b0075fa33f8de7fca51e1e46eeb
-lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb: a0f9cbbb795766a470c62952718918ca
+lib/smart_answer_flows/overseas-passports/outcomes/ips_application_result_online.govspeak.erb: 8eec46fb7d4b471dfa561ff617addcd7
 lib/smart_answer_flows/overseas-passports/outcomes/making_your_application/_apply_in_person.govspeak.erb: 0c53679c9a5bade801983b029dc8c862
 lib/smart_answer_flows/overseas-passports/outcomes/making_your_application/_apply_in_person_or_via_proxy.govspeak.erb: ecd3a646c341b2339978f31b7a16f7a1
 lib/smart_answer_flows/overseas-passports/outcomes/making_your_application/_book_appointment_by_email.govspeak.erb: fce872e417a5ddf0e678ffd3a2fdceab


### PR DESCRIPTION
Consistently display the courier information in overseas-passports. The cost is now always on a separate line to the information about what you're paying for. This brings the display of this information inline with that for Tajikistan, Turkmenistan and Uzbekistan. This should help us remove duplication in future.

We spoke to Ben Mortimer about making this change and he's happy for it to be deployed. No fact check required.
