### PR TITLE
Removed inaccurate hint text

### DIFF
--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/questions/children.govspeak.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/questions/children.govspeak.erb
@@ -8,5 +8,5 @@
 ) %>
 
 <% content_for :hint do %>
-  Children include legally-adopted sons or daughters (but not stepchildren) and any children where the deceased had a parental role.
+  Children include legally-adopted sons or daughters (but not stepchildren).
 <% end %>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes/yes.txt
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes/yes.txt
@@ -2,7 +2,7 @@ Are there any living children, grandchildren or other direct descendants (eg gre
 
 
 
-Children include legally-adopted sons or daughters (but not stepchildren) and any children where the deceased had a parental role.
+Children include legally-adopted sons or daughters (but not stepchildren).
 
   * yes: Yes
   * no: No

--- a/test/data/inherits-someone-dies-without-will-files.yml
+++ b/test/data/inherits-someone-dies-without-will-files.yml
@@ -30,7 +30,7 @@ lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_65.go
 lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_66.govspeak.erb: 5b3bba2a4f72feba458f4eb536325900
 lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_67.govspeak.erb: 7a700f45942198e910df5553186f7c5e
 lib/smart_answer_flows/inherits-someone-dies-without-will/questions/aunts_or_uncles.govspeak.erb: 198756b4d76400d7ea13edfec4b992a4
-lib/smart_answer_flows/inherits-someone-dies-without-will/questions/children.govspeak.erb: a0030250faa9fd0082c935caac15a593
+lib/smart_answer_flows/inherits-someone-dies-without-will/questions/children.govspeak.erb: 52df493bf86dfe45558982dc8d6b7209
 lib/smart_answer_flows/inherits-someone-dies-without-will/questions/estate_over_250000.govspeak.erb: 91c0b1452734f988266135ce2ee715b7
 lib/smart_answer_flows/inherits-someone-dies-without-will/questions/grandparents.govspeak.erb: df88d3c96e707062c32d161a566f599f
 lib/smart_answer_flows/inherits-someone-dies-without-will/questions/great_aunts_or_uncles.govspeak.erb: d12a7a5d4f03ce6fb2aac1e115df8e66


### PR DESCRIPTION
Trello card: https://trello.com/c/3I2ufDzz

## Factcheck

[Link](https://smart-answers-pr-2694.herokuapp.com/inherits-someone-dies-without-will/y/england-and-wales/no)

## Expected changes

[URL on gov.uk](https://www.gov.uk/inherits-someone-dies-without-will/y/england-and-wales/no)

* Change the explanatory text for the intestacy tool to remove "and any children where the deceased had a parental role"

### Before

![Before screenshot](https://cloud.githubusercontent.com/assets/657807/17775884/3976cf40-6552-11e6-9767-27e2c79daa8e.png)

### After

![After screenshot](https://cloud.githubusercontent.com/assets/657807/17775892/3fc0b6cc-6552-11e6-8adc-814eb143614e.png)