### PR TITLE
Fix question layout when increasing font size

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -231,13 +231,12 @@ $is-ie: false !default;
 
   .step.current {
     background-color: #fff;
-    margin-right: 15em;
-    padding: 0 10em 1em 0;
+    margin-right: 0;
+    padding: 0 0 1em 0;
     position: relative;
 
-    @include media-down(tablet) {
-      margin-right: 0;
-      padding: 0 0 1em;
+    @include media(tablet) {
+      width: percentage(2/3);
     }
   }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/rd2r84Pf/226-accessibility-bug-increasing-font-size-breaks-question-page-layout)

The question page breaks when the font size gets increased,
making the content too narrow, showing only 1-2 words per line.
This is because the grid of the question page does not use
the standard grid and it's using `em` instead of `px` or `%`.
This fix does not implement the standard grid as that would mean
changing all 396 question artefacts. But it does the next best thing
which design-wise and behaviour-wise is the same as our standard grid
but code-wise it is not. This also includes changing the width
of the question page content from 7/12 to 2/3, which is our standard.

## Expected behaviour

For users who increase their browser's font size, the copy will become much more readable. A side effect of the change as an effort to streamline it with our standard design, the content area of question pages will be a bit wider.

On the example of `/benefit-cap-calculator/y/default/yes/no/no/bereavement`...

### With 200% increased font size (fixes bug)
Before:
![screen shot 2016-07-21 at 20 51 29](https://cloud.githubusercontent.com/assets/108893/17036730/6d75b168-4f85-11e6-910c-0e0d9e9fa1a9.png)

After:
![screen shot 2016-07-21 at 20 52 10](https://cloud.githubusercontent.com/assets/108893/17036752/8acdbfe4-4f85-11e6-9f5f-56bf46740891.png)

### Normal font size (fixes inconsistency)
Before:
![screen shot 2016-07-21 at 20 49 42](https://cloud.githubusercontent.com/assets/108893/17036699/50dbb304-4f85-11e6-8f78-bae32da3a8be.png)

After:
![screen shot 2016-07-21 at 20 51 49](https://cloud.githubusercontent.com/assets/108893/17036713/5f154598-4f85-11e6-9125-73f12bba16c2.png)
