### PR TITLE
Add JS function to annotate content with link to template on Github

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -171,3 +171,20 @@ $(document).ready(function() {
   contentPosition.init();
 
 });
+
+function linkToTemplatesOnGithub() {
+  $('*[data-debug-template-path]').each(function() {
+    var element = $(this);
+    var path = element.data('debug-template-path');
+    var filename = path.split('/').pop();
+    var host = 'https://github.com';
+    var organisation = 'alphagov';
+    var repository = 'smart-answers'
+    var branch = 'deployed-to-production';
+    var url = [host, organisation, repository, 'blob', branch, path].join('/');
+    var anchor = $('<a>Template on GitHub</a>').attr('href', url).attr('style', 'color: deeppink;').attr('title', filename);
+    element.prepend(anchor);
+    element.attr('style', 'border: 3px solid deeppink; padding: 10px; margin: 3px');
+    element.removeAttr('data-debug-template-path');
+  });
+};


### PR DESCRIPTION
## Description

Trello: https://trello.com/c/X7t256s9

This JavaScript relies on the `debug-template-path` data attributes made available in #2667. This idea is to call the new function from a bookmarklet or the GOV.UK Chrome extension.

I wanted to add the new function in a separate file, but I couldn't get this to work. So for the moment I've added it in the existing `smart-answers.js` file.

Ideally I would've added some unit tests around the function. However, we don't have any such tests at the moment, so it would be a fair bit of work.

Today is my last day working on Smart Answers, I wanted to get this code live so the Content Designers could start using it. Since it's not critical functionality I think not having tests is OK for the moment.

## External changes

No visible changes. The new `linkToTemplatesOnGithub` function should be available in the browser on any page in Smart Answers.