### PR TITLE
Amendment to Durham Passport Office address

### DIFF
--- a/lib/smart_answer_flows/overseas-passports/outcomes/_sending_your_application.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_sending_your_application.govspeak.erb
@@ -8,10 +8,9 @@
   $A
   Her Majesty’s Passport Office
   OVS-D
-  Millburngate House
-  Millburngate
+  Freeman’s Reach
   Durham
-  DH97 1PA
+  DH1 1SL
   $A
 <% when 'belfast' %>
   ## Send your application


### PR DESCRIPTION
The address of the Durham Passport Office has changed, so I've amended the _sending_your_application.govspeak.erb for <% when 'durham' %>

Needs to go live on 06/09/2016.