### PR TITLE
Add content_id for all-smart-answer-questions draft flow

### DIFF
--- a/lib/smart_answer_flows/all-smart-answer-questions.rb
+++ b/lib/smart_answer_flows/all-smart-answer-questions.rb
@@ -2,6 +2,7 @@
 module SmartAnswer
   class AllSmartAnswerQuestionsFlow < Flow
     def define
+      content_id '92661afb-63ce-4ded-b06e-cf6288c0d629'
       name 'all-smart-answer-questions'
       status :draft
 

--- a/test/integration/publishing_api_test.rb
+++ b/test/integration/publishing_api_test.rb
@@ -1,0 +1,11 @@
+require_relative '../test_helper'
+
+class PublishingApiTest < ActiveSupport::TestCase
+  should 'make content_id available for every flow' do
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
+    flow_presenters.each do |flow_presenter|
+      message = "The '#{flow_presenter.slug}' flow has no 'content_id'"
+      assert flow_presenter.content_id.present?, message
+    end
+  end
+end


### PR DESCRIPTION
## Description

Even draft flows must have a `content_id`, because they are registered with the Publishing API in the integration environment.

I've added a test to catch this problem, but it would be better to modify the `Flow` class to effectively make it impossible to create a flow without a `content_id`.

## External changes

None in production. However, this should fix [the exception][1] that was happening in `rake publishing_api:publish` when the integration build was deployed.

[1]: https://errbit.integration.publishing.service.gov.uk/apps/533c2ee40da115303f0129a5/problems/5797b6606578632af8d47f00