### PR TITLE
Refactor uk-benefits-abroad to remove use of next_node_calculation blocks

### DIFF
--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -12,5 +12,9 @@ module SmartAnswer::Calculators
          latvia liechtenstein lithuania luxembourg malta netherlands norway
          poland portugal romania slovakia slovenia spain sweden switzerland).include?(country)
     end
+
+    def former_yugoslavia?
+      COUNTRIES_OF_FORMER_YUGOSLAVIA.include?(country)
+    end
   end
 end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -25,5 +25,10 @@ module SmartAnswer::Calculators
       (COUNTRIES_OF_FORMER_YUGOSLAVIA +
       %w(barbados bermuda guernsey jersey israel jamaica mauritius philippines turkey)).include?(country)
     end
+
+    def social_security_countries_bereavement_benefits?
+      (COUNTRIES_OF_FORMER_YUGOSLAVIA +
+      %w(barbados bermuda canada guernsey jersey israel jamaica mauritius new-zealand philippines turkey usa)).include?(country)
+    end
   end
 end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -20,5 +20,10 @@ module SmartAnswer::Calculators
     def social_security_countries_jsa?
       (COUNTRIES_OF_FORMER_YUGOSLAVIA + %w(guernsey jersey new-zealand)).include?(country)
     end
+
+    def social_security_countries_iidb?
+      (COUNTRIES_OF_FORMER_YUGOSLAVIA +
+      %w(barbados bermuda guernsey jersey israel jamaica mauritius philippines turkey)).include?(country)
+    end
   end
 end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -3,5 +3,12 @@ module SmartAnswer::Calculators
     include ActiveModel::Model
 
     attr_accessor :country
+
+    def eea_country?
+      %w(austria belgium bulgaria croatia cyprus czech-republic denmark estonia
+         finland france germany gibraltar greece hungary iceland ireland italy
+         latvia liechtenstein lithuania luxembourg malta netherlands norway
+         poland portugal romania slovakia slovenia spain sweden switzerland).include?(country)
+    end
   end
 end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -1,5 +1,7 @@
 module SmartAnswer::Calculators
   class UkBenefitsAbroadCalculator
     include ActiveModel::Model
+
+    attr_accessor :country
   end
 end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -16,5 +16,9 @@ module SmartAnswer::Calculators
     def former_yugoslavia?
       COUNTRIES_OF_FORMER_YUGOSLAVIA.include?(country)
     end
+
+    def social_security_countries_jsa?
+      (COUNTRIES_OF_FORMER_YUGOSLAVIA + %w(guernsey jersey new-zealand)).include?(country)
+    end
   end
 end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -2,6 +2,8 @@ module SmartAnswer::Calculators
   class UkBenefitsAbroadCalculator
     include ActiveModel::Model
 
