### PR TITLE
Rake task to add smart answers to the search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ See:
 * [Viewing state of a Smart Answer](doc/viewing-state.md)
 * [Visualising flows](doc/visualising-flows.md)
 
+### Registering on GOV.UK
+
+- `bundle exec rake panopticon:register` will send smart answers to panopticon. Panopticon will register the URL.
+
+### Search indexing
+
+- `bundle exec rake rummager:index_all` will send the data to Rummager for indexing in search.
+
 ## Licence
 
 [MIT License](./LICENSE.md)

--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -1,0 +1,30 @@
+class SearchPayloadPresenter
+  attr_reader :flow_presenter
+  delegate :slug,
+           :title,
+           :description,
+           :indexable_content,
+           :content_id,
+           to: :flow_presenter
+
+  def initialize(flow_presenter)
+    @flow_presenter = flow_presenter
+  end
+
+  def self.call(flow_presenter)
+    new(flow_presenter).call
+  end
+
+  def call
+    {
+      content_id: content_id,
+      rendering_app: 'smartanswers',
+      publishing_app: 'smartanswers',
+      format: 'smart-answer',
+      title: title,
+      description: description,
+      indexable_content: indexable_content,
+      link: "/#{slug}"
+    }
+  end
+end

--- a/app/services/rummager_notifier.rb
+++ b/app/services/rummager_notifier.rb
@@ -1,0 +1,24 @@
+require 'gds_api/rummager'
+
+class RummagerNotifier
+  attr_reader :flow_presenters
+
+  def initialize(flow_presenters)
+    @flow_presenters = flow_presenters
+  end
+
+  def notify
+    logger.info "Looking up flows, with options: #{FLOW_REGISTRY_OPTIONS}"
+
+    flow_presenters.each do |flow_presenter|
+      logger.info "Indexing '#{flow_presenter.title}' in rummager..."
+      SearchIndexer.call(flow_presenter)
+    end
+  end
+
+private
+
+  def logger
+    GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+  end
+end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,0 +1,30 @@
+class SearchIndexer
+  attr_reader :flow_presenter
+  delegate :slug, to: :flow_presenter
+
+  def initialize(flow_presenter)
+    @flow_presenter = flow_presenter
+  end
+
+  def self.call(flow_presenter)
+    new(flow_presenter).call
+  end
+
+  def call
+    Services.rummager.add_document(document_type, document_id, payload)
+  end
+
+private
+
+  def document_type
+    'edition'
+  end
+
+  def document_id
+    "/#{slug}"
+  end
+
+  def payload
+    SearchPayloadPresenter.call(flow_presenter)
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,6 +2,7 @@ require 'gds_api/publishing_api_v2'
 require 'gds_api/imminence'
 require 'gds_api/worldwide'
 require 'gds_api/content_api'
+require 'gds_api/rummager'
 
 module Services
   def self.publishing_api
@@ -21,5 +22,9 @@ module Services
 
   def self.content_api
     @content_api ||= GdsApi::ContentApi.new(Plek.new.find("contentapi"))
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
   end
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,7 @@
+namespace :rummager do
+  desc "Indexes all smart answers in Rummager"
+  task index_all: :environment do
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
+    RummagerNotifier.new(flow_presenters).notify
+  end
+end

--- a/test/unit/services/search_indexer_test.rb
+++ b/test/unit/services/search_indexer_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class SearchIndexerTest < ActiveSupport::TestCase
+  def test_indexing_to_rummager
+    flow_presenter = stub(
+      slug: 'student-finance-forms',
+      title: 'Student finance forms',
+      description: 'Download Student Finance',
+      indexable_content: 'Download student finance content',
+      content_id: '67764435-e8ed-4700-a657-2e0432cb1f5b'
+    )
+    Services.rummager.expects(:add_document).with(
+      'edition',
+      "/#{flow_presenter.slug}",
+      content_id: flow_presenter.content_id,
+      rendering_app:  "smartanswers",
+      publishing_app: "smartanswers",
+      format: "smart-answer",
+      title: flow_presenter.title,
+      description: flow_presenter.description,
+      indexable_content: flow_presenter.indexable_content,
+      link: "/#{flow_presenter.slug}",
+    )
+
+    SearchIndexer.call(flow_presenter)
+  end
+end


### PR DESCRIPTION
Previously, panopticon would send artifacts to Rummager. That flow is now being
deprecated in favour of a simpler approach which is to send documents directly
to rummager.

This commit adds a class that allows us to add smart answers to the
search index directly. It also adds a rake task `rummager:index_all` whose job
is to index smart answers in Rummager.

The payload now includes the following extra attributes:

- publishing_app
- rendering_app
- content_id

Trello: https://trello.com/c/gsHnT5WF/161-epic-send-things-to-rummager-directly-instead-of-via-panopticon

Before this change, the search results looked like this:

<img width="1174" alt="smart-answers-before" src="https://cloud.githubusercontent.com/assets/416701/18666547/436ce84a-7f24-11e6-9fd7-cc234571faa4.png">

They now look like this:

<img width="1054" alt="smart-answers-after" src="https://cloud.githubusercontent.com/assets/416701/18666550/49663d78-7f24-11e6-85cf-d051dd1e4961.png">
