### PR TITLE
Remove next_node_calculation block functionality

### DIFF
--- a/doc/adding-new-regression-tests.md
+++ b/doc/adding-new-regression-tests.md
@@ -46,7 +46,7 @@ $ rm -rf coverage && \
 
       * Code in node-level blocks (e.g. in `value_question`, `date_question`, `multiple_choice` & `outcome` blocks) will always be executed at *flow-definition-time*, and so coverage of these lines is of **no** significance when assessing test coverage of the flow logic.
 
-      * Code in blocks inside node-level blocks (e.g. in `precalculate`, `next_node_calculation` & `validate` blocks) will be executed at *flow-execution-time*, and so coverage of these lines is of significance when assessing test coverage of the flow logic.
+      * Code in blocks inside node-level blocks (e.g. in `precalculate` & `validate` blocks) will be executed at *flow-execution-time*, and so coverage of these lines is of significance when assessing test coverage of the flow logic.
 
       * Coverage of code in ancillary classes (e.g. calculators) should also be considered at this point.
 

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -225,19 +225,18 @@ second_state = first_state.transition_to(:third_node, 'second-response')
 
 #### In-question blocks
 
-All question definition blocks, must include a single `next_node` block. A number of other in-question blocks can optionally be defined by passing a block to any of the following methods on `SmartAnswer::Node` & `SmartAnswer::Question::Base`: `precalculate`, `on_response`, `next_node_calculation`, `validate`, `next_node` & `calculate`. The `save_input_as` method is used in a similar way, but does not accept a block.
+All question definition blocks, must include a single `next_node` block. A number of other in-question blocks can optionally be defined by passing a block to any of the following methods on `SmartAnswer::Node` & `SmartAnswer::Question::Base`: `precalculate`, `on_response`, `validate`, `next_node` & `calculate`. The `save_input_as` method is used in a similar way, but does not accept a block.
 
 The value of `self` inside all these blocks is an instance of `SmartAnswer::State` ([see above](#state)). The code inside these blocks is executed at request time, not at flow definition time.
 
-All blocks of a particular type (within a single question) are executed at particular points in the request processing sequence e.g. all `on_response` blocks are executed before all `next_node_calculation` blocks.
+All blocks of a particular type (within a single question) are executed at particular points in the request processing sequence e.g. all `on_response` blocks are executed before all `validate` blocks.
 
-The order in which the blocks are defined only affects the order in which they are executed within the group of blocks of the same type e.g. when two `on_response` blocks are defined, the one defined first will be executed before the one defined second; however, even if a `next_node_calculation` block is defined before both of these `on_response` blocks, it will always be executed after both of them.
+The order in which the blocks are defined only affects the order in which they are executed within the group of blocks of the same type e.g. when two `on_response` blocks are defined, the one defined first will be executed before the one defined second; however, even if a `validate` block is defined before both of these `on_response` blocks, it will always be executed after both of them.
 
 The block types are executed in the following order:
 
 * [`precalculate`](#precalculatevariable_name-block)
 * [`on_response`](#on_responseblock)
-* [`next_node_calculation`](#next_node_calculationvariable_name-block)
 * [`validate`](#validatemessage_key-block)
 * [`next_node`](#next_nodeblock)
 * [`save_input_as`](#save_input_asvariable_name)
@@ -259,25 +258,16 @@ Each of these block types and the point at which they are executed is explained 
 ##### `on_response(&block)`
 
 * These blocks are intended to be used to store user responses on a `calculator` state variable. They are a [relatively new addition to the DSL][introduction-of-on-response-blocks].
-* These blocks are called after the question/outcome template has been rendered and after the user response has been parsed from the request path, but before any of the `next_node_calculation` blocks are executed.
+* These blocks are called after the question/outcome template has been rendered and after the user response has been parsed from the request path, but before any of the `validate` blocks are executed.
 * The parsed response is passed to the block as the only argument and by convention is named `response`.
 * The block return value is not used and no state variable is stored.
 
 > The use of these blocks is encouraged; however, they should only ever be used to store a single, `calculator` state variable (in the first question definition); otherwise they should only be used to store user responses on that `calculator` object.
 
-##### `next_node_calculation(variable_name, &block)`
-
-* These blocks were intended to be used to store state variables that are needed in the `next_node` block.
-* These blocks are executed after all the `on_response` blocks have been executed and before any of the `validate` blocks are executed.
-* The parsed response is passed to the block as the only argument and by convention is named `response`.
-* The block return value is stored on the state object as a state variable named `variable_name`.
-
-> The use of these blocks is deprecated and should never be necessary. Define methods on a `calculator` object instead.
-
 ##### `validate(message_key, &block)`
 
 * These blocks are intended to be used to validate the user response.
-* These blocks are executed after all the `next_node_calculation` blocks have been executed and before the `next_node` block is executed.
+* These blocks are executed after all the `on_response` blocks have been executed and before the `next_node` block is executed.
 * The parsed response is passed to the block as the only argument and by convention is named `response`.
 * If the block return value is truth-y, then no action is taken.
 * If the block return value is false-y, then:
@@ -330,7 +320,6 @@ These are very similar to question nodes. However, it only makes sense to use `p
 
 * [`precalculate`](#precalculatevariable_name-block)
 * [`on_response`](#on_responseblock)
-* [`next_node_calculation`](#next_node_calculationvariable_name-block)
 * [`calculate`](#calculatevariable_name-block)
 
 If any attempt is made to process a response when the current node is an outcome node (e.g. by hacking the URL path), an exception will be raised.

--- a/doc/storing-data.md
+++ b/doc/storing-data.md
@@ -1,10 +1,9 @@
 # Storing data for later use
 
-You can use the `on_response`, `precalculate`, `next_node_calculation`, `save_input_as` and `calculate` methods to store data for later use. These values are stored in the state and are available in the rest of the flow and in the ERB templates.
+You can use the `on_response`, `precalculate`, `save_input_as` and `calculate` methods to store data for later use. These values are stored in the state and are available in the rest of the flow and in the ERB templates.
 
 * `precalculate` values are available in:
   * The question template
-  * The `next_node_calculation` block
   * The `validate` block
   * The `next_node` block
   * The `calculate` block
@@ -13,7 +12,6 @@ You can use the `on_response`, `precalculate`, `next_node_calculation`, `save_in
 __NOTE.__ `precalculate` blocks are not evaluated in the first question. This is because they're evaluated during the transition of one question to the next.
 
 * `on_response` values are available in:
-  * The `next_node_calculation` block
   * The `validate` block
   * The `next_node` block
   * The `calculate` block
@@ -54,12 +52,6 @@ value_question :question_2? do
   end
 end
 ```
-
-* `next_node_calculation` values are available in:
-  * The `validate` block
-  * The `next_node` block
-  * The `calculate` block
-  * All subsequent questions and outcomes
 
 * `save_input_as` values are available in:
   * The `calculate` block
@@ -102,23 +94,12 @@ multiple_choice :question_2? do
     self.q2_saved_response = response
   end
 
-  next_node_calculation :q2_next_node_calculated_answer do |response|
-    # response                => 'q2_option'
-    # responses               => ['q1_option']
-    # q1_calculated_answer    => 'q1-calculated-answer'
-    # q2_precalculated_answer => 'q2-precalculated-answer'
-    # q2_saved_response       => 'q2_option'
-
-    'q2-next-node-calculated-answer'
-  end
-
   validate do |response|
     # response                       => 'q2_option'
     # responses                      => ['q1_option']
     # q1_calculated_answer           => 'q1-calculated-answer'
     # q2_precalculated_answer        => 'q2-precalculated-answer'
     # q2_saved_response              => 'q2_option'
-    # q2_next_node_calculated_answer => 'q2-next-node-calculated-answer'
   end
 
   next_node do |response|
@@ -127,7 +108,6 @@ multiple_choice :question_2? do
     # q1_calculated_answer           => 'q1-calculated-answer'
     # q2_precalculated_answer        => 'q2-precalculated-answer'
     # q2_saved_response              => 'q2_option'
-    # q2_next_node_calculated_answer => 'q2-next-node-calculated-answer'
   end
 
   save_input_as :q2_answer
@@ -139,7 +119,6 @@ multiple_choice :question_2? do
     # q2_answer                      => 'q2_option'
     # q2_precalculated_answer        => 'q2-precalculated-answer'
     # q2_saved_response              => 'q2_option'
-    # q2_next_node_calculated_answer => 'q2-next-node-calculated-answer'
   end
 end
 ```

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -3,14 +3,13 @@ require 'active_support/inflector'
 module SmartAnswer
   class Node
     attr_accessor :flow
-    attr_reader :name, :calculations, :next_node_calculations, :precalculations
+    attr_reader :name, :calculations, :precalculations
 
     def initialize(flow, name, &block)
       @flow = flow
       @name = name
       @on_response_blocks = []
       @calculations = []
-      @next_node_calculations = []
       @precalculations = []
       instance_eval(&block) if block_given?
     end
@@ -33,10 +32,6 @@ module SmartAnswer
 
     def calculate(variable_name, &block)
       @calculations << Calculation.new(variable_name, &block)
-    end
-
-    def next_node_calculation(variable_name, &block)
-      @next_node_calculations << Calculation.new(variable_name, &block)
     end
 
     def precalculate(variable_name, &block)

--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -52,11 +52,8 @@ module SmartAnswer
 
       def transition(current_state, raw_input)
         input = parse_input(raw_input)
-        state_after_on_response_blocks = @on_response_blocks.inject(current_state.dup) do |state, block|
+        new_state = @on_response_blocks.inject(current_state.dup) do |state, block|
           block.evaluate(state, input)
-        end
-        new_state = @next_node_calculations.inject(state_after_on_response_blocks.dup) do |state, calculation|
-          calculation.evaluate(state, input)
         end
         next_node = next_node_for(new_state, input)
         new_state = new_state.transition_to(next_node, input) do |state|

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -147,17 +147,17 @@ class QuestionBaseTest < ActiveSupport::TestCase
       assert_equal [:red], new_state.my_responses
     end
 
-    should "execute on_response block before next_node_calculation" do
+    should "execute on_response block before validate" do
       @question.on_response do
         self.foo = :value_from_on_response_block
       end
-      @question.next_node_calculation(:bar) do
-        foo
+      @question.validate do
+        foo == :value_from_on_response_block
       end
       @question.next_node { outcome :done }
       initial_state = SmartAnswer::State.new(@question.name)
       new_state = @question.transition(initial_state, :red)
-      assert_equal :value_from_on_response_block, new_state.bar
+      assert_equal :value_from_on_response_block, new_state.foo
     end
 
     should "execute on_response block before validation" do
@@ -195,23 +195,6 @@ class QuestionBaseTest < ActiveSupport::TestCase
       new_state = @question.transition(initial_state, :red)
       assert_equal :green, new_state.complementary_colour
       assert new_state.frozen?
-    end
-
-    should "execute next_node_calculation block before next_node" do
-      @question.next_node_calculation :complementary_colour do |response|
-        response == :red ? :green : :red
-      end
-      @question.next_node_calculation :blah do
-        "blah"
-      end
-      @question.next_node do
-        outcome :done if complementary_colour == :green
-      end
-      initial_state = SmartAnswer::State.new(@question.name)
-      new_state = @question.transition(initial_state, :red)
-      assert_equal :green, new_state.complementary_colour
-      assert_equal "blah", new_state.blah
-      assert_equal :done, new_state.current_node
     end
   end
 


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/w7nopJh3

This is the culmination of a series of pull requests which have been moving all flows towards a [new style][1] with a focus on removing usages of `next_node_calculation` blocks. In the new style, `next_node_calculation` blocks are deprecated.

This pull request depends on two as yet un-merged pull requests:

* [Convert next_node_calculation blocks into on_response blocks in benefit-cap-calculator](https://github.com/alphagov/smart-answers/pull/2638)
* [Refactor maternity-paternity-calculator to remove use of next_node_calculation blocks](https://github.com/alphagov/smart-answers/pull/2637)

However, I have included the changes from those PRs in two temporary squash commits. The idea is that these commits will disappear once those PRs are merged and this PR is rebased against master.

I've also updated the documentation to remove all references to `next_node_calculation`.

I ran *all* the regression tests to check that I hadn't accidentally broken anything.

## External changes

None. This is just an internal refactoring.

[1]: https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md