### PR TITLE
Fix flow visualisation in Chrome

### DIFF
--- a/app/assets/javascripts/joint.patch.js
+++ b/app/assets/javascripts/joint.patch.js
@@ -1,0 +1,5 @@
+// fix bug in old JointJS v0.9.0 without updating it as an update would require jQuery 2.1.3+
+// see https://github.com/clientIO/joint/issues/203
+SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformToElement || function(toElement) {
+  return toElement.getScreenCTM().inverse().multiply(this.getScreenCTM());
+};

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title do %><%= @presenter.title %><% end %>
 <% content_for :head do %>
 <meta name="robots" content="noindex, nofollow">
+<%= javascript_include_tag 'joint.patch' %>
 <%= javascript_include_tag 'joint' %>
 <%= javascript_include_tag 'joint.layout.DirectedGraph' %>
 <%= javascript_include_tag 'dagre' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module SmartAnswers
 
     # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
     config.assets.precompile += %w(
+      joint.patch.js
       joint.js
       joint.layout.DirectedGraph.js
       joint.css


### PR DESCRIPTION
[Trello card](https://trello.com/c/YN09P43l)

The flow visualisation was broken in Chrome since version 48 as they removed support for `getTransformToElement` and it was also removed from the SVG spec (see https://www.w3.org/TR/SVG2/changes.html#types).

Although it was fixed upstream with a polyfill, I only copied that polyfill to patch up the old library. An update of the whole library would need us to update jQuery as well. @floehopper tried to update it and its dependencies and was running into problems.

See also http://jointjs.com/blog/get-transform-to-element-polyfill.html

## Expected results ##

Visualise URLs are now showing flow visualisations in Chrome again.

* [Example on production (broken)](https://www.gov.uk/register-a-birth/visualise)
* [Example on Heroku (fixed)](https://smart-answers-pr-2724.herokuapp.com/register-a-birth/visualise)