### PR TITLE
Enlarge hit area of checkboxes

### DIFF
--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -1,7 +1,7 @@
 <ul class="options">
   <% question.options.each.with_index do |option, i| %>
     <li>
-      <label for="response_<%= i %>">
+      <label for="response_<%= i %>" class="selectable">
         <%= check_box_tag "response[]", option.value, prefill_value_includes?(question, option.value), id: "response_#{i}" %>
         <%= option.label %>
       </label>

--- a/test/artefacts/benefit-cap-calculator/default/yes/no/no.html
+++ b/test/artefacts/benefit-cap-calculator/default/yes/no/no.html
@@ -42,91 +42,91 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="bereavement" />
         Bereavement Allowance
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="carers" />
         Carer's Allowance
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="child_benefit" />
         Child Benefit
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="child_tax" />
         Child Tax Credit
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="esa" />
         Employment and Support Allowance
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="guardian" />
         Guardian's Allowance
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="incapacity" />
         Incapacity Benefit
       </label>
     </li>
     <li>
-      <label for="response_7">
+      <label for="response_7" class="selectable">
         <input type="checkbox" name="response[]" id="response_7" value="income_support" />
         Income Support
       </label>
     </li>
     <li>
-      <label for="response_8">
+      <label for="response_8" class="selectable">
         <input type="checkbox" name="response[]" id="response_8" value="jsa" />
         Jobseeker’s Allowance
       </label>
     </li>
     <li>
-      <label for="response_9">
+      <label for="response_9" class="selectable">
         <input type="checkbox" name="response[]" id="response_9" value="maternity" />
         Maternity Allowance
       </label>
     </li>
     <li>
-      <label for="response_10">
+      <label for="response_10" class="selectable">
         <input type="checkbox" name="response[]" id="response_10" value="sda" />
         Severe Disablement Allowance
       </label>
     </li>
     <li>
-      <label for="response_11">
+      <label for="response_11" class="selectable">
         <input type="checkbox" name="response[]" id="response_11" value="widowed_mother" />
         Widowed Mother's Allowance
       </label>
     </li>
     <li>
-      <label for="response_12">
+      <label for="response_12" class="selectable">
         <input type="checkbox" name="response[]" id="response_12" value="widowed_parent" />
         Widowed Parent's Allowance
       </label>
     </li>
     <li>
-      <label for="response_13">
+      <label for="response_13" class="selectable">
         <input type="checkbox" name="response[]" id="response_13" value="widow_pension" />
         Widow's Pension
       </label>
     </li>
     <li>
-      <label for="response_14">
+      <label for="response_14" class="selectable">
         <input type="checkbox" name="response[]" id="response_14" value="widows_aged" />
         Widow's Pension (age related)
       </label>

--- a/test/artefacts/benefit-cap-calculator/future/yes/no/no.html
+++ b/test/artefacts/benefit-cap-calculator/future/yes/no/no.html
@@ -42,79 +42,79 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="bereavement" />
         Bereavement Allowance
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="child_benefit" />
         Child Benefit
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="child_tax" />
         Child Tax Credit
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="esa" />
         Employment and Support Allowance
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="incapacity" />
         Incapacity Benefit
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="income_support" />
         Income Support
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="jsa" />
         Jobseeker’s Allowance
       </label>
     </li>
     <li>
-      <label for="response_7">
+      <label for="response_7" class="selectable">
         <input type="checkbox" name="response[]" id="response_7" value="maternity" />
         Maternity Allowance
       </label>
     </li>
     <li>
-      <label for="response_8">
+      <label for="response_8" class="selectable">
         <input type="checkbox" name="response[]" id="response_8" value="sda" />
         Severe Disablement Allowance
       </label>
     </li>
     <li>
-      <label for="response_9">
+      <label for="response_9" class="selectable">
         <input type="checkbox" name="response[]" id="response_9" value="widowed_mother" />
         Widowed Mother's Allowance
       </label>
     </li>
     <li>
-      <label for="response_10">
+      <label for="response_10" class="selectable">
         <input type="checkbox" name="response[]" id="response_10" value="widowed_parent" />
         Widowed Parent's Allowance
       </label>
     </li>
     <li>
