### PR TITLE
SPIKE: Links from content to template/partial on GitHub

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -164,3 +164,25 @@ $(document).ready(function() {
   contentPosition.init();
 
 });
+
+$(document).ready(function() {
+  $('.debug.template').each(function() {
+    var element = $(this);
+    var path = element.data('path');
+    var filename = path.split('/').pop();
+    var key = element.data('key');
+    var url = 'https://github.com/alphagov/smart-answers/blob/release/' + path;
+    var anchor = $('<a>Template on GitHub (key: ' + key + ')</a>').attr('href', url).attr('style', 'color: deeppink;').attr('title', filename);
+    element.prepend(anchor);
+    element.attr('style', 'border: 3px solid deeppink; padding: 10px; margin: 3px');
+  });
+  $('.debug.partial-template').each(function() {
+    var element = $(this);
+    var path = element.data('path');
+    var filename = path.split('/').pop();
+    var url = 'https://github.com/alphagov/smart-answers/blob/release/' + path;
+    var anchor = $('<a>Partial template on GitHub</a>').attr('href', url).attr('style', 'color: hotpink;').attr('title', filename);
+    element.prepend(anchor);
+    element.attr('style', 'border: 3px dotted hotpink; padding: 10px; margin: 3px');
+  });
+});

--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -2,170 +2,173 @@ function browserSupportsHtml5HistoryApi() {
   return !! (history && history.replaceState && history.pushState);
 }
 
+// $(document).ready(function() {
+//   if(browserSupportsHtml5HistoryApi()) {
+//     var formSelector = ".current form";
+//
+//     initializeHistory();
+//
+//     var getCurrentPosition = function () {
+//       var slugArray = document.URL.split('/');
+//       return slugArray.splice(3, slugArray.length).join('/');
+//     };
+//
+//     // events
+//     // get new questions on submit
+//     $('#content').on('submit', formSelector, function(event) {
+//       $('input[type=submit]', this).attr('disabled', 'disabled');
+//       var form = $(this);
+//       var postData = form.serializeArray();
+//       reloadQuestions(form.attr('action'), postData);
+//       event.preventDefault();
+//       return false;
+//     });
+//
+//     // Track when a user clicks on 'Start again' link
+//     $('#content').on('click', '.start-right', function() {
+//       GOVUK && GOVUK.analytics && GOVUK.analytics.trackEvent && GOVUK.analytics.trackEvent('MS_smart_answer', getCurrentPosition(), {label: 'Start again'});
+//       reloadQuestions($(this).attr('href'));
+//       return false;
+//     });
+//
+//     // Track when a user clicks on a 'Change Answer' link
+//     $('#content').on('click', '.link-right a', function() {
+//       var href = $(this).attr('href');
+//       GOVUK && GOVUK.analytics && GOVUK.analytics.trackEvent && GOVUK.analytics.trackEvent('MS_smart_answer', href, {label: 'Change Answer'});
+//       reloadQuestions(href);
+//       return false;
+//     });
+//
+//     // manage next/back by tracking popstate event
+//     window.onpopstate = function (event) {
+//       if(event.state !== null) {
+//         updateContent(event.state['html_fragment']);
+//       } else {
+//         return false;
+//       }
+//     };
+//   }
+//
+//   $('#current-error').focus();
+//
+//   // helper functions
+//   function toJsonUrl(url) {
+//     var parts = url.split('?');
+//     var json_url = parts[0].replace(/\/$/, "") + ".json";
+//     if (parts[1]) {
+//       json_url += "?";
+//       json_url += parts[1];
+//     }
+//     return window.location.protocol + "//" + window.location.host + json_url;
+//   }
+//
+//   function fromJsonUrl(url) {
+//     return url.replace(/\.json$/, "");
+//   }
+//
+//   function redirectToNonAjax(url) {
+//     window.location = url;
+//   }
+//
+//   // replace all the questions currently in the page with whatever is returned for given url
+//   function reloadQuestions(url, params) {
+//     var url = toJsonUrl(url);
+//
+//     addLoading('<p class="next-step">Loading next step&hellip;</p>');
+//
+//     $.ajax(url, {
+//       type: 'GET',
+//       dataType:'json',
+//       data: params,
+//       timeout: 10000,
+//       error: function(jqXHR, textStatus, errorStr) {
+//         var paramStr = $.param(params);
+//         redirectToNonAjax(url.replace('.json', '?' + paramStr).replace('??', '?'));
+//       },
+//       success: function(data, textStatus, jqXHR) {
+//         addToHistory(data);
+//         updateContent(data['html_fragment']);
+//       }
+//     });
+//   }
+//
+//   // manage the URL
+//   function addToHistory(data) {
+//     history.pushState(data, data['title'], data['url']);
+//     GOVUK && GOVUK.analytics && GOVUK.analytics.trackPageview && GOVUK.analytics.trackPageview(data['url']);
+//   }
+//
+//   // add an indicator of loading
+//   function addLoading(fragment){
+//     $('#content .step.current')
+//       .addClass('loading')
+//       .find('form .next-question')
+//       .append(fragment);
+//     $.event.trigger('smartanswerAnswer');
+//   };
+//
+//   // update the content (i.e. plonk in the html fragment)
+//   function updateContent(fragment){
+//     $('.smart_answer #js-replaceable').html(fragment);
+//     $.event.trigger('smartanswerAnswer');
+//     if ($(".outcome").length !== 0) {
+//       $.event.trigger('smartanswerOutcome');
+//     }
+//   }
+//
+//   function initializeHistory(data) {
+//     if (! browserSupportsHtml5HistoryApi() && window.location.pathname.match(/\/.*\//) ) {
+//       addToHistory({url: window.location.pathname});
+//     }
+//
+//     data = {
+//       html_fragment: $('.smart_answer #js-replaceable').html(),
+//       title: "Question",
+//       url: window.location.toString()
+//     };
+//     history.replaceState(data, data['title'], data['url']);
+//   }
+//
+//   var contentPosition = {
+//     latestQuestionTop : 0,
+//     latestQuestionIsOffScreen: function($latestQuestion) {
+//       var top_of_view = $(window).scrollTop();
+//
+//       this.latestQuestionTop = $latestQuestion.offset().top;
+//       return (this.latestQuestionTop < top_of_view);
+//     },
+//     correctOffscreen: function() {
+//       $latestQuestion = $('.smart_answer .done-questions li.done:last-child');
+//       if (!$latestQuestion.length) {
+//         $latestQuestion = $('body');
+//       }
+//
+//       if(this.latestQuestionIsOffScreen($latestQuestion)) {
+//         $(window).scrollTop(this.latestQuestionTop);
+//       }
+//     },
+//     init: function() {
+//       var self = this;
+//       $(document).bind('smartanswerAnswer', function() {
+//         self.correctOffscreen();
+//         $('.meta-wrapper').show();
+//       });
+//       // Show feedback form in outcomes
+//       $(document).bind('smartanswerOutcome', function() {
+//         $('.report-a-problem-container form #url').val(window.location.href);
+//         $('.meta-wrapper').show();
+//       });
+//     }
+//   };
+//
+//   contentPosition.init();
+//
+// });
+
 $(document).ready(function() {
-  if(browserSupportsHtml5HistoryApi()) {
-    var formSelector = ".current form";
+  // no tags allowed inside title tag, so remove any html i.e. span tag
+  $('title').text(($($('title').text()).text()));
 
-    initializeHistory();
-
-    var getCurrentPosition = function () {
-      var slugArray = document.URL.split('/');
-      return slugArray.splice(3, slugArray.length).join('/');
-    };
-
-    // events
-    // get new questions on submit
-    $('#content').on('submit', formSelector, function(event) {
-      $('input[type=submit]', this).attr('disabled', 'disabled');
-      var form = $(this);
-      var postData = form.serializeArray();
-      reloadQuestions(form.attr('action'), postData);
-      event.preventDefault();
-      return false;
-    });
-
-    // Track when a user clicks on 'Start again' link
-    $('#content').on('click', '.start-right', function() {
-      GOVUK && GOVUK.analytics && GOVUK.analytics.trackEvent && GOVUK.analytics.trackEvent('MS_smart_answer', getCurrentPosition(), {label: 'Start again'});
-      reloadQuestions($(this).attr('href'));
-      return false;
-    });
-
-    // Track when a user clicks on a 'Change Answer' link
-    $('#content').on('click', '.link-right a', function() {
-      var href = $(this).attr('href');
-      GOVUK && GOVUK.analytics && GOVUK.analytics.trackEvent && GOVUK.analytics.trackEvent('MS_smart_answer', href, {label: 'Change Answer'});
-      reloadQuestions(href);
-      return false;
-    });
-
-    // manage next/back by tracking popstate event
-    window.onpopstate = function (event) {
-      if(event.state !== null) {
-        updateContent(event.state['html_fragment']);
-      } else {
-        return false;
-      }
-    };
-  }
-
-  $('#current-error').focus();
-
-  // helper functions
-  function toJsonUrl(url) {
-    var parts = url.split('?');
-    var json_url = parts[0].replace(/\/$/, "") + ".json";
-    if (parts[1]) {
-      json_url += "?";
-      json_url += parts[1];
-    }
-    return window.location.protocol + "//" + window.location.host + json_url;
-  }
-
-  function fromJsonUrl(url) {
-    return url.replace(/\.json$/, "");
-  }
-
-  function redirectToNonAjax(url) {
-    window.location = url;
-  }
-
-  // replace all the questions currently in the page with whatever is returned for given url
-  function reloadQuestions(url, params) {
-    var url = toJsonUrl(url);
-
-    addLoading('<p class="next-step">Loading next step&hellip;</p>');
-
-    $.ajax(url, {
-      type: 'GET',
-      dataType:'json',
-      data: params,
-      timeout: 10000,
-      error: function(jqXHR, textStatus, errorStr) {
-        var paramStr = $.param(params);
-        redirectToNonAjax(url.replace('.json', '?' + paramStr).replace('??', '?'));
-      },
-      success: function(data, textStatus, jqXHR) {
-        addToHistory(data);
-        updateContent(data['html_fragment']);
-      }
-    });
-  }
-
-  // manage the URL
-  function addToHistory(data) {
-    history.pushState(data, data['title'], data['url']);
-    GOVUK && GOVUK.analytics && GOVUK.analytics.trackPageview && GOVUK.analytics.trackPageview(data['url']);
-  }
-
-  // add an indicator of loading
-  function addLoading(fragment){
-    $('#content .step.current')
-      .addClass('loading')
-      .find('form .next-question')
-      .append(fragment);
-    $.event.trigger('smartanswerAnswer');
-  };
-
-  // update the content (i.e. plonk in the html fragment)
-  function updateContent(fragment){
-    $('.smart_answer #js-replaceable').html(fragment);
-    $.event.trigger('smartanswerAnswer');
-    if ($(".outcome").length !== 0) {
-      $.event.trigger('smartanswerOutcome');
-    }
-  }
-
-  function initializeHistory(data) {
-    if (! browserSupportsHtml5HistoryApi() && window.location.pathname.match(/\/.*\//) ) {
-      addToHistory({url: window.location.pathname});
-    }
-
-    data = {
-      html_fragment: $('.smart_answer #js-replaceable').html(),
-      title: "Question",
-      url: window.location.toString()
-    };
-    history.replaceState(data, data['title'], data['url']);
-  }
-
-  var contentPosition = {
-    latestQuestionTop : 0,
-    latestQuestionIsOffScreen: function($latestQuestion) {
-      var top_of_view = $(window).scrollTop();
-
-      this.latestQuestionTop = $latestQuestion.offset().top;
-      return (this.latestQuestionTop < top_of_view);
-    },
-    correctOffscreen: function() {
-      $latestQuestion = $('.smart_answer .done-questions li.done:last-child');
-      if (!$latestQuestion.length) {
-        $latestQuestion = $('body');
-      }
-
-      if(this.latestQuestionIsOffScreen($latestQuestion)) {
-        $(window).scrollTop(this.latestQuestionTop);
-      }
-    },
-    init: function() {
-      var self = this;
-      $(document).bind('smartanswerAnswer', function() {
-        self.correctOffscreen();
-        $('.meta-wrapper').show();
-      });
-      // Show feedback form in outcomes
-      $(document).bind('smartanswerOutcome', function() {
-        $('.report-a-problem-container form #url').val(window.location.href);
-        $('.meta-wrapper').show();
-      });
-    }
-  };
-
-  contentPosition.init();
-
-});
-
-$(document).ready(function() {
   $('.debug.template').each(function() {
     var element = $(this);
     var path = element.data('path');
@@ -176,6 +179,7 @@ $(document).ready(function() {
     element.prepend(anchor);
     element.attr('style', 'border: 3px solid deeppink; padding: 10px; margin: 3px');
   });
+
   $('.debug.partial-template').each(function() {
     var element = $(this);
     var path = element.data('path');
@@ -184,5 +188,35 @@ $(document).ready(function() {
     var anchor = $('<a>Partial template on GitHub</a>').attr('href', url).attr('style', 'color: hotpink;').attr('title', filename);
     element.prepend(anchor);
     element.attr('style', 'border: 3px dotted hotpink; padding: 10px; margin: 3px');
+  });
+
+  $('.debug.single-line').each(function() {
+    var element = $(this);
+    if (element.parents('.previous-answers,.page-header').length > 0) {
+      element.replaceWith(element.html());
+      return;
+    }
+    var path = element.data('path');
+    var filename = path.split('/').pop();
+    var key = element.data('key');
+    var url = 'https://github.com/alphagov/smart-answers/blob/release/' + path;
+    var anchor = $('<a>Template on GitHub (key: ' + key + ')</a>').attr('href', url).attr('style', 'color: deeppink;').attr('title', filename);
+    element.parent().before(anchor);
+    element.parent().attr('style', 'border: 3px solid deeppink; padding: 10px; margin: 3px');
+  });
+
+  $('.debug.option').each(function() {
+    var element = $(this);
+    if (element.parents('.previous-answers').length > 0) {
+      element.replaceWith(element.html());
+      return;
+    }
+    var path = element.data('path');
+    var filename = path.split('/').pop();
+    var key = element.data('key');
+    var url = 'https://github.com/alphagov/smart-answers/blob/release/' + path;
+    var anchor = $('<a>Template on GitHub (option key: ' + key + ')</a>').attr('href', url).attr('style', 'color: deeppink;').attr('title', filename);
+    element.text(element.text() + ' - ');
+    element.after(anchor);
   });
 });

--- a/config/initializers/partial_template_wrapper.rb
+++ b/config/initializers/partial_template_wrapper.rb
@@ -1,0 +1,20 @@
+module PartialTemplateWrapper
+  include ActionView::Helpers::TagHelper
+
+  def render(context, options, block)
+    result = super
+    identifier = @template ? @template.identifier : @path
+    template_path = Pathname.new(identifier).relative_path_from(Rails.root).to_s
+    if result.blank? || template_path.start_with?('app/views/smart_answers')
+      result
+    else
+      content_tag(:div, "\n" + result, {
+        class: 'debug partial-template',
+        markdown: 1,
+        data: { path: template_path }
+      })
+    end
+  end
+end
+
+ActionView::PartialRenderer.prepend(PartialTemplateWrapper)

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -26,7 +26,17 @@ module SmartAnswer
     def content_for(key, html: true)
       content = rendered_view.content_for(key) || ''
       content = strip_leading_spaces(content.to_str)
-      html ? GovspeakPresenter.new(content).html : normalize_blank_lines(content).html_safe
+      if html
+        result = GovspeakPresenter.new(content).html
+        if result.blank?
+          result
+        else
+          template_path = erb_template_path.relative_path_from(Rails.root).to_s
+          @view.content_tag(:div, result, class: 'debug template', data: { path: template_path, key: key })
+        end
+      else
+        normalize_blank_lines(content).html_safe
+      end
     end
 
     def option_text(key)

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -20,7 +20,13 @@ module SmartAnswer
     end
 
     def single_line_of_content_for(key)
-      content_for(key, html: false).chomp.html_safe
+      result = content_for(key, html: false).chomp.html_safe
+      if result.blank? || key == :meta_description
+        result
+      else
+        template_path = erb_template_path.relative_path_from(Rails.root).to_s
+        @view.content_tag(:span, result, class: 'debug single-line', data: { path: template_path, key: key })
+      end
     end
 
     def content_for(key, html: true)
@@ -41,7 +47,9 @@ module SmartAnswer
 
     def option_text(key)
       rendered_view
-      @view.options.fetch(key).html_safe
+      result = @view.options.fetch(key).html_safe
+      template_path = erb_template_path.relative_path_from(Rails.root).to_s
+      @view.content_tag(:span, result, class: 'debug option', data: { path: template_path, key: key })
     end
 
     def erb_template_path


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/X7t256s9

I've prototyped a way to get from a piece of rendered content to the source template (or partial template) on GitHub. Currently this works as follows:

* Chunks of Govspeak-generated HTML are wrapped in a `<div>` element.
  * CSS classes are used to make the elements easily identifiable.
  * Data attributes are used to make the template path and content key available in the DOM
* Govspeak generated from a partial template is wrapped in a `<div>` element
  * CSS classes are used to make the elements easily identifiable.
  * Data attributes are used to make the template path and content key available in the DOM
  * The `markdown="1"` attribute means that Govspeak/Kramdown will still convert the wrapped text.
* Some JavaScript in the main application highlights the `<div>` elements mentioned above to the user.
  * Border, padding & margin are added to each element.
  * A link to the source template on GitHub is added (`release` branch).

## Heroku

I've deployed this to Heroku so people can have a play with it and see what they think. Here are a few URLs which show it in action:

* https://smart-answers-pr-2642.herokuapp.com/marriage-abroad
* https://smart-answers-pr-2642.herokuapp.com/marriage-abroad/y/italy/uk/partner_local/opposite_sex
* https://smart-answers-pr-2642.herokuapp.com/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27701.0/yes
* https://smart-answers-pr-2642.herokuapp.com/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27701.0/yes/123.0/2342.0/2342.0

## To Do

- [ ] Is it worth making it work for single-line/non-Govspeak content?
- [ ] Should probably only be available in some environments or require a query string parameter.
- [ ] Is the `release` branch the right place to links to?
- [ ] Would it better to have the JS in a bookmarklet i.e. not part of the main app?
- [ ] Possibly put the JS in the [GOV.UK Toolkit Chrome extension](https://github.com/alphagov/govuk-toolkit-chrome)?
- [ ] Prepending the `PartialTemplateWrapper` module into `ActionView::PartialRenderer` probably isn't very robust and the initializer should probably fail fast if the version of Rails changes significantly.
- [ ] Fix failing tests
- [ ] Add tests for new code

## Screenshots

### Minimum wage calculator for employers

<img width="665" alt="2016-07-14 at 16 08" src="https://cloud.githubusercontent.com/assets/3169/16844846/a2ed0ffa-49de-11e6-92a7-2cf58a0b4fdb.png">

### Marriage abroad

<img width="673" alt="2016-07-14 at 16 09" src="https://cloud.githubusercontent.com/assets/3169/16844852/a8cb37f8-49de-11e6-8209-60dbed1be04b.png">

### Calculate your Married Couple's allowance (question page)

<img width="630" alt="2016-07-14 at 16 12" src="https://cloud.githubusercontent.com/assets/3169/16844864/b5388072-49de-11e6-9342-2794b550cd37.png">

### Calculate your Married Couple's allowance (outcome page)

<img width="1027" alt="2016-07-14 at 16 10" src="https://cloud.githubusercontent.com/assets/3169/16844859/b0132e1c-49de-11e6-8fe7-ba9e4d92bdc1.png">

