### PR TITLE
Amend earliest application date

### DIFF
--- a/lib/smart_answer/calculators/state_pension_age_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_age_calculator.rb
@@ -59,7 +59,7 @@ module SmartAnswer::Calculators
   private
 
     def earliest_application_date
-      state_pension_date - 4.months - 4.days
+      state_pension_date - 4.months
     end
   end
 end

--- a/test/data/state-pension-age-files.yml
+++ b/test/data/state-pension-age-files.yml
@@ -9,6 +9,7 @@ lib/smart_answer_flows/state-pension-age/questions/dob_age.govspeak.erb: 336a91f
 lib/smart_answer_flows/state-pension-age/questions/gender.govspeak.erb: 4624dfdac5be156a8573cbc21245e36d
 lib/smart_answer_flows/state-pension-age/questions/which_calculation.govspeak.erb: 047d48d2d752d7b53c0b78f0eaedac3f
 lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb: 84df7264d442e78955023ab6357910a4
+lib/smart_answer/calculators/state_pension_age_calculator.rb: 0c676371d0cc6ef15addac73fcd47f16
 lib/data/rates/state_pension.yml: a9beaaf4eea7e2df87ccf7fcca7440f9
 lib/data/state_pension_date_query.rb: 6a5bc3072ae8b986f7ee6d47ecd5da41
 lib/data/state_pension_dates.yml: da1bdee8a5b42c489b3966c43b625113

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -208,21 +208,21 @@ module SmartAnswer::Calculators
     end
 
     context "#can_apply?" do
+      setup do
+        @answers = { dob: Date.parse("1951-12-17") }
+      end
       context "for women" do
         setup do
-          @answers = { gender: "female" }
-          @calculator = StatePensionAgeCalculator.new(@answers)
+          @calculator = StatePensionAgeCalculator.new(@answers.merge(gender: "female"))
         end
-        should "return true for someone is approaching pension age in 4 months and 4 days time" do
-          Timecop.freeze(Date.parse('2020-01-11')) do
-            @calculator.stubs(dob: Date.parse("1954-06-06"))
+        should "return true for a woman approaching state pension age (at 61 years, 8 months, 20 days) in 4 months time" do
+          Timecop.freeze(Date.parse("2013-05-06")) do
             assert @calculator.can_apply?
           end
         end
 
-        should "return false for someone is approaching pension age in more than  4 months and 4 days time" do
-          Timecop.freeze(Date.parse('2020-03-11')) do
-            @calculator.stubs(dob: Date.parse("1954-12-06"))
+        should "return false for a woman approaching state pension age (at 61 years, 8 months, 20 days) in more than  4 months time" do
+          Timecop.freeze(Date.parse("2013-05-05")) do
             refute @calculator.can_apply?
           end
         end
@@ -230,17 +230,16 @@ module SmartAnswer::Calculators
 
       context "for men" do
         setup do
-          @answers = { gender: "male" }
-          @calculator = StatePensionAgeCalculator.new(@answers.merge(dob: Date.parse("1951-12-06")))
+          @calculator = StatePensionAgeCalculator.new(@answers.merge(gender: "male"))
         end
-        should "return true for someone is approaching pension age in 4 months and 4 days time" do
-          Timecop.freeze(Date.parse('2016-09-11')) do
+        should "return true for a man approaching pension age (at 65 years) in 4 months time" do
+          Timecop.freeze(Date.parse("2016-08-17")) do
             assert @calculator.can_apply?
           end
         end
 
-        should "return false for someone is approaching pension age in more than 4 months and 4 days time" do
-          Timecop.freeze(Date.parse('2016-03-11')) do
+        should "return false for a man approaching pension age (at 65 years) in more than 4 months time" do
+          Timecop.freeze(Date.parse("2016-08-16")) do
             refute @calculator.can_apply?
           end
         end


### PR DESCRIPTION
Supersedes #2683

[Trello card](https://trello.com/c/7jcImWLw/274-check-state-pension-age-correction-content-change-request)

[Trello card](https://trello.com/c/7jcImWLw/342-check-state-pension-age-correction-content-change-request)

* Show notification message to soon to be pensioners who are 4months from receiving State Pension (SP) age can apply to get their State Pension. (i.e. advising them that they don't have to wait till their Sate Pension age before doing this.). #Previously, the notification message was also rendered for those within  4months and 4 days, but the rules have now been changed to only show the notification from 4months.


## Factcheck
[Preview Link](https://smart-answers-pr-2690.herokuapp.com/state-pension-age/y/)
[GOVU.UK](https://gov.uk/state-pension-age/y/)


### Expected changes
*  Display notification to only soon to be pensioners who are 4months from receiving State Pension (SP) and not for those within 4months and 4 days.
    * With a state pension date of 2016-12-17 and birthday of  1951-12-17
    * Under 4 months and 4 days rule 2016-12-21 is boundary with today's date of 2016-08-17
    * Under 4 months and 4 days rule 2016-12-17 is boundary with today's date of 2016-08-17


## Factcheck (4 months and 4 days)
[Preview Link](https://smart-answers-pr-2690.herokuapp.com/state-pension-age/y/age/1951-12-21/male)
[GOVU.UK](https://gov.uk/state-pension-age/y/age/1951-12-21/male)


### Before 

![screen shot 2016-08-17 at 16 00 01](https://cloud.githubusercontent.com/assets/84896/17741340/bbadd518-6493-11e6-9634-13450ffef481.png)


### After

![screen shot 2016-08-17 at 16 02 51](https://cloud.githubusercontent.com/assets/84896/17741453/1c3c2858-6494-11e6-9f67-5eb43ae47286.png)

## Factcheck (4 months) No Changes
[Preview Link](https://smart-answers-pr-2690.herokuapp.com/state-pension-age/y/age/1951-12-17/male)
[GOVU.UK](https://gov.uk/state-pension-age/y/age/1951-12-17/male)

### Before 


![screen shot 2016-08-17 at 16 05 22](https://cloud.githubusercontent.com/assets/84896/17741528/6d969224-6494-11e6-97e2-536bf0ece378.png)


### After

![screen shot 2016-08-17 at 16 04 52](https://cloud.githubusercontent.com/assets/84896/17741516/59dea4d8-6494-11e6-8a2c-c2c79a4f7e23.png)

