### PR TITLE
Removed inaccurate hint text

### DIFF
--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/questions/children.govspeak.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/questions/children.govspeak.erb
@@ -8,5 +8,5 @@
 ) %>
 
 <% content_for :hint do %>
-  Children include legally-adopted sons or daughters (but not stepchildren) and any children where the deceased had a parental role.
+  Children include legally-adopted sons or daughters (but not stepchildren).
 <% end %>


### PR DESCRIPTION
Deleted "... and any children where the deceased had a parental role."
Requested in Zen #1317975.
https://trello.com/c/3I2ufDzz/205-remove-misleading-text-from-intestacy-tool