### PR TITLE
Add "Deploy to Heroku" button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Read more in [Lisa Scott's GDS blog post](https://gds.blog.gov.uk/2012/02/16/smart-answers-are-smart/).
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Screenshots
 
 ![Student Finance Forms screenshot](./doc/assets/govuk-student-finance-forms.png)

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+  "name": "Smart Answers",
+  "website": "https://www.gov.uk/",
+  "repository": "https://github.com/alphagov/smart-answers",
+  "success_url": "/",
+  "env": {
+    "GOVUK_APP_DOMAIN": "integration.publishing.service.gov.uk",
+    "PLEK_SERVICE_CONTENTAPI_URI": "https://www.gov.uk/api",
+    "PLEK_SERVICE_STATIC_URI": "https://assets-origin.integration.publishing.service.gov.uk/",
+    "RUNNING_ON_HEROKU": "true",
+    "EXPOSE_GOVSPEAK": "true",
+    "ERRBIT_ENV": "integration"
+  },
+  "image": "heroku/ruby",
+  "buildpacks": [ { "url": "heroku/ruby" } ]
+}

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -1,10 +1,14 @@
 class SmartAnswersController < ApplicationController
-  before_action :find_smart_answer
+  before_action :find_smart_answer, except: %w(index)
   before_action :redirect_response_to_canonical_url, only: %w{show}
   before_action :set_header_footer_only, only: %w{visualise}
 
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
   rescue_from SmartAnswer::InvalidNode, with: :error_404
+
+  def index
+    @flows = flow_registry.flows.sort_by(&:name)
+  end
 
   def show
     set_slimmer_artefact(@presenter.artefact)

--- a/app/views/smart_answers/index.html.erb
+++ b/app/views/smart_answers/index.html.erb
@@ -1,0 +1,7 @@
+<h1>Smart Answers</h1>
+
+<ul>
+  <% @flows.each do |flow| %>
+    <li><%= link_to flow.name, smart_answer_path(flow.name) %></li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 SmartAnswers::Application.routes.draw do
+  root to: 'smart_answers#index'
+
   get 'healthcheck', to: proc { [200, {}, ['']] }
 
   constraints id: /[a-z0-9-]+/i do

--- a/test/functional/routing_test.rb
+++ b/test/functional/routing_test.rb
@@ -8,4 +8,8 @@ class RoutingTest < ActionDispatch::IntegrationTest
       get "/non-gb-driving-licence%E2%EF%BF%BD%EF%BF%BD"
     end
   end
+
+  should "route root path to smart answers controller index action" do
+    assert_routing "/", controller: "smart_answers", action: "index"
+  end
 end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -18,6 +18,32 @@ class SmartAnswersControllerTest < ActionController::TestCase
     teardown_fixture_flows
   end
 
+  context "GET /" do
+    setup do
+      @flow_a = stub("flow", name: "flow-a")
+      @flow_b = stub("flow", name: "flow-b")
+      registry = stub("Flow registry")
+      registry.stubs(:flows).returns([@flow_b, @flow_a])
+      @controller.stubs(:flow_registry).returns(registry)
+    end
+
+    should "assign flows sorted alphabetically by name" do
+      get :index
+      assert_equal [@flow_a, @flow_b], assigns(:flows)
+    end
+
+    should "render index template" do
+      get :index
+      assert_template "index"
+    end
+
+    should "render list of links to flows" do
+      get :index
+      assert_select "ul li a[href='/flow-a']", text: "flow-a"
+      assert_select "ul li a[href='/flow-b']", text: "flow-b"
+    end
+  end
+
   context "GET /<slug>" do
     should "respond with 404 if not found" do
       @registry = stub("Flow registry")


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/X40d9w9t

This PR adds a [Heroku Deploy button][1] to the repo README. The idea is to make it easier for developers and content designers to deploy a version of the app for previewing and/or fact-checking purposes.

<img width="651" alt="2016-07-20 at 15 59" src="https://cloud.githubusercontent.com/assets/3169/16991343/1a7c87d6-4e93-11e6-94e4-8b9ecf0dc536.png">

The URL for this button [uses an implicit template][2] which means that Heroku determines the fork and branch of the repo to be deployed from the "Referer" HTTP header. This should mean that content designers can use this button to deploy changes from a fork of the canonical repo.

In order to make the button work, I've added an `app.json` file (based on earlier work by @chrisroos) to the root directory of the repo. This file is used by Heroku to configure the app. The environment variable settings are copied from the `startup_heroku.sh` script. At some point we might be able to do away with the latter script and just use the button, but that's a job for another day.

I've also introduced a home page to the app which renders a simple list of links to the landing pages of all the flows. This means we can sensibly set the `success_url` in `app.json` to be the root path. The user can then navigate to the flow which they are interested in.

<img width="434" alt="2016-07-20 at 16 03" src="https://cloud.githubusercontent.com/assets/3169/16991438/7f486a7c-4e93-11e6-8447-b4b24c545880.png">

The new home page should only be visible when the app is running standalone i.e. not behind an instance of the GOV.UK router. This is because the URL is not registered with Panopticon. Thus you will not be able to see it in integration, staging or production.

## External changes

None, although it's worth bearing in mind that the Heroku Deploy button should be visible near the top of the README on the GitHub repo.

[1]: https://devcenter.heroku.com/articles/heroku-button
[2]: https://devcenter.heroku.com/articles/heroku-button#using-an-implicit-template