### PR TITLE
Make smart answers log to stdout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'tilt', '1.4.1'
 gem 'uglifier'
 gem 'uk_postcode', '~> 1.0.1'
 gem 'unicorn', '4.8.3'
+gem 'rails_stdout_logging'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,9 +167,10 @@ GEM
     rails-i18n (4.0.4)
       i18n (~> 0.6)
       railties (~> 4.0)
-    railties (4.2.7.1)
-      actionpack (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    rails_stdout_logging (0.0.5)
+    railties (4.2.6)
+      actionpack (= 4.2.6)
+      activesupport (= 4.2.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
@@ -286,6 +287,7 @@ DEPENDENCIES
   rack_strip_client_ip (= 0.0.1)
   rails (~> 4.2.7)
   rails-i18n
+  rails_stdout_logging
   sass-rails (~> 5.0.0)
   shoulda (~> 3.5.0)
   simplecov (~> 0.10.0)

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,4 @@
 
 require File.expand_path('../config/application', __FILE__)
 
-# Speed up test run
-ENV["DISABLE_LOGGING_IN_TEST"] = "true"
-
 SmartAnswers::Application.load_tasks

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,10 +38,6 @@ SmartAnswers::Application.configure do
   # Disable checksum being created for assets in test
   config.assets.digest = false
 
-  if ENV["DISABLE_LOGGING_IN_TEST"]
-    File.open(Rails.root.join("log", "test.log"), "a") do |file|
-      file.puts "\n*NOTE* Disabling logging in an attempt to speed up the tests.\n\n"
-    end
-    config.logger = Logger.new(nil)
-  end
+  # Speed up test run
+  config.log_level = :fatal
 end


### PR DESCRIPTION
Logging on the paas only works if the app logs to stdout.