### PR TITLE
Stop relying on slugs in areas returned by the imminence api

### DIFF
--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -46,7 +46,7 @@ module SmartAnswer::Calculators
     end
 
     def london?(postcode)
-      area(postcode).any? { |result| result[:slug] == "london" }
+      area(postcode).any? { |result| result[:type] == 'EUR' && result[:name] == "London" }
     end
 
     def area(postcode)

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -40,4 +40,4 @@ lib/smart_answer_flows/benefit-cap-calculator/questions/widowed_parent_amount.go
 lib/smart_answer_flows/benefit-cap-calculator/questions/widows_aged_amount.govspeak.erb: 56ddf0a2aed4310db694dafeaea8e1db
 lib/smart_answer_flows/benefit-cap-calculator/questions/working_tax_credit.govspeak.erb: d96c2ff97c1bb068389fbefc25b9ed1a
 lib/data/benefit_cap_data.yml: 06aa9d991cf0fead2da7809c4a6eb73c
-lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb: 5d2222a2574e7922b0ba23730e3cb3b2
+lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb: 3e611116231f14679fe6e083c0aeff93

--- a/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
+++ b/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
@@ -11,8 +11,8 @@ class BenefitCapCalculatorTest < ActiveSupport::TestCase
   setup do
     setup_for_testing_flow SmartAnswer::BenefitCapCalculatorFlow
 
-    imminence_has_areas_for_postcode("WC2B%206SE", [{ slug: 'london', country_name: 'England' }])
-    imminence_has_areas_for_postcode("B1%201PW", [{ slug: "birmingham-city-council", country_name: 'England' }])
+    imminence_has_areas_for_postcode("WC2B%206SE", [{ type: 'EUR', name: 'London', country_name: 'England' }])
+    imminence_has_areas_for_postcode("B1%201PW", [{ type: 'EUR', name: 'West Midlands', country_name: 'England' }])
   end
 
   context "Benefit cap calculator" do

--- a/test/integration/smart_answer_flows/landlord_immigration_check_test.rb
+++ b/test/integration/smart_answer_flows/landlord_immigration_check_test.rb
@@ -11,8 +11,8 @@ class LandlordImmigrationCheckFlowTest < ActiveSupport::TestCase
   setup do
     setup_for_testing_flow SmartAnswer::LandlordImmigrationCheckFlow
 
-    imminence_has_areas_for_postcode("PA3%202SW",   [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
-    imminence_has_areas_for_postcode("B1%201PW", [{ slug: "birmingham-city-council", country_name: 'England' }])
+    imminence_has_areas_for_postcode("PA3%202SW", [{ type: 'EUR', name: 'Scotland', country_name: 'Scotland' }])
+    imminence_has_areas_for_postcode("B1%201PW", [{ type: 'EUR', name: 'West Midlands', country_name: 'England' }])
   end
 
   should "start by asking first question" do

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -72,9 +72,9 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
         setup_worldwide_locations
 
-        imminence_has_areas_for_postcode("PA3%202SW",  [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
-        imminence_has_areas_for_postcode("B1%201PW",   [{ slug: "birmingham-city-council", country_name: 'England' }])
-        imminence_has_areas_for_postcode("WC2B%206SE", [{ slug: 'london', country_name: 'England' }])
+        imminence_has_areas_for_postcode("PA3%202SW",  [{ type: 'EUR', name: 'Scotland', country_name: 'Scotland' }])
+        imminence_has_areas_for_postcode("B1%201PW",   [{ type: 'EUR', name: 'West Midlands', country_name: 'England' }])
+        imminence_has_areas_for_postcode("WC2B%206SE", [{ type: 'EUR', name: 'London', country_name: 'England' }])
 
         self.class.setup_has_run!
       end

--- a/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
@@ -142,7 +142,7 @@ module SmartAnswer::Calculators
       context "location of user" do
         context "lives outside of Greater London" do
           setup do
-            imminence_has_areas_for_postcode("B1%201PW", [{ slug: "birmingham-city-council", country_name: 'England' }])
+            imminence_has_areas_for_postcode("B1%201PW", [{ type: 'EUR', name: 'West Midlands', country_name: 'England' }])
           end
           should "return false" do
             assert_equal false, @config.london?("B1%201PW")
@@ -150,7 +150,7 @@ module SmartAnswer::Calculators
         end
         context "lives in Greater London" do
           setup do
-            imminence_has_areas_for_postcode("IG6%202BA", [{ slug: 'london', country_name: 'England' }])
+            imminence_has_areas_for_postcode("IG6%202BA", [{ type: 'EUR', name: 'London', country_name: 'England' }])
           end
           should "return true" do
             assert_equal true, @config.london?("IG6%202BA")

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -11,7 +11,7 @@ module SmartAnswer::Calculators
 
     context 'when postcode is in England' do
       setup do
-        imminence_has_areas_for_postcode("RH6 0NP", [{ slug: 'crawley-borough-council', country_name: 'England' }])
+        imminence_has_areas_for_postcode("RH6 0NP", [{ type: 'EUR', name: 'South East', country_name: 'England' }])
         @calculator.postcode = "RH6 0NP"
       end
 
@@ -22,7 +22,7 @@ module SmartAnswer::Calculators
 
     context 'when postcode is outside England' do
       setup do
-        imminence_has_areas_for_postcode("PA3 2SW", [{ slug: 'renfrewshire-council', country_name: 'Scotland' }])
+        imminence_has_areas_for_postcode("PA3 2SW", [{ type: 'EUR', name: 'Scotland', country_name: 'Scotland' }])
         @calculator.postcode = "PA3 2SW"
       end
 
@@ -34,8 +34,8 @@ module SmartAnswer::Calculators
     context 'when postcode has multiple areas all in England' do
       setup do
         imminence_has_areas_for_postcode("RH6 0NP", [
-          { slug: 'crawley-borough-council', country_name: 'England' },
-          { slug: 'west-sussex-county-council', country_name: 'England' },
+          { type: 'EUR', name: 'South East', country_name: 'England' },
+          { type: 'DIS', name: 'Crawley Borough Council', country_name: 'England' },
         ])
         @calculator.postcode = "RH6 0NP"
       end
@@ -52,8 +52,8 @@ module SmartAnswer::Calculators
     context 'when postcode has multiple areas some in England and some not' do
       setup do
         imminence_has_areas_for_postcode("XY1 0AB", [
-          { slug: 'xy-borough-council', country_name: 'England' },
-          { slug: 'xy-county-council', country_name: 'Scotland' },
+          { type: 'CTY', name: 'Cumbria County Council', country_name: 'England' },
+          { type: 'SPC', name: 'Dumfriesshire', country_name: 'Scotland' },
         ])
         @calculator.postcode = "XY1 0AB"
       end


### PR DESCRIPTION
For: https://trello.com/c/PKAohBzb/468-stop-adding-slugs-to-areas-returned-from-mapit-by-imminence-2

Imminence is removing the slugs because they are based on transforming the
names, which aren't static pieces of data and so shouldn't be relied on.
The only real change here is how the benefit-cap-calculator determines if
the claimant is based in London or not.  Instead of looking for an area
with the slug 'london' we look for an area with the type EUR (European
parliament constituency) and the name 'London'.  This is no more robust
than checking against the slug, as the names of the constituencies could
change, or the boundaries could change, or we could leave Europe and no
longer need these areas, but slug is going away so we have to do
something.

A better solution might be to check for known london councils, or use
mapit directly instead of imminience and check for different area types
(GLA for example) that are more permanent and idicative of a postcode
being in London.  We may also need to refer to the legislation to see
how it defines what "in London" means as it may not equate to "votes in
the London European Parliament Consitituency".

See https://github.com/alphagov/imminence/pull/136 for the imminence change