### PR TITLE
Document use of custom Google Analytics Tracking ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See:
 
 ### Debugging
 
+* [Custom Google Analytics accounts and Tracking IDs](doc/custom-google-analytics-tracking-id.md)
 * [Viewing landing pages and outcomes as Govspeak](doc/viewing-templates-as-govspeak.md)
 * [Viewing state of a Smart Answer](doc/viewing-state.md)
 * [Visualising flows](doc/visualising-flows.md)

--- a/doc/custom-google-analytics-tracking-id.md
+++ b/doc/custom-google-analytics-tracking-id.md
@@ -18,6 +18,11 @@ Open your copy of Static and replace the `universalId` variable in [analytics/in
 
 Open your Google Analytics account and visit the Real Time > Overview report. Visit your local copy of Smart Answers and observe the activity in Google Analytics.
 
+## Debugging
+
+The [Google Analytics Debugger Chrome extension][ga-debugger] can be useful when trying to understand why you're not seeing the data you expect in Google Analytics.
+
+[ga-debugger]: https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en
 [static-dev]: http://static.dev.gov.uk
 [static-repository]: https://github.com/alphagov/static
 [static-universal-id]: https://github.com/alphagov/static/blob/059f6a534b595c543852c25ced151019b2b6cd72/app/assets/javascripts/analytics/init.js#L13

--- a/doc/custom-google-analytics-tracking-id.md
+++ b/doc/custom-google-analytics-tracking-id.md
@@ -1,0 +1,23 @@
+# Custom Google Analytics account and Tracking ID
+
+This describes how to record data in a different Google Analytics account. This can be useful when testing Google Analytics integration to ensure that things are working as expected.
+
+## Custom Tracking ID
+
+You'll need your own Google Analytics account and to have created a Tracking ID for Smart Answers. Creating these is outside the scope of this guide.
+
+## Running Static locally
+
+You'll need to have a copy of [Static][static-repository] running locally. Smart Answers expects to find your local copy of Static at [http://static.dev.gov.uk][static-dev]. You can change this by setting the `PLEK_SERVICE_STATIC_URI` environment variable.
+
+## Using your custom Tracking ID
+
+Open your copy of Static and replace the `universalId` variable in [analytics/init.js][static-universal-id] with your Tracking ID.
+
+## Testing that it works
+
+Open your Google Analytics account and visit the Real Time > Overview report. Visit your local copy of Smart Answers and observe the activity in Google Analytics.
+
+[static-dev]: http://static.dev.gov.uk
+[static-repository]: https://github.com/alphagov/static
+[static-universal-id]: https://github.com/alphagov/static/blob/059f6a534b595c543852c25ced151019b2b6cd72/app/assets/javascripts/analytics/init.js#L13


### PR DESCRIPTION
This document describes how to configure your local copy of [Static](https://github.com/alphagov/static) to send Google Analytics data to your own account (rather than to the main GOV.UK account). This can help ensure that the Google Analytics tracking code is working as expected.