+    COUNTRIES_OF_FORMER_YUGOSLAVIA = %w(bosnia-and-herzegovina kosovo macedonia montenegro serbia).freeze
+
     attr_accessor :country
 
     def eea_country?

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -1,0 +1,5 @@
+module SmartAnswer::Calculators
+  class UkBenefitsAbroadCalculator
+    include ActiveModel::Model
+  end
+end

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -124,10 +124,6 @@ module SmartAnswer
           (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
         end
 
-        next_node_calculation :social_security_countries_jsa do |response|
-          (countries_of_former_yugoslavia + %w(guernsey jersey new-zealand)).include?(response)
-        end
-
         next_node_calculation :social_security_countries_iidb do |response|
           (countries_of_former_yugoslavia +
           %w(barbados bermuda guernsey jersey israel jamaica mauritius philippines turkey)).include?(response)
@@ -143,11 +139,11 @@ module SmartAnswer
           when 'jsa'
             if already_abroad && calculator.eea_country?
               outcome :jsa_eea_already_abroad_outcome # A3 already_abroad
-            elsif already_abroad && social_security_countries_jsa
+            elsif already_abroad && calculator.social_security_countries_jsa?
               outcome :jsa_social_security_already_abroad_outcome # A4 already_abroad
             elsif going_abroad && calculator.eea_country?
               outcome :jsa_eea_going_abroad_outcome # A5 going_abroad
-            elsif going_abroad && social_security_countries_jsa
+            elsif going_abroad && calculator.social_security_countries_jsa?
               outcome :jsa_social_security_going_abroad_outcome # A6 going_abroad
             else
               outcome :jsa_not_entitled_outcome # A7 going_abroad and A5 already_abroad

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -124,11 +124,6 @@ module SmartAnswer
           (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
         end
 
-        next_node_calculation :social_security_countries_bereavement_benefits do |response|
-          (countries_of_former_yugoslavia +
-          %w(barbados bermuda canada guernsey jersey israel jamaica mauritius new-zealand philippines turkey usa)).include?(response)
-        end
-
         next_node do |response|
           case benefit
           when 'jsa'
@@ -239,7 +234,7 @@ module SmartAnswer
             if going_abroad
               if calculator.eea_country?
                 outcome :bb_going_abroad_eea_outcome # A39 going_abroad
-              elsif social_security_countries_bereavement_benefits
+              elsif calculator.social_security_countries_bereavement_benefits?
                 outcome :bb_going_abroad_ss_outcome # A40 going_abroad
               else
                 outcome :bb_going_abroad_other_outcome # A38 going_abroad
@@ -247,7 +242,7 @@ module SmartAnswer
             elsif already_abroad
               if calculator.eea_country?
                 outcome :bb_already_abroad_eea_outcome # A37 already_abroad
-              elsif social_security_countries_bereavement_benefits
+              elsif calculator.social_security_countries_bereavement_benefits?
                 outcome :bb_already_abroad_ss_outcome # A38 already_abroad
               else
                 outcome :bb_already_abroad_other_outcome # A39 already_abroad

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -17,6 +17,10 @@ module SmartAnswer
         option :already_abroad
         save_input_as :going_or_already_abroad
 
+        on_response do
+          self.calculator = Calculators::UkBenefitsAbroadCalculator.new
+        end
+
         calculate :country_question_title do
           if going_or_already_abroad == "going_abroad"
             "Which country are you moving to?"

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -9,7 +9,7 @@ module SmartAnswer
       exclude_countries = %w(british-antarctic-territory french-guiana guadeloupe holy-see martinique mayotte reunion st-maarten)
       additional_countries = [OpenStruct.new(slug: "jersey", name: "Jersey"), OpenStruct.new(slug: "guernsey", name: "Guernsey")]
 
-      countries_of_former_yugoslavia = %w(bosnia-and-herzegovina kosovo macedonia montenegro serbia).freeze
+      countries_of_former_yugoslavia = Calculators::UkBenefitsAbroadCalculator::COUNTRIES_OF_FORMER_YUGOSLAVIA
 
       # Q1
       multiple_choice :going_or_already_abroad? do

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -124,11 +124,6 @@ module SmartAnswer
           (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
         end
 
-        next_node_calculation :social_security_countries_iidb do |response|
-          (countries_of_former_yugoslavia +
-          %w(barbados bermuda guernsey jersey israel jamaica mauritius philippines turkey)).include?(response)
-        end
-
         next_node_calculation :social_security_countries_bereavement_benefits do |response|
           (countries_of_former_yugoslavia +
           %w(barbados bermuda canada guernsey jersey israel jamaica mauritius new-zealand philippines turkey usa)).include?(response)
@@ -184,7 +179,7 @@ module SmartAnswer
             if going_abroad
               if calculator.eea_country?
                 outcome :iidb_going_abroad_eea_outcome # A32 going_abroad
-              elsif social_security_countries_iidb
+              elsif calculator.social_security_countries_iidb?
                 outcome :iidb_going_abroad_ss_outcome # A33 going_abroad
               else
                 outcome :iidb_going_abroad_other_outcome # A34 going_abroad
@@ -192,7 +187,7 @@ module SmartAnswer
             elsif already_abroad
               if calculator.eea_country?
                 outcome :iidb_already_abroad_eea_outcome # A31 already_abroad
-              elsif social_security_countries_iidb
+              elsif calculator.social_security_countries_iidb?
                 outcome :iidb_already_abroad_ss_outcome # A32 already_abroad
               else
                 outcome :iidb_already_abroad_other_outcome # A33 already_abroad

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -124,10 +124,6 @@ module SmartAnswer
           (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
         end
 
-        next_node_calculation :responded_with_former_yugoslavia do |response|
-          countries_of_former_yugoslavia.include?(response)
-        end
-
         next_node_calculation :social_security_countries_jsa do |response|
           (countries_of_former_yugoslavia + %w(guernsey jersey new-zealand)).include?(response)
         end
@@ -175,7 +171,7 @@ module SmartAnswer
           when 'child_benefit'
             if calculator.eea_country?
               question :do_either_of_the_following_apply? # Q13 going_abroad and Q12 already_abroad
-            elsif responded_with_former_yugoslavia
+            elsif calculator.former_yugoslavia?
               if going_abroad
                 outcome :child_benefit_fy_going_abroad_outcome # A14 going_abroad
               else
@@ -230,7 +226,7 @@ module SmartAnswer
             if going_abroad
               if calculator.eea_country?
                 outcome :esa_going_abroad_eea_outcome # A29 going_abroad
-              elsif responded_with_former_yugoslavia
+              elsif calculator.former_yugoslavia?
                 outcome :esa_going_abroad_eea_outcome
               elsif %w(barbados guernsey israel jersey jamaica turkey usa).include?(response)
                 outcome :esa_going_abroad_eea_outcome
@@ -240,7 +236,7 @@ module SmartAnswer
             elsif already_abroad
               if calculator.eea_country?
                 outcome :esa_already_abroad_eea_outcome # A27 already_abroad
-              elsif responded_with_former_yugoslavia
+              elsif calculator.former_yugoslavia?
                 outcome :esa_already_abroad_ss_outcome # A28 already_abroad
               elsif %w(barbados jersey guernsey jamaica turkey usa).include?(response)
                 outcome :esa_already_abroad_ss_outcome

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -124,13 +124,6 @@ module SmartAnswer
           (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
         end
 
-        next_node_calculation :responded_with_eea_country do |response|
-          %w(austria belgium bulgaria croatia cyprus czech-republic denmark estonia
-             finland france germany gibraltar greece hungary iceland ireland italy
-             latvia liechtenstein lithuania luxembourg malta netherlands norway
-             poland portugal romania slovakia slovenia spain sweden switzerland).include?(response)
-        end
-
         next_node_calculation :responded_with_former_yugoslavia do |response|
           countries_of_former_yugoslavia.include?(response)
         end
@@ -152,11 +145,11 @@ module SmartAnswer
         next_node do |response|
           case benefit
           when 'jsa'
-            if already_abroad && responded_with_eea_country
+            if already_abroad && calculator.eea_country?
               outcome :jsa_eea_already_abroad_outcome # A3 already_abroad
             elsif already_abroad && social_security_countries_jsa
               outcome :jsa_social_security_already_abroad_outcome # A4 already_abroad
-            elsif going_abroad && responded_with_eea_country
+            elsif going_abroad && calculator.eea_country?
               outcome :jsa_eea_going_abroad_outcome # A5 going_abroad
             elsif going_abroad && social_security_countries_jsa
               outcome :jsa_social_security_going_abroad_outcome # A6 going_abroad
@@ -164,13 +157,13 @@ module SmartAnswer
               outcome :jsa_not_entitled_outcome # A7 going_abroad and A5 already_abroad
             end
           when 'maternity_benefits'
-            if responded_with_eea_country
+            if calculator.eea_country?
               question :working_for_a_uk_employer? # Q8 going_abroad and Q7 already_abroad
             else
               question :employer_paying_ni? # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
             end
           when 'winter_fuel_payment'
-            if responded_with_eea_country
+            if calculator.eea_country?
               if going_abroad
                 outcome :wfp_going_abroad_outcome # A9 going_abroad
               else
@@ -180,7 +173,7 @@ module SmartAnswer
               outcome :wfp_not_eligible_outcome # A8 going_abroad and A6 already_abroad
             end
           when 'child_benefit'
-            if responded_with_eea_country
+            if calculator.eea_country?
               question :do_either_of_the_following_apply? # Q13 going_abroad and Q12 already_abroad
             elsif responded_with_former_yugoslavia
               if going_abroad
@@ -197,7 +190,7 @@ module SmartAnswer
             end
           when 'iidb'
             if going_abroad
-              if responded_with_eea_country
+              if calculator.eea_country?
                 outcome :iidb_going_abroad_eea_outcome # A32 going_abroad
               elsif social_security_countries_iidb
                 outcome :iidb_going_abroad_ss_outcome # A33 going_abroad
@@ -205,7 +198,7 @@ module SmartAnswer
                 outcome :iidb_going_abroad_other_outcome # A34 going_abroad
               end
             elsif already_abroad
-              if responded_with_eea_country
+              if calculator.eea_country?
                 outcome :iidb_already_abroad_eea_outcome # A31 already_abroad
               elsif social_security_countries_iidb
                 outcome :iidb_already_abroad_ss_outcome # A32 already_abroad
@@ -214,7 +207,7 @@ module SmartAnswer
               end
             end
           when 'disability_benefits'
-            if responded_with_eea_country
+            if calculator.eea_country?
               question :db_claiming_benefits? # Q30 going_abroad and Q29 already_abroad
             elsif going_abroad
               outcome :db_going_abroad_other_outcome # A36 going_abroad
@@ -222,20 +215,20 @@ module SmartAnswer
               outcome :db_already_abroad_other_outcome # A35 already_abroad
             end
           when 'ssp'
-            if responded_with_eea_country
+            if calculator.eea_country?
               question :working_for_uk_employer_ssp? # Q15 going_abroad and Q14 already_abroad
             else
               question :employer_paying_ni? # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
             end
           when 'tax_credits'
-            if responded_with_eea_country
+            if calculator.eea_country?
               question :tax_credits_currently_claiming? # Q20 already_abroad
             else
               outcome :tax_credits_unlikely_outcome # A21 already_abroad and A23 going_abroad
             end
           when 'esa'
             if going_abroad
-              if responded_with_eea_country
+              if calculator.eea_country?
                 outcome :esa_going_abroad_eea_outcome # A29 going_abroad
               elsif responded_with_former_yugoslavia
                 outcome :esa_going_abroad_eea_outcome
@@ -245,7 +238,7 @@ module SmartAnswer
                 outcome :esa_going_abroad_other_outcome # A30 going_abroad
               end
             elsif already_abroad
-              if responded_with_eea_country
+              if calculator.eea_country?
                 outcome :esa_already_abroad_eea_outcome # A27 already_abroad
               elsif responded_with_former_yugoslavia
                 outcome :esa_already_abroad_ss_outcome # A28 already_abroad
@@ -257,7 +250,7 @@ module SmartAnswer
             end
           when 'bereavement_benefits'
             if going_abroad
-              if responded_with_eea_country
+              if calculator.eea_country?
                 outcome :bb_going_abroad_eea_outcome # A39 going_abroad
               elsif social_security_countries_bereavement_benefits
                 outcome :bb_going_abroad_ss_outcome # A40 going_abroad
@@ -265,7 +258,7 @@ module SmartAnswer
                 outcome :bb_going_abroad_other_outcome # A38 going_abroad
               end
             elsif already_abroad
-              if responded_with_eea_country
+              if calculator.eea_country?
                 outcome :bb_already_abroad_eea_outcome # A37 already_abroad
               elsif social_security_countries_bereavement_benefits
                 outcome :bb_already_abroad_ss_outcome # A38 already_abroad

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -116,10 +116,12 @@ module SmartAnswer
 
       ## Country Question - Shared
       country_select :which_country?, additional_countries: additional_countries, exclude_countries: exclude_countries do
-        save_input_as :country
+        on_response do |response|
+          calculator.country = response
+        end
 
         calculate :country_name do
-          (WorldLocation.all + additional_countries).find { |c| c.slug == country }.name
+          (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
         end
 
         next_node_calculation :responded_with_eea_country do |response|
@@ -330,7 +332,7 @@ module SmartAnswer
             #not SSP benefits
             if response == 'yes'
               question :eligible_for_smp? # Q9 going_abroad and Q8 already_abroad
-            elsif (countries_of_former_yugoslavia + %w(barbados guernsey jersey israel turkey)).include?(country)
+            elsif (countries_of_former_yugoslavia + %w(barbados guernsey jersey israel turkey)).include?(calculator.country)
               if already_abroad
                 outcome :maternity_benefits_social_security_already_abroad_outcome # A10 already_abroad
               else

--- a/test/data/uk-benefits-abroad-files.yml
+++ b/test/data/uk-benefits-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/uk-benefits-abroad.rb: 62cbeec29d3f571985efdcb0c540eb18
+lib/smart_answer_flows/uk-benefits-abroad.rb: 866546b9bf29daa90b9b53f43171ac8c
 test/data/uk-benefits-abroad-questions-and-responses.yml: 279454ec0916c13ac09ed5a90ad58777
 test/data/uk-benefits-abroad-responses-and-expected-results.yml: dbf714c4de3ed03f81c868c354aa9c81
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/_tax_credits_already_abroad_helpline.govspeak.erb: d79b1b09c2fe01c66cdda028a7679b8b
@@ -96,3 +96,4 @@ lib/smart_answer_flows/uk-benefits-abroad/questions/which_country.govspeak.erb: 
 lib/smart_answer_flows/uk-benefits-abroad/questions/working_for_a_uk_employer.govspeak.erb: 8367cff3d1d36a843d6d966a547d179b
 lib/smart_answer_flows/uk-benefits-abroad/questions/working_for_uk_employer_ssp.govspeak.erb: 15e9162bb80fe215af169d0e39dd53d0
 lib/smart_answer_flows/uk-benefits-abroad/uk_benefits_abroad.govspeak.erb: 289ed7bd184696294095c760f24ffb0d
+lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb: 7ef61bd2e7662905c1189918d3701b79


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/g0Z5s0XE

Similar to #2619, this moves the flow _towards_ the style described in the [refactoring documentation][1]. However, unlike previous similar refactoring PRs, I've focussed exclusively on removing the use of `next_node_calculation` blocks from the flow definition. This is so I can get to the point where I can remove `next_node_calculation` from the DSL as soon as possible. It would be a _lot_ more work to fully refactor this flow to the new-style.

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md
