### PR TITLE
Addition of disabled students' forms on Student Finance Forms start page.

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb
@@ -12,6 +12,7 @@
   + forms PN1, PR1, PTL1, PFF2 and CYI
   + forms for parents
   + forms for EU students
+  + forms for Disabled Students’ Allowances (DSA)
 <% end %>
 
 <% content_for :post_body do %>

--- a/test/artefacts/student-finance-forms/student-finance-forms.txt
+++ b/test/artefacts/student-finance-forms/student-finance-forms.txt
@@ -5,6 +5,7 @@ Download student finance forms and guidance notes for Student Finance England in
 + forms PN1, PR1, PTL1, PFF2 and CYI
 + forms for parents
 + forms for EU students
++ Disabled Students’ Allowance (DSA) forms
 
 
 ##Before you start

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -47,4 +47,4 @@ lib/smart_answer_flows/student-finance-forms/questions/pt_course_start.govspeak.
 lib/smart_answer_flows/student-finance-forms/questions/type_of_student.govspeak.erb: 7b236a9aae750540e95e476dace07a3f
 lib/smart_answer_flows/student-finance-forms/questions/what_year_full_time.govspeak.erb: fc407cbafeb1b3ed2a1c726cec57ced3
 lib/smart_answer_flows/student-finance-forms/questions/what_year_part_time.govspeak.erb: fc407cbafeb1b3ed2a1c726cec57ced3
-lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb: af25e2b4e702d9415ae2498653353655
+lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb: 4e002f95cc761ea3632dcc002f0d7a09


### PR DESCRIPTION
Supersedes #2650

[Trello card (dsa forms)](https://trello.com/c/XtL2Oyh6/203-dsa-forms) and also this [Trello card](https://trello.com/c/pCsJWXo8/275-1-sep-update-to-student-finance-form-finder-add-ccg2-form)

## Description

Minor change for Student Loans forms finder. Adding reference to disabled students' forms on start page

## Factcheck

[Main Preview Link](https://smart-answers-pr-2702.herokuapp.com/student-finance-forms)

[GOV.UK](https://gov.uk/student-finance-forms)

* Addition of disabled students' forms on Student Finance Forms start page.

### Before
![screen shot 2016-08-23 at 10 56 37](https://cloud.githubusercontent.com/assets/84896/17887888/5650135c-6920-11e6-9755-5435016e7289.png)


### After
![screen shot 2016-08-24 at 10 54 08](https://cloud.githubusercontent.com/assets/84896/17926468/20f1ada0-69e9-11e6-8357-24c32beb59d9.png)

