### PR TITLE
Fix question layout when increasing font size

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -231,14 +231,9 @@ $is-ie: false !default;
 
   .step.current {
     background-color: #fff;
-    margin-right: 15em;
-    padding: 0 10em 1em 0;
+    margin-right: 0;
+    padding: 0 0 1em 0;
     position: relative;
-
-    @include media-down(tablet) {
-      margin-right: 0;
-      padding: 0 0 1em;
-    }
   }
 
   @include ie(6) {
@@ -315,18 +310,6 @@ $is-ie: false !default;
   /*
    * results / outcome
    */
-
-  article.outcome {
-    @extend %grid-row;
-
-    .result-info {
-      @include grid-column( 2/3 );
-    }
-    .related-wrapper {
-      @include grid-column( 1/3 );
-    }
-  }
-
 
   .next-steps {
     right: -24em;

--- a/app/views/smart_answers/show.html.erb
+++ b/app/views/smart_answers/show.html.erb
@@ -1,19 +1,20 @@
 <% content_for :title do %><%= @presenter.title %><% end %>
 <% content_for :head do %>
-<%= javascript_include_tag "smart-answers", defer: true %>
+  <%= javascript_include_tag "smart-answers", defer: true %>
 <% end %>
-<% unless @presenter.started? %><div class="grid-row"><% end %>
-<main id="content" role="main">
-  <div id="js-replaceable" <% if @presenter.started? %> class="smart-answer-questions group"<% end %>>
-    <%= render partial: "content" %>
-  </div>
 
-  <div class="meta-wrapper">
-    <div id="report-a-problem"></div>
-    <%= render :partial => 'smartanswer_metadata' %>
-  </div>
-</main>
-<% unless @presenter.started? %>
-<div id="related-items"></div>
+<div class="grid-row">
+  <main id="content" role="main">
+    <div id="js-replaceable" <% if @presenter.started? %> class="smart-answer-questions group"<% end %>>
+      <%= render partial: "content" %>
+    </div>
+
+    <div class="meta-wrapper">
+      <div id="report-a-problem"></div>
+      <%= render :partial => 'smartanswer_metadata' %>
+    </div>
+  </main>
+  <% unless @presenter.started? %>
+    <div id="related-items"></div>
+  <% end %>
 </div>
-<% end %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/rd2r84Pf/226-accessibility-bug-increasing-font-size-breaks-question-page-layout)
This is a better fix and an alternative version of #2654.

The question page breaks when the font size gets increased,
making the content too narrow, showing only 1-2 words per line.
This is because the grid of the question page does not use
the standard grid and it's using `em` instead of `px` or `%`.

This implements the stardard grid. A side effect is that
the width of question page content changes from 7/12
to our standard of 2/3 and that width now includes the h1.

## Expected behaviour

For users who increase their browser's font size, the copy will become much more readable. A side effect of the change as an effort to streamline it with our standard design, the content area of question pages will be a bit wider.

On the example of `/benefit-cap-calculator/y/default/yes/no/no/bereavement`...

### With 200% increased font size (fixes bug)
Before:
![screen shot 2016-07-21 at 20 51 29](https://cloud.githubusercontent.com/assets/108893/17036730/6d75b168-4f85-11e6-910c-0e0d9e9fa1a9.png)

After:
![screen shot 2016-07-21 at 20 52 10](https://cloud.githubusercontent.com/assets/108893/17036752/8acdbfe4-4f85-11e6-9f5f-56bf46740891.png)

### Normal font size (fixes inconsistencies)
Before:
![screen shot 2016-08-01 at 20 28 45](https://cloud.githubusercontent.com/assets/108893/17306231/c8792db6-5826-11e6-8bd8-6e5d09f07633.png)

After:
![screen shot 2016-08-01 at 20 31 10](https://cloud.githubusercontent.com/assets/108893/17306254/f10eaba2-5826-11e6-93c5-00489a03dd55.png)

## Testing help

* When reviewing the "Files changed", remember you cand add `?w=1` to the URL to repress any whitespace changes.
* Increasing the font size without zooming is a bit hidden in browsers. These screenshots I found on the web show it in all your favourite browsers:

Safari:
![image](https://cloud.githubusercontent.com/assets/108893/17306443/015e835a-5828-11e6-9c15-3f86ede1407d.png)

Firefox:
![image](https://cloud.githubusercontent.com/assets/108893/17306454/0fbb69b8-5828-11e6-84cf-27b6ff743157.png)

Chrome:
![image](https://cloud.githubusercontent.com/assets/108893/17306459/1a8f60ba-5828-11e6-9700-6b5a09d2a5c2.png)
