### PR TITLE
Convert next_node_calculation blocks into on_response blocks in benefit-cap-calculator

### DIFF
--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -102,8 +102,8 @@ module SmartAnswer
           option benefit
         end
 
-        next_node_calculation :benefit_types do |response|
-          response.split(",").map(&:to_sym)
+        on_response do |response|
+          self.benefit_types = response.split(",").map(&:to_sym)
         end
 
         next_node do |response|
@@ -121,8 +121,8 @@ module SmartAnswer
           option benefit
         end
 
-        next_node_calculation :benefit_types do |response|
-          response.split(",").map(&:to_sym)
+        on_response do |response|
+          self.benefit_types = response.split(",").map(&:to_sym)
         end
 
         next_node do |response|

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/benefit-cap-calculator.rb: 9cfdb589e4263719940b7634d1842f5f
+lib/smart_answer_flows/benefit-cap-calculator.rb: f4479dbfd3aa646bd37ae522e6087824
 test/data/benefit-cap-calculator-questions-and-responses.yml: c49cc1cdb19e8b0e46f3a8146d83e0ef
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 79e2ce032529e01911e3f50946f510bc
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: ce5203f11989c0b35bd9c53ade1f3f82


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/LP9tmz3N

This is part of an effort to move all flows towards a [new style][1]. In the new style, `next_node_calculation` blocks are deprecated. This commit removes the only two remaining usages in production code (once other pending PRs have been merged).

Note that I've chosen to update the regression test checksums in this commit, because all the regression tests are still passing i.e. this was just an internal refactoring; no external behaviour has changed.

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md