### PR TITLE
Clarified postgraduates need to use DSA full form

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb
@@ -1,28 +1,35 @@
 <% content_for :title do %>
-  Disabled Students' Allowances
+  Disabled Students' Allowances (DSAs)
 <% end %>
 
 <% content_for :body do %>
 
-  There are 2 different forms.  You only need to complete one.
+  There are 2 different forms. You only need to complete one.
 
-  If you’re only applying for DSA and no other student finance, complete the DSA1 full.
+  Fill in the DSA1 full form if you're either:
+
+  - an undergraduate student and you haven't applied for any other student finance (like a Tuition Fee Loan)
+  - a postgraduate student
 
   Academic year | Form
   - | -
   2016 to 2017 | [DSA1 - full form (PDF, 662KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_form_1617_d.pdf)
   2016 to 2017 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_notes_1617_d.pdf)
 
-  If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
+  Fill in the DSA slim form if you're an undergraduate and you’ve already applied for other student finance (like a Tuition Fee Loan).
 
+  You'll need to put your Customer Reference Number (CRN) in the form.
 
   Academic year | Form
   - | -
   2016 to 2017 | [DSA - slim form (PDF, 125KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa_slimline_form_1617_d.pdf)
 
-
-
   <%= render partial: 'where_to_send_your_forms_uk.govspeak.erb' %>
+
+  *[DSAs]: Disabled Students Allowances
+  *[DSA]: Disabled Students Allowance
+  *[CRN]: Customer Reference Number 
+
 <% end %>
 
 <% content_for :next_steps do %>


### PR DESCRIPTION
https://trello.com/c/GO8q4xcP/340-fw-dsa-for-postgraduate-loans-form-finder
https://govuk.zendesk.com/agent/tickets/1385461

Postgraduate students must always fill in the DSA1 full form.

CHANGED TITLE 
Disabled Students' Allowances

TO
Disabled Students' Allowances (DSAs)

REASON
Add the acronym on the first instance

CHANGED
If you’re only applying for DSA and no other student finance, complete the DSA1 full.

TO
Fill in the DSA1 full form if you're either:

- an undergraduate student and you haven't applied for any other student finance (like a Tuition Fee Loan)
- a postgraduate student

REASON
- postgraduate students don't have a choice of forms: they must fill in the DSA1 full form.
- our style is "fill in" not "complete" 

CHANGED
If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.

TO
Fill in the DSA slim form if you're an undergraduate and you’ve already applied for other student finance (like a Tuition Fee Loan).

You'll need to put your Customer Reference Number (CRN) in the form.

REASON
- clarified that only undergraduate students should use this form.
- our style is "fill in" not "complete" 

ADDED
*[DSA]: Disabled Students Allowance
*[DSAs]: Disabled Students Allowances
*[CRN]: Customer Reference Number

REASON
Explain the acronyms.