### PR TITLE
Correct broken link to GRO for Scotland

### DIFF
--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -17,7 +17,7 @@
       It might be quicker to order a certified copy of your certificate from the:
 
       - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
-      - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+      - [GRO for Scotland](http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers)
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/general-register-office-for-northern-ireland)
 
       ^A photocopy of your document won’t be accepted.^
@@ -34,7 +34,7 @@
       It might be quicker to order a certified copy of your letter from the:
 
       - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
-      - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+      - [GRO for Scotland](http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers)
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/general-register-office-for-northern-ireland)
 
       ^A photocopy of your document won’t be accepted.^  
@@ -151,7 +151,7 @@
       It might be quicker to order a certified copy of your certificate from the:
 
       - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
-      - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+      - [GRO for Scotland](http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers)
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/order-life-event-certificates/order-a-marriage-certificate.htm)
 
       ^A photocopy of your GRO document won’t be accepted.^


### PR DESCRIPTION
Out of date link in lines 20, 37 and 154. I've updated this to go to the correct link: http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers

Trello card: https://trello.com/c/uKSn3Xgz/329-broken-links-to-scotland-legalisation-document-checker-y-degree-certificate-uk-marriage-certificate