### PR TITLE
Add 2016/2017 CCG2 form to Student Finance Forms

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
@@ -11,9 +11,8 @@
   - | -
   2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
   2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
-  2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)   
-  2013 to 2014 | [CCG2: Childcare Costs Confirmation Form 2013 to 2014 (PDF, 206KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)   
-  
+  2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)    
+
   ##Where to send your form(s)
 
   $A

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
@@ -7,13 +7,13 @@
 
   At the end of each term confirm your actual childcare costs. Use the CCG2 form for the academic year the costs relate to.
 
-  Academic Year | Form
+  Academic year | Form
   - | -
-  2016 to 2017 | Form available September 2016
-  2015 to 2016 | [CCG2 - cost confirmation form (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
-  2014 to 2015 | [CCG2 - cost confirmation form (PDF, 210KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)
-  2013 to 2014 | [CCG2 – cost confirmation form (PDF, 201KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)
-
+  2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
+  2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
+  2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)   
+  2013 to 2014 | [CCG2: Childcare Costs Confirmation Form 2013 to 2014 (PDF, 206KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)   
+  
   ##Where to send your form(s)
 
   $A

--- a/test/artefacts/student-finance-forms/uk-full-time/ccg-expenses.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/ccg-expenses.txt
@@ -3,12 +3,12 @@ Childcare Grant - cost confirmation
 
 At the end of each term confirm your actual childcare costs. Use the CCG2 form for the academic year the costs relate to.
 
-Academic Year | Form
+Academic year | Form
 - | -
-2016 to 2017 | Form available September 2016
-2015 to 2016 | [CCG2 - cost confirmation form (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
-2014 to 2015 | [CCG2 - cost confirmation form (PDF, 210KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)
-2013 to 2014 | [CCG2 – cost confirmation form (PDF, 201KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)
+2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
+2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
+2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)   
+2013 to 2014 | [CCG2: Childcare Costs Confirmation Form 2013 to 2014 (PDF, 206KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)   
 
 ##Where to send your form(s)
 

--- a/test/artefacts/student-finance-forms/uk-full-time/ccg-expenses.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/ccg-expenses.txt
@@ -7,8 +7,7 @@ Academic year | Form
 - | -
 2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
 2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
-2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)   
-2013 to 2014 | [CCG2: Childcare Costs Confirmation Form 2013 to 2014 (PDF, 206KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)   
+2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)    
 
 ##Where to send your form(s)
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_
 lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_uk.govspeak.erb: e32479a47518d9f72b5786d00bbf8ca7
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1516.govspeak.erb: 8c4197c95ee1efd165da56a007540829
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1617.govspeak.erb: 55cf43443c590c8f1b5958f1a3531357
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 8e94113b21c6bb7485d6e60a7474f5c7
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 9c1f30184e9315bcead5f75e8a0128eb
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: 5dadef6e9f2457405f19272b32f1f398
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb: 4a2be819e1dee45b674e6566d4dbf97f
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb: 138af9f1d1bce252d5af9f95d166babd

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_
 lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_uk.govspeak.erb: e32479a47518d9f72b5786d00bbf8ca7
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1516.govspeak.erb: 8c4197c95ee1efd165da56a007540829
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1617.govspeak.erb: 55cf43443c590c8f1b5958f1a3531357
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 9c1f30184e9315bcead5f75e8a0128eb
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 7075a03f8fcf458e8cc8352d28136d89
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: 5dadef6e9f2457405f19272b32f1f398
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb: 4a2be819e1dee45b674e6566d4dbf97f
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb: 138af9f1d1bce252d5af9f95d166babd


### PR DESCRIPTION
Supersedes #2695

[Trello card](https://trello.com/c/pCsJWXo8/275-1-sep-update-to-student-finance-form-finder-add-ccg2-form)

## Description

Addition of the CCG2 form for 2016/2017. GO LIVE ON 1 SEP 2016 (NOT BEFORE).

## Factcheck


[Main Preview Link]( https://smart-answers-pr-2701.herokuapp.com/student-finance-forms/y/uk-full-time/ccg-expenses)

[GOV.UK](https://gov.uk/student-finance-forms/y/uk-full-time/ccg-expenses)

* Existence of 2016/2017 CCG2 form to the student finance forms smart answers.
* Also includes some cosmetic changes to the content


### Before
![screen shot 2016-08-23 at 11 00 51](https://cloud.githubusercontent.com/assets/84896/17888011/eecaf05c-6920-11e6-9727-cc86146b98ff.png)


### After
![screen shot 2016-08-26 at 10 22 13](https://cloud.githubusercontent.com/assets/84896/18000665/025366f6-6b77-11e6-8ae2-b94ad7527c65.png)



### Affected outcome

 https://smart-answers-pr-2701.herokuapp.com/student-finance-forms/y/uk-full-time/ccg-expenses