-      <label for="response_11">
+      <label for="response_11" class="selectable">
         <input type="checkbox" name="response[]" id="response_11" value="widow_pension" />
         Widow's Pension
       </label>
     </li>
     <li>
-      <label for="response_12">
+      <label for="response_12" class="selectable">
         <input type="checkbox" name="response[]" id="response_12" value="widows_aged" />
         Widow's Pension (age related)
       </label>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.html
@@ -41,43 +41,43 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="1" />
         Monday
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="2" />
         Tuesday
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="3" />
         Wednesday
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="4" />
         Thursday
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="5" />
         Friday
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="6" />
         Saturday
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="0" />
         Sunday
       </label>

--- a/test/artefacts/calculate-statutory-sick-pay/y.html
+++ b/test/artefacts/calculate-statutory-sick-pay/y.html
@@ -42,31 +42,31 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="statutory_maternity_pay" />
         Statutory Maternity Pay
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="maternity_allowance" />
         Maternity Allowance
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="statutory_paternity_pay" />
         Statutory Paternity Pay
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="statutory_adoption_pay" />
         Statutory Adoption Pay
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="additional_statutory_paternity_pay" />
         Additional Statutory Paternity Pay
       </label>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency.html
@@ -47,19 +47,19 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="benefits" />
         You’re getting benefits
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="property" />
         You own your property
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="permission" />
         You rent privately but have permission from the owner to install or upgrade the boiler
       </label>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house.html
@@ -41,55 +41,55 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="mains_gas" />
         Mains gas
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="electric_heating" />
         Electric heating
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="modern_double_glazing" />
         Double glazing (or secondary glazing for listed properties)
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="loft_attic_conversion" />
         Loft or attic conversion
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="loft_insulation" />
         Loft insulation
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="solid_wall_insulation" />
         Solid wall insulation
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="cavity_wall_insulation" />
         Cavity wall insulation
       </label>
     </li>
     <li>
-      <label for="response_7">
+      <label for="response_7" class="selectable">
         <input type="checkbox" name="response[]" id="response_7" value="modern_boiler" />
         Modern boiler (less than 10 years)
       </label>
     </li>
     <li>
-      <label for="response_8">
+      <label for="response_8" class="selectable">
         <input type="checkbox" name="response[]" id="response_8" value="draught_proofing" />
         Draught proofing
       </label>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house.html
@@ -41,49 +41,49 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="mains_gas" />
         Mains gas
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="electric_heating" />
         Electric heating
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="modern_double_glazing" />
         Double glazing (or secondary glazing for listed properties)
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="loft_attic_conversion" />
         Loft or attic conversion
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="loft_insulation" />
         Loft insulation
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="solid_wall_insulation" />
         Solid wall insulation
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="modern_boiler" />
         Modern boiler (less than 10 years)
       </label>
     </li>
     <li>
-      <label for="response_7">
+      <label for="response_7" class="selectable">
         <input type="checkbox" name="response[]" id="response_7" value="draught_proofing" />
         Draught proofing
       </label>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house.html
@@ -41,25 +41,25 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="mains_gas" />
         Mains gas
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="electric_heating" />
         Electric heating
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="loft_attic_conversion" />
         Loft or attic conversion
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="draught_proofing" />
         Draught proofing
       </label>

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill.html
@@ -42,25 +42,25 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="benefits" />
         You’re getting benefits
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="property" />
         You own your property
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="permission" />
         You rent privately but have permission from the owner to make energy saving improvements (eg upgrade the boiler)
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="social_housing" />
         You’re a social housing tenant
       </label>

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01.html
@@ -42,43 +42,43 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="pension_credit" />
         Pension Credit
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="income_support" />
         Income Support
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="jsa" />
         Income based Jobseeker’s Allowance
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="esa" />
         Income-related Employment and Support Allowance (ESA)
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="child_tax_credit" />
         Child Tax Credit - only if your income is £16,010 or less
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="working_tax_credit" />
         Working Tax Credit - only if your income is £16,010 or less
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="universal_credit" />
         Universal Credit (and you earned £1,250 or less after tax in any assessment period in the last 12 months)
       </label>

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01/pension_credit,income_support,jsa,esa,child_tax_credit,working_tax_credit.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01/pension_credit,income_support,jsa,esa,child_tax_credit,working_tax_credit.html
@@ -42,37 +42,37 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="disabled" />
         You or your partner are disabled.
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="disabled_child" />
         You have a disabled child.
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="child_under_5" />
         You have a child under 5.
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="child_under_16" />
         You have a child under 16 or under 20 if in full-time education.
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="pensioner_premium" />
         You (or your partner) get a ‘pensioner premium’.
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="work_support_esa" />
         You’re in the work-related or support group of ESA.
       </label>

--- a/test/artefacts/legalisation-document-checker/y.html
+++ b/test/artefacts/legalisation-document-checker/y.html
@@ -41,367 +41,367 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="acro-police-certificate" />
         ACRO Police Certificate
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="affidavit" />
         Affidavit
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="articles-of-association" />
         Articles of association
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="bank-statement" />
         Bank statement
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="baptism-certificate" />
         Baptism certificate
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="birth-certificate" />
         Birth certificate
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="certificate-of-incorporation" />
         Certificate of incorporation
       </label>
     </li>
     <li>
-      <label for="response_7">
+      <label for="response_7" class="selectable">
         <input type="checkbox" name="response[]" id="response_7" value="certificate-of-freesale" />
         Certificate of freesale
       </label>
     </li>
     <li>
-      <label for="response_8">
+      <label for="response_8" class="selectable">
         <input type="checkbox" name="response[]" id="response_8" value="certificate-of-memorandum" />
         Certificate of memorandum
       </label>
     </li>
     <li>
-      <label for="response_9">
+      <label for="response_9" class="selectable">
         <input type="checkbox" name="response[]" id="response_9" value="certificate-of-naturalisation" />
         Certificate of naturalisation
       </label>
     </li>
     <li>
-      <label for="response_10">
+      <label for="response_10" class="selectable">
         <input type="checkbox" name="response[]" id="response_10" value="certificate-of-no-impediment" />
         Certificate of no impediment
       </label>
     </li>
     <li>
-      <label for="response_11">
+      <label for="response_11" class="selectable">
         <input type="checkbox" name="response[]" id="response_11" value="chamber-of-commerce-document" />
         Chamber of Commerce document
       </label>
     </li>
     <li>
-      <label for="response_12">
+      <label for="response_12" class="selectable">
         <input type="checkbox" name="response[]" id="response_12" value="change-of-name-deed" />
         Change of name deed
       </label>
     </li>
     <li>
-      <label for="response_13">
+      <label for="response_13" class="selectable">
         <input type="checkbox" name="response[]" id="response_13" value="civil-partnership-certificate" />
         Civil partnership certificate
       </label>
     </li>
     <li>
-      <label for="response_14">
+      <label for="response_14" class="selectable">
         <input type="checkbox" name="response[]" id="response_14" value="criminal-records-bureau-document" />
         Criminal Records Bureau (CRB) document
       </label>
     </li>
     <li>
-      <label for="response_15">
+      <label for="response_15" class="selectable">
         <input type="checkbox" name="response[]" id="response_15" value="criminal-records-check" />
         Criminal records check
       </label>
     </li>
     <li>
-      <label for="response_16">
+      <label for="response_16" class="selectable">
         <input type="checkbox" name="response[]" id="response_16" value="companies-house-document" />
         Companies House document
       </label>
     </li>
     <li>
-      <label for="response_17">
+      <label for="response_17" class="selectable">
         <input type="checkbox" name="response[]" id="response_17" value="county-court-document" />
         County court document
       </label>
     </li>
     <li>
-      <label for="response_18">
+      <label for="response_18" class="selectable">
         <input type="checkbox" name="response[]" id="response_18" value="court-document" />
         Court document
       </label>
     </li>
     <li>
-      <label for="response_19">
+      <label for="response_19" class="selectable">
         <input type="checkbox" name="response[]" id="response_19" value="court-of-bankruptcy-document" />
         Court of Bankruptcy document
       </label>
     </li>
     <li>
-      <label for="response_20">
+      <label for="response_20" class="selectable">
         <input type="checkbox" name="response[]" id="response_20" value="death-certificate" />
         Death certificate
       </label>
     </li>
     <li>
-      <label for="response_21">
+      <label for="response_21" class="selectable">
         <input type="checkbox" name="response[]" id="response_21" value="decree-nisi" />
         Decree nisi
       </label>
     </li>
     <li>
-      <label for="response_22">
+      <label for="response_22" class="selectable">
         <input type="checkbox" name="response[]" id="response_22" value="decree-absolute" />
         Decree absolute
       </label>
     </li>
     <li>
-      <label for="response_23">
+      <label for="response_23" class="selectable">
         <input type="checkbox" name="response[]" id="response_23" value="degree-certificate-uk" />
         Degree certificate (UK)
       </label>
     </li>
     <li>
-      <label for="response_24">
+      <label for="response_24" class="selectable">
         <input type="checkbox" name="response[]" id="response_24" value="department-of-business-innovation-skills-document" />
         Department of Business, Innovation and Skills (BIS) document
       </label>
     </li>
     <li>
-      <label for="response_25">
+      <label for="response_25" class="selectable">
         <input type="checkbox" name="response[]" id="response_25" value="department-of-health-document" />
         Department of Health document
       </label>
     </li>
     <li>
-      <label for="response_26">
+      <label for="response_26" class="selectable">
         <input type="checkbox" name="response[]" id="response_26" value="diploma" />
         Diploma
       </label>
     </li>
     <li>
-      <label for="response_27">
+      <label for="response_27" class="selectable">
         <input type="checkbox" name="response[]" id="response_27" value="disclosure-scotland-document" />
         Disclosure Scotland document
       </label>
     </li>
     <li>
-      <label for="response_28">
+      <label for="response_28" class="selectable">
         <input type="checkbox" name="response[]" id="response_28" value="doctor-letter-medical" />
         Doctor’s letter (medical)
       </label>
     </li>
     <li>
-      <label for="response_29">
+      <label for="response_29" class="selectable">
         <input type="checkbox" name="response[]" id="response_29" value="driving-licence" />
         Driving licence (copy)
       </label>
     </li>
     <li>
-      <label for="response_30">
+      <label for="response_30" class="selectable">
         <input type="checkbox" name="response[]" id="response_30" value="educational-certificate-uk" />
         Educational certificate (UK)
       </label>
     </li>
     <li>
-      <label for="response_31">
+      <label for="response_31" class="selectable">
         <input type="checkbox" name="response[]" id="response_31" value="export-certificate" />
         Export certificate
       </label>
     </li>
     <li>
-      <label for="response_32">
+      <label for="response_32" class="selectable">
         <input type="checkbox" name="response[]" id="response_32" value="family-division-high-court-justice-document" />
         Family Division of the High Court of Justice document
       </label>
     </li>
     <li>
-      <label for="response_33">
+      <label for="response_33" class="selectable">
         <input type="checkbox" name="response[]" id="response_33" value="fingerprints" />
         Fingerprints document
       </label>
     </li>
     <li>
-      <label for="response_34">
+      <label for="response_34" class="selectable">
         <input type="checkbox" name="response[]" id="response_34" value="fit-note-from-a-doctor" />
         Fit note (from a doctor)
       </label>
     </li>
     <li>
-      <label for="response_35">
+      <label for="response_35" class="selectable">
         <input type="checkbox" name="response[]" id="response_35" value="government-issued-document" />
         Government issued document
       </label>
     </li>
     <li>
-      <label for="response_36">
+      <label for="response_36" class="selectable">
         <input type="checkbox" name="response[]" id="response_36" value="grant-of-probate" />
         Grant of probate
       </label>
     </li>
     <li>
-      <label for="response_37">
+      <label for="response_37" class="selectable">
         <input type="checkbox" name="response[]" id="response_37" value="high-court-justice-document" />
         High Court of Justice document
       </label>
     </li>
     <li>
-      <label for="response_38">
+      <label for="response_38" class="selectable">
         <input type="checkbox" name="response[]" id="response_38" value="hmrc-document" />
         HM Revenue and Customs document
       </label>
     </li>
     <li>
-      <label for="response_39">
+      <label for="response_39" class="selectable">
         <input type="checkbox" name="response[]" id="response_39" value="home-office-document" />
         Home Office document
       </label>
     </li>
     <li>
-      <label for="response_40">
+      <label for="response_40" class="selectable">
         <input type="checkbox" name="response[]" id="response_40" value="last-will-testament" />
         Last will and testament
       </label>
     </li>
     <li>
-      <label for="response_41">
+      <label for="response_41" class="selectable">
         <input type="checkbox" name="response[]" id="response_41" value="letter-from-employer" />
         Letter from an employer
       </label>
     </li>
     <li>
-      <label for="response_42">
+      <label for="response_42" class="selectable">
         <input type="checkbox" name="response[]" id="response_42" value="letter-of-enrolment" />
         Letter of enrolment
       </label>
     </li>
     <li>
-      <label for="response_43">
+      <label for="response_43" class="selectable">
         <input type="checkbox" name="response[]" id="response_43" value="letter-of-invitation" />
         Letter of invitation
       </label>
     </li>
     <li>
-      <label for="response_44">
+      <label for="response_44" class="selectable">
         <input type="checkbox" name="response[]" id="response_44" value="letter-of-no-trace" />
         Letter of no trace
       </label>
     </li>
     <li>
-      <label for="response_45">
+      <label for="response_45" class="selectable">
         <input type="checkbox" name="response[]" id="response_45" value="medical-report" />
         Medical report
       </label>
     </li>
     <li>
-      <label for="response_46">
+      <label for="response_46" class="selectable">
         <input type="checkbox" name="response[]" id="response_46" value="marriage-certificate" />
         Marriage certificate
       </label>
     </li>
     <li>
-      <label for="response_47">
+      <label for="response_47" class="selectable">
         <input type="checkbox" name="response[]" id="response_47" value="name-change-deed-or-document" />
         Name change deed or document
       </label>
     </li>
     <li>
-      <label for="response_48">
+      <label for="response_48" class="selectable">
         <input type="checkbox" name="response[]" id="response_48" value="passport-copy-only" />
         Passport (copy only)
       </label>
     </li>
     <li>
-      <label for="response_49">
+      <label for="response_49" class="selectable">
         <input type="checkbox" name="response[]" id="response_49" value="pet-export-document" />
         Pet export document from the Department of Environment, Food and Rural Affairs (DEFRA)
       </label>
     </li>
     <li>
-      <label for="response_50">
+      <label for="response_50" class="selectable">
         <input type="checkbox" name="response[]" id="response_50" value="police-disclosure-document" />
         Police disclosure document
       </label>
     </li>
     <li>
-      <label for="response_51">
+      <label for="response_51" class="selectable">
         <input type="checkbox" name="response[]" id="response_51" value="power-of-attorney" />
         Power of attorney
       </label>
     </li>
     <li>
-      <label for="response_52">
+      <label for="response_52" class="selectable">
         <input type="checkbox" name="response[]" id="response_52" value="probate" />
         Probate
       </label>
     </li>
     <li>
-      <label for="response_53">
+      <label for="response_53" class="selectable">
         <input type="checkbox" name="response[]" id="response_53" value="reference-from-an-employer" />
         Reference from an employer
       </label>
     </li>
     <li>
-      <label for="response_54">
+      <label for="response_54" class="selectable">
         <input type="checkbox" name="response[]" id="response_54" value="religious-document" />
         Religious document
       </label>
     </li>
     <li>
-      <label for="response_55">
+      <label for="response_55" class="selectable">
         <input type="checkbox" name="response[]" id="response_55" value="sheriff-court-document" />
         Sheriff court document
       </label>
     </li>
     <li>
-      <label for="response_56">
+      <label for="response_56" class="selectable">
         <input type="checkbox" name="response[]" id="response_56" value="sick-note-from-doctor" />
         Sick note (from a doctor)
       </label>
     </li>
     <li>
-      <label for="response_57">
+      <label for="response_57" class="selectable">
         <input type="checkbox" name="response[]" id="response_57" value="statutory-declaration" />
         Statutory declaration
       </label>
     </li>
     <li>
-      <label for="response_58">
+      <label for="response_58" class="selectable">
         <input type="checkbox" name="response[]" id="response_58" value="test-results-medical" />
         Test results (medical)
       </label>
     </li>
     <li>
-      <label for="response_59">
+      <label for="response_59" class="selectable">
         <input type="checkbox" name="response[]" id="response_59" value="translation" />
         Translation
       </label>
     </li>
     <li>
-      <label for="response_60">
+      <label for="response_60" class="selectable">
         <input type="checkbox" name="response[]" id="response_60" value="utility-bill" />
         Utility bill
       </label>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month.html
@@ -41,43 +41,43 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="0" />
         Sunday
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="1" />
         Monday
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="2" />
         Tuesday
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="3" />
         Wednesday
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="4" />
         Thursday
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="5" />
         Friday
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="6" />
         Saturday
       </label>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month.html
@@ -41,43 +41,43 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="0" />
         Sunday
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="1" />
         Monday
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="2" />
         Tuesday
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="3" />
         Wednesday
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="4" />
         Thursday
       </label>
     </li>
     <li>
-      <label for="response_5">
+      <label for="response_5" class="selectable">
         <input type="checkbox" name="response[]" id="response_5" value="5" />
         Friday
       </label>
     </li>
     <li>
-      <label for="response_6">
+      <label for="response_6" class="selectable">
         <input type="checkbox" name="response[]" id="response_6" value="6" />
         Saturday
       </label>

--- a/test/artefacts/simplified-expenses-checker/yes.html
+++ b/test/artefacts/simplified-expenses-checker/yes.html
@@ -42,25 +42,25 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="car_or_van" />
         Car or van (business use)
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="motorcycle" />
         Motorcycle (business use)
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="using_home_for_business" />
         Working from home (the main purpose of the building is your home)
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="live_on_business_premises" />
         Living on your business premises (the main purpose of the building where you live is your business, eg a B&amp;B, and you're likely to pay business rates instead of council tax)
       </label>

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home/100000.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home/100000.html
@@ -41,31 +41,31 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="children-under-17" />
         You’ve got children under 17
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="dependant-adult" />
         An adult depends on you financially
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="has-disability" />
         You have a disability, health condition or learning difficulty, eg dyslexia
       </label>
     </li>
     <li>
-      <label for="response_3">
+      <label for="response_3" class="selectable">
         <input type="checkbox" name="response[]" id="response_3" value="low-income" />
         You’re on low income, eg you find it hard to pay for basics like food and accommodation
       </label>
     </li>
     <li>
-      <label for="response_4">
+      <label for="response_4" class="selectable">
         <input type="checkbox" name="response[]" id="response_4" value="no" />
         None of these
       </label>

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-part-time/6000.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-part-time/6000.html
@@ -41,19 +41,19 @@
 
       <ul class="options">
     <li>
-      <label for="response_0">
+      <label for="response_0" class="selectable">
         <input type="checkbox" name="response[]" id="response_0" value="has-disability" />
         You have a disability, health condition or learning difficulty, eg dyslexia
       </label>
     </li>
     <li>
-      <label for="response_1">
+      <label for="response_1" class="selectable">
         <input type="checkbox" name="response[]" id="response_1" value="low-income" />
         You’re on a low income, eg you find it hard to pay for food and accommodation
       </label>
     </li>
     <li>
-      <label for="response_2">
+      <label for="response_2" class="selectable">
         <input type="checkbox" name="response[]" id="response_2" value="no" />
         None of these
       </label>


### PR DESCRIPTION
[Trello card](https://trello.com/c/FM41X6a8/227-accessibility-bug-checkboxes-have-no-large-hit-area)

This gives checkbox questions the standard design and makes it consistent with multiple choice questions. It increases the checkboxes' hit area so that it's easier to hit the otherwise tiny boxes.

Any flow with a checkbox question will be affected:

* benefit-cap-calculator
* calculate-statutory-sick-pay
* energy-grants-calculator
* legalisation-document-checker
* maternity-paternity-calculator
* simplified-expenses-checker
* student-finance-calculator

I ran the regression tests after the commit again and they passed.

## Expected changes

Checkboxes will change their design from a non-standard to a standard design, which increases the hit area.
You can test it out on e.g. `/calculate-statutory-sick-pay/y`

Before:
![screen shot 2016-07-20 at 16 58 21](https://cloud.githubusercontent.com/assets/108893/16993568/d3d375c0-4e9b-11e6-9f72-b1d39354c3e2.png)

After:
![screen shot 2016-07-20 at 16 57 43](https://cloud.githubusercontent.com/assets/108893/16993581/e0cd500c-4e9b-11e6-8532-8512f744cdc7.png)
