### PR TITLE
Add draft Smart Answer with all question types

### DIFF
--- a/lib/smart_answer_flows/all-smart-answer-questions.rb
+++ b/lib/smart_answer_flows/all-smart-answer-questions.rb
@@ -1,0 +1,123 @@
+# not a real smart answer, this is here to make testing and changing all front-end elements easier
+module SmartAnswer
+  class AllSmartAnswerQuestionsFlow < Flow
+    def define
+      name 'all-smart-answer-questions'
+      status :draft
+
+      additional_countries = [OpenStruct.new(slug: "mordor", name: "Mordor")]
+
+      checkbox_question :which_checkboxes? do
+        option :radagast
+        option :mithrandir
+        option :olorin
+        option :tharkun
+        option :elrohir
+
+        next_node do
+          question :which_country?
+        end
+      end
+
+      country_select :which_country?, additional_countries: additional_countries do
+        next_node do
+          question :which_date?
+        end
+      end
+
+      date_question :which_date? do
+        next_node do
+          question :which_date_of_birth?
+        end
+      end
+
+      date_question :which_date_of_birth? do
+        date_of_birth_defaults
+
+        next_node do
+          question :which_date_within_range?
+        end
+      end
+
+      date_question :which_date_within_range? do
+        from { Date.today }
+        to { 4.years.since(Date.today) }
+
+        validate_in_range
+
+        next_node do
+          question :which_date_this_year?
+        end
+      end
+
+      date_question :which_date_this_year? do
+        from { 1.years.ago.beginning_of_year.to_date }
+        to { ::Date.today.end_of_year }
+
+        default_year { 0 }
+
+        next_node do
+          question :how_much_money?
+        end
+      end
+
+      money_question :how_much_money? do
+        next_node do
+          question :which_choice?
+        end
+      end
+
+      multiple_choice :which_choice? do
+        option :one
+        option :two
+        option :three
+        option :four
+
+        next_node do
+          question :which_boolean_choice?
+        end
+      end
+
+      multiple_choice :which_boolean_choice? do
+        option :yes
+        option :no
+
+        next_node do
+          question :which_postcode?
+        end
+      end
+
+      postcode_question :which_postcode? do
+        next_node do
+          question :how_much_salary?
+        end
+      end
+
+      salary_question :how_much_salary? do
+        next_node do
+          question :which_value?
+        end
+      end
+
+      value_question :which_value? do
+        next_node do
+          outcome :which_integer?
+        end
+      end
+
+      value_question :which_integer?, parse: Integer do
+        next_node do
+          outcome :which_float?
+        end
+      end
+
+      value_question :which_float?, parse: Float do
+        next_node do
+          outcome :outcome
+        end
+      end
+
+      outcome :outcome
+    end
+  end
+end

--- a/lib/smart_answer_flows/all-smart-answer-questions/all_smart_answer_questions.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/all_smart_answer_questions.govspeak.erb
@@ -1,0 +1,16 @@
+<% content_for :meta_description do %>
+  Do SEO magic here.
+<% end %>
+
+<% content_for :title do %>
+  All Smart Answer questions
+<% end %>
+
+<% content_for :body do %>
+  This flow shows all the different question types for Smart Answers.
+  You can [peek at the results](/all-smart-answer-questions/y/mithrandir,olorin,tharkun/mordor/2019-01-01/1900-01-01/2020-02-29/0000-12-25/9999999.0/four/yes/WC2B%206NH/500000.0-month/world/0/0.5) and access all the different question types individually via changing the previous answers.
+<% end %>
+
+<% content_for :post_body do %>
+  Enjoy!
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/outcomes/outcome.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/outcomes/outcome.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  Congratulations
+<% end %>
+
+<% content_for :body do %>
+  You managed to get through all the questions.
+<% end %>
+
+<% content_for :next_steps do %>
+  Now you can close the browser. Or not.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_money.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_money.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  Money question: How much does the world cost?
+<% end %>
+
+<% content_for :suffix_label do %>
+  this year
+<% end %>
+
+<% content_for :error_message do %>
+  It's gotta be more than that!
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_salary.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_salary.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Salary question: What would you like your salary to be?
+<% end %>
+
+<% content_for :error_message do %>
+  Really, not more?
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_boolean_choice.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_boolean_choice.govspeak.erb
@@ -1,0 +1,12 @@
+<% content_for :title do %>
+  Multiple choice (yes/no): Would you like to see the other questions?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>
+
+<% content_for :error_message do %>
+  Of course you would!
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_checkboxes.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_checkboxes.govspeak.erb
@@ -1,0 +1,27 @@
+<% content_for :title do %>
+  Checkbox question: What are other names for Gandalf?
+<% end %>
+
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
+<% content_for :post_body do %>
+  Post body can contain less important information.
+<% end %>
+
+<% options(
+  "radagast": "Radagast",
+  "mithrandir": "Mithrandir",
+  "olorin": "Olórin",
+  "tharkun": "Tharkûn",
+  "elrohir": "Elrohir"
+) %>
+
+<% content_for :hint do %>
+  This is a hint
+<% end %>
+
+<% content_for :error_message do %>
+  It's neither Elrohir nor Radagast.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_choice.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_choice.govspeak.erb
@@ -1,0 +1,14 @@
+<% content_for :title do %>
+  Multiple choice: Which of these numbers is not a prime number?
+<% end %>
+
+<% options(
+  "one": "One",
+  "two": "Two",
+  "three": "Three",
+  "four": "Four"
+) %>
+
+<% content_for :error_message do %>
+  4 is divisible by 2.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_country.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_country.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Country select: Where are you now?
+<% end %>
+
+<% content_for :error_message do %>
+  You are currently in a fictional country?
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Date question: What date is tomorrow?
+<% end %>
+
+<% content_for :error_message do %>
+  That's not tomorrow.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_of_birth.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_of_birth.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Date question: What is your date of birth?
+<% end %>
+
+<% content_for :error_message do %>
+  You haven't been born yet.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_this_year.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_this_year.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Date question: When is Christmas this year?
+<% end %>
+
+<% content_for :error_message do %>
+  That's not Christmas.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_within_range.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_within_range.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Date question: When will be the next 29 February?
+<% end %>
+
+<% content_for :error_message do %>
+  That's not a leap year.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_float.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_float.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  Value/float question: What is 1/2?
+<% end %>
+
+<% content_for :label do %>
+  Number
+<% end %>
+
+<% content_for :error_message do %>
+  0.5
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_integer.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_integer.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Value/integer question: How many software engineers does it take to change a light bulb?
+<% end %>
+
+<% content_for :error_message do %>
+  None. That's a hardware problem. Or: The light bulb works fine on the system in my office. Or: Darkness is working as intended.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_postcode.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_postcode.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Postcode question: Where is Aviation House?
+<% end %>
+
+<% content_for :error_message do %>
+  It's WC2B 6NH.
+<% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_value.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_value.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  Value question: "Hello ..."?
+<% end %>
+
+<% content_for :suffix_label do %>
+  !
+<% end %>
+
+<% content_for :error_message do %>
+  "world"
+<% end %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/tO7drViD/230-create-example-flow-with-all-question-types)

This is not intended to ever be live, it was specifically done to make it easier to work on all the front-end elements. Therefore no tests are necessary.

I would also like to add simple error validation to all elements. That might be added in a separate PR.
I added four different date questions, because it is very likely we will have more than one type of date question in the future.

## Expected changes

None on production. On other environments a new Smart Answer gets added under `/all-smart-answer-questions`.