### PR TITLE
Make template path available as data attribute

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -25,4 +25,8 @@ class OutcomePresenter < NodePresenter
   def next_steps(html: true)
     @renderer.content_for(:next_steps, html: html)
   end
+
+  def relative_erb_template_path
+    @renderer.relative_erb_template_path
+  end
 end

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -50,6 +50,10 @@ class QuestionPresenter < NodePresenter
     @renderer.content_for(:post_body, html: html)
   end
 
+  def relative_erb_template_path
+    @renderer.relative_erb_template_path
+  end
+
   def options
     []
   end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -22,4 +22,8 @@ class StartNodePresenter < NodePresenter
   def post_body(html: true)
     @renderer.content_for(:post_body, html: html)
   end
+
+  def relative_erb_template_path
+    @renderer.relative_erb_template_path
+  end
 end

--- a/app/views/smart_answers/_current_question.html.erb
+++ b/app/views/smart_answers/_current_question.html.erb
@@ -1,4 +1,4 @@
-<div class="question">
+<div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
   <h2>
     <%= question.title %>
   </h2>

--- a/app/views/smart_answers/_landing.html.erb
+++ b/app/views/smart_answers/_landing.html.erb
@@ -13,7 +13,7 @@
 </header>
 
 <div class="article-container group">
-  <article role="article" class="group">
+  <article role="article" class="group" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
     <div class="inner">
       <div class="intro">
         <%= start_node.body %>

--- a/app/views/smart_answers/_result.html.erb
+++ b/app/views/smart_answers/_result.html.erb
@@ -1,6 +1,6 @@
 <div class="article-container outcome">
   <article class="outcome group">
-    <div class="result-info">
+    <div class="result-info" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
       <div class="inner group">
         <% if outcome.title.present? %>
         <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -38,6 +38,10 @@ module SmartAnswer
       @template_directory.join(erb_template_name)
     end
 
+    def relative_erb_template_path
+      erb_template_path.relative_path_from(Rails.root).to_s
+    end
+
   private
 
     def erb_template_name

--- a/test/functional/smart_answers_controller_debug_template_path_test.rb
+++ b/test/functional/smart_answers_controller_debug_template_path_test.rb
@@ -1,0 +1,63 @@
+require_relative '../test_helper'
+require_relative '../helpers/fixture_flows_helper'
+require_relative '../fixtures/smart_answer_flows/smart-answers-controller-sample'
+require 'gds_api/test_helpers/content_api'
+
+class SmartAnswersControllerDebugTemplatePathTest < ActionController::TestCase
+  tests SmartAnswersController
+
+  include FixtureFlowsHelper
+  include GdsApi::TestHelpers::ContentApi
+
+  def setup
+    stub_content_api_default_artefact
+    setup_fixture_flows
+    registry = SmartAnswer::FlowRegistry.instance
+    flow_name = 'smart-answers-controller-sample'
+    @template_directory = registry.load_path.join(flow_name)
+  end
+
+  def teardown
+    teardown_fixture_flows
+  end
+
+  context 'rendering landing page' do
+    setup do
+      get :show, id: 'smart-answers-controller-sample'
+    end
+
+    should 'include element with debug-template-path data attribute' do
+      template_name = 'smart_answers_controller_sample.govspeak.erb'
+      template_path = relative_template_path(template_name)
+      assert_select "*[data-debug-template-path=?]", template_path
+    end
+  end
+
+  context 'rendering question page' do
+    setup do
+      get :show, id: 'smart-answers-controller-sample', started: 'y'
+    end
+
+    should 'include element with debug-template-path data attribute' do
+      template_name = 'questions/do_you_like_chocolate.govspeak.erb'
+      template_path = relative_template_path(template_name)
+      assert_select "*[data-debug-template-path=?]", template_path
+    end
+  end
+
+  context 'rendering outcome page' do
+    setup do
+      get :show, id: 'smart-answers-controller-sample', started: 'y', responses: 'yes'
+    end
+
+    should 'include element with debug-template-path data attribute' do
+      template_name = 'outcomes/you_have_a_sweet_tooth.govspeak.erb'
+      template_path = relative_template_path(template_name)
+      assert_select "*[data-debug-template-path=?]", template_path
+    end
+  end
+
+  def relative_template_path(template_name)
+    @template_directory.join(template_name).relative_path_from(Rails.root).to_s
+  end
+end

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -12,6 +12,20 @@ module SmartAnswer
       end
     end
 
+    test '#relative_erb_template_path returns a relative version of erb_template_path' do
+      erb_template = ''
+      with_erb_template_file('template-name', erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: 'template-name')
+
+        erb_template_path = stub('erb-template-path')
+        relative_erb_template_path = Pathname.new('relative-erb-template-path')
+        erb_template_path.stubs(:relative_path_from).returns(relative_erb_template_path)
+        renderer.stubs(:erb_template_path).returns(erb_template_path)
+
+        assert_equal relative_erb_template_path.to_s, renderer.relative_erb_template_path
+      end
+    end
+
     test "#content_for raises an exception when the erb template doesn't exist" do
       renderer = ErbRenderer.new(template_directory: Pathname.new('/path/to/non-existent'), template_name: 'template-name')
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -74,5 +74,11 @@ module SmartAnswer
 
       assert_equal 'next-steps-govspeak', @presenter.next_steps(html: false)
     end
+
+    test '#relative_erb_template_path delegates to renderer' do
+      @renderer.stubs(:relative_erb_template_path).returns('relative-erb-template-path')
+
+      assert_equal 'relative-erb-template-path', @presenter.relative_erb_template_path
+    end
   end
 end

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -114,5 +114,11 @@ module SmartAnswer
 
       assert_nil @presenter.error_message_for('error_key')
     end
+
+    test '#relative_erb_template_path delegates to renderer' do
+      @renderer.stubs(:relative_erb_template_path).returns('relative-erb-template-path')
+
+      assert_equal 'relative-erb-template-path', @presenter.relative_erb_template_path
+    end
   end
 end

--- a/test/unit/start_node_presenter_test.rb
+++ b/test/unit/start_node_presenter_test.rb
@@ -56,5 +56,11 @@ module SmartAnswer
 
       assert_equal 'post-body-govspeak', @presenter.post_body(html: false)
     end
+
+    test '#relative_erb_template_path delegates to renderer' do
+      @renderer.stubs(:relative_erb_template_path).returns('relative-erb-template-path')
+
+      assert_equal 'relative-erb-template-path', @presenter.relative_erb_template_path
+    end
   end
 end


### PR DESCRIPTION
## Description

Trello card: https://trello.com/c/X7t256s9

This PR makes the relative path to a template available in each of the `NodePresenter` sub-classes, i.e.  `StartNodePresenter`, `QuestionPresenter` & `OutcomePresenter`. This is then added to an appropriate HTML element as a data attribute, `debug-template-path`.

The plan is to use this in [a bookmarklet to annotate content with a link to the underlying ERB template in the smart-answers repo][1]. This should make it easier for Content Designers to edit the templates directly themselves.

I hope to add functionality to do something similar for _partial_ templates, but I thought that this PR is useful in its own right.

## External changes

There should not be any visible changes. However, if you view the source of any Smart Answers page, you should be able to see a data attribute named `debug-template-path`.

[1]: https://gist.github.com/floehopper/045408d7fe2f6386c0d1457f53481bb0
