### PR TITLE
Amend earliest application date

### DIFF
--- a/lib/smart_answer/calculators/state_pension_age_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_age_calculator.rb
@@ -59,7 +59,7 @@ module SmartAnswer::Calculators
   private
 
     def earliest_application_date
-      state_pension_date - 4.months - 4.days
+      state_pension_date - 4.months
     end
   end
 end


### PR DESCRIPTION
People claim within exactly 4 months of State Pension age, not 4 months and 4 days.

https://trello.com/c/7jcImWLw/342-check-state-pension-age-correction-content-change-request
https://govuk.zendesk.com/agent/tickets/1388751