### PR TITLE
Disable AJAX for some Smart Answers

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,7 @@
+//= require smart-answers
+//= require helpers
+//= require start-button-ab-test-july-2016
+
+$(document).ready(function() {
+  $('#current-error').focus();
+});

--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -1,0 +1,21 @@
+var SmartAnswer = SmartAnswer || {};
+SmartAnswer.isStartPage = function(slug) { // Used mostly during A/B testing
+  return window.location.pathname.split("/").join("") == slug;
+}
+
+function linkToTemplatesOnGithub() {
+  $('*[data-debug-template-path]').each(function() {
+    var element = $(this);
+    var path = element.data('debug-template-path');
+    var filename = path.split('/').pop();
+    var host = 'https://github.com';
+    var organisation = 'alphagov';
+    var repository = 'smart-answers'
+    var branch = 'deployed-to-production';
+    var url = [host, organisation, repository, 'blob', branch, path].join('/');
+    var anchor = $('<a>Template on GitHub</a>').attr('href', url).attr('style', 'color: deeppink;').attr('title', filename);
+    element.prepend(anchor);
+    element.attr('style', 'border: 3px solid deeppink; padding: 10px; margin: 3px');
+    element.removeAttr('data-debug-template-path');
+  });
+};

--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -7,7 +7,7 @@ function browserSupportsHtml5HistoryApi() {
 }
 
 $(document).ready(function() {
-  if(browserSupportsHtml5HistoryApi()) {
+  if(browserSupportsHtml5HistoryApi() && SmartAnswer.AJAX_ENABLED) {
     var formSelector = ".current form";
 
     initializeHistory();

--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -1,9 +1,6 @@
-//= require start-button-ab-test-july-2016
-
-var SmartAnswer = SmartAnswer || {};
-SmartAnswer.isStartPage = function(slug) { // Used mostly during A/B testing
-  return window.location.pathname.split("/").join("") == slug;
-}
+/**
+ * Load questions via AJAX
+ */
 
 function browserSupportsHtml5HistoryApi() {
   return !! (history && history.replaceState && history.pushState);
@@ -55,8 +52,6 @@ $(document).ready(function() {
       }
     };
   }
-
-  $('#current-error').focus();
 
   // helper functions
   function toJsonUrl(url) {
@@ -171,20 +166,3 @@ $(document).ready(function() {
   contentPosition.init();
 
 });
-
-function linkToTemplatesOnGithub() {
-  $('*[data-debug-template-path]').each(function() {
-    var element = $(this);
-    var path = element.data('debug-template-path');
-    var filename = path.split('/').pop();
-    var host = 'https://github.com';
-    var organisation = 'alphagov';
-    var repository = 'smart-answers'
-    var branch = 'deployed-to-production';
-    var url = [host, organisation, repository, 'blob', branch, path].join('/');
-    var anchor = $('<a>Template on GitHub</a>').attr('href', url).attr('style', 'color: deeppink;').attr('title', filename);
-    element.prepend(anchor);
-    element.attr('style', 'border: 3px solid deeppink; padding: 10px; margin: 3px');
-    element.removeAttr('data-debug-template-path');
-  });
-};

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,12 @@ module ApplicationHelper
   def last_updated_date
     File.mtime(Rails.root.join('REVISION')).to_date rescue Date.today
   end
+
+  def ajax_enabled_for?(name)
+    %w(
+      energy-grants-calculator
+      calculate-employee-redundancy-pay
+      register-a-death
+    ).exclude?(name)
+  end
 end

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -37,6 +37,10 @@ class FlowPresenter
     @current_state ||= @flow.process(all_responses)
   end
 
+  def name
+    @flow.name
+  end
+
   def collapsed_questions
     @flow.path(all_responses).map do |name|
       presenter_for(@flow.node(name))

--- a/app/views/smart_answers/show.html.erb
+++ b/app/views/smart_answers/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title do %><%= @presenter.title %><% end %>
 <% content_for :head do %>
-  <%= javascript_include_tag "smart-answers", defer: true %>
+  <%= javascript_include_tag "application", defer: true %>
 <% end %>
 
 <div class="grid-row">

--- a/app/views/smart_answers/show.html.erb
+++ b/app/views/smart_answers/show.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title do %><%= @presenter.title %><% end %>
 <% content_for :head do %>
+  <script>
+    var SmartAnswer = SmartAnswer || {};
+    SmartAnswer.AJAX_ENABLED = <%= ajax_enabled_for?(@presenter.name) %>;
+  </script>
   <%= javascript_include_tag "application", defer: true %>
 <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,6 @@ module SmartAnswers
 
     # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
     config.assets.precompile += %w(
-      smart-answers.js
       joint.js
       joint.layout.DirectedGraph.js
       joint.css

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -89,4 +89,8 @@ class FlowPresenterTest < ActiveSupport::TestCase
     start_node_2 = @flow_presenter.start_node
     assert_same start_node_1, start_node_2
   end
+
+  test '#name returns Flow name' do
+    assert_equal @flow_presenter.name, @flow.name
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/CBDnKPys)

This disables the JS which loads questions via AJAX.
We would like to remove the AJAX altogether as it is not making things much quicker and it introduces maintability issues and bugs. To be reassured that this will not worsen the user experience, we only disable it on some Smart Answers.
The list of Smart Answers was provided by Dan Gilbert who chose some which are not visited too often or too seldom.

I also restructured the JS files to follow standard Rails conventions and to make sure `smart-answers.js` only contains JS relevant to the AJAX.

## Expected changes

The pages `energy-grants-calculator`, `calculate-employee-redundancy-pay` and `register-a-death` will not use any AJAX calls in the background. The users will most probably not notice any difference. (We made this change to verify that assumption.) They will experience less bugs and very slightly longer delays when the page reloads.
As a developer you can check changes in Firefox by watching the console for those AJAX calls (which will be missing for the three Smart Answers mentioned above but be there for all other Smart Answers). In Chrome it can be checked in the console via the Network tab and filter by XHR.
