### PR TITLE
Fix commented out code in flow_preview initializer

### DIFF
--- a/config/initializers/flow_preview.rb
+++ b/config/initializers/flow_preview.rb
@@ -8,4 +8,4 @@ end
 
 # Uncomment the following to run smartanswers with the test flows instead of the real ones
 #
-#FLOW_REGISTRY_OPTIONS[:load_path] = Rails.root.join('test', 'fixtures', 'flows')
+#FLOW_REGISTRY_OPTIONS[:smart_answer_load_path] = Rails.root.join('test', 'fixtures', 'smart_answer_flows')


### PR DESCRIPTION
## Description

This commented out code is intended to allow a developer to use the app to view fixture flows. Since the code is commented out, inevitably it has become out-of-date. I'm not totally convinced it's worth keeping this hanging around, but in the meantime I thought it was worth fixing it.

## External changes

None. This is change is only relevant to developers who might want to un-comment out this code.
