### PR TITLE
Fix label's `for` and input's `id` of money question mismatching

### DIFF
--- a/app/views/smart_answers/_money_question.html.erb
+++ b/app/views/smart_answers/_money_question.html.erb
@@ -1,1 +1,1 @@
-<label for="response_amount">&pound; <%= text_field_tag('response', nil, size: 5, value: prefill_value_for(question)) %><%= question.suffix_label %></label>
+<label for="response">&pound; <%= text_field_tag('response', nil, size: 5, value: prefill_value_for(question)) %><%= question.suffix_label %></label>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
 
 
       

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
 
 
       

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
 
 
       

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2015-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2015-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
 
 
       

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2015-10-01/no/25/1/16.0/100.0/8.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2015-10-01/no/25/1/16.0/100.0/8.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
 
 
       

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2015-10-01/no/25/1/16.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2015-10-01/no/25/1/16.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/bereavement.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no/none.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no/none.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21/3.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21/3.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
 
 
       

--- a/test/artefacts/calculate-married-couples-allowance/yes/no/1955-01-01.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/no/1955-01-01.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27701.0/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27701.0/yes.html
@@ -50,7 +50,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27701.0/yes/10000.0/5000.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27701.0/yes/10000.0/5000.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27701.0/yes/10000.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27701.0/yes/10000.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31.html
@@ -44,7 +44,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
 
 
       

--- a/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21/3.html
+++ b/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21/3.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_diff_amount.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_same_amount.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/weekly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/weekly_diff_amount.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/no.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/no.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/every_4_weeks.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/every_4_weeks.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/fortnightly.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/fortnightly.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/yearly.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/yearly.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_diff_amount.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount/43.3.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount/43.3.html
@@ -46,7 +46,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount/520.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount/520.html
@@ -46,7 +46,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount.html
@@ -43,7 +43,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount/10.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount/10.html
@@ -46,7 +46,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07/2013-03-02.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07/2013-03-02.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />for the tax year</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />for the tax year</label>
 
 
       

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
 
 
       

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
 
 
       

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
 
 
       

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2015-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2015-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
 
 
       

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2015-10-01/no/25/1/16.0/100.0/8.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2015-10-01/no/25/1/16.0/100.0/8.html
@@ -39,7 +39,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
 
 
       

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2015-10-01/no/25/1/16.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2015-10-01/no/25/1/16.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
 
 
       

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000/26.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000/26.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/no/no.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/no/no.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500.html
+++ b/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/state-pension-topup/1912-10-12/male.html
+++ b/test/artefacts/state-pension-topup/1912-10-12/male.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-full-time.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-full-time.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home.html
@@ -40,7 +40,7 @@
 
     <div class="">
 
-      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+      <label for="response">&pound; <input type="text" name="response" id="response" size="5" /></label>
 
 
       


### PR DESCRIPTION
[Trello card](https://trello.com/c/PjrgAkfN/228-bug-label-mismatches-input-for-money-questions)

This fixes invalid HTML which is also an improvement for screen readers.
Any flow with a money question will be affected:

* am-i-getting-minimum-wage
* benefit-cap-calculator
* calculate-employee-redundancy-pay
* calculate-married-couples-allowance
* calculate-statutory-sick-pay
* calculate-your-child-maintenance
* calculate-your-redundancy-pay
* childcare-costs-for-tax-credits
* estimate-self-assessment-penalties
* maternity-paternity-calculator
* minimum-wage-calculator-employers
* part-year-profit-tax-credits (has/needs no artefacts due to being new type)
* simplified-expenses-checker
* state-pension-topup
* student-finance-calculator

## Expected changes

When clicking the label of a money question (just "£" in this case), the associated input is focussed. An example question page to try this on could be: /state-pension-topup/y/1950-01-01/male