### PR TITLE
Updated SP top up results page

### DIFF
--- a/lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb
@@ -10,7 +10,6 @@
     - <%= number_to_currency(amount_and_age[:amount], precision: 0) %> when you're <%= amount_and_age[:age] %>
   <% end %>
 
-  Make sure you’ll get the full [basic State Pension](/state-pension-statement) before making Class 3A contributions.
 
   You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.
 
@@ -18,10 +17,11 @@
 
   ##Apply
 
-  You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+  You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need your National Insurance number and one of the following to prove your identity:
 
-  - proof of your identity, eg your P60 or the last 4 digits of your bank account
-  - your National Insurance number (if you know it)
+  - P60
+  - passport
+  - payslip
 
   You can also apply over the phone.
 


### PR DESCRIPTION
Removed and updated incorrect information:

* Removed 
"Make sure you’ll get the full [basic State Pension](/state-pension-statement) before making Class 3A contributions."
* Changed application info to
"You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need your National Insurance number and one of the following to prove your identity:
- P60
- passport
- payslip"