### PR TITLE
Use smart answer name to run regression tests from jenkins.sh script

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+# 1. This function first lists the branches available.
+# 2. Finds the current branch (i.e starts with an asterisk).
+# 3. Finds the value/group between the asterisk and forward slash.
+# 4. Returns the value/group.
+parse_git_branch(){
+  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)\(\/.*\)/\1/'
+}
+
 # Try to merge master into the current branch, and abort if it doesn't exit
 # cleanly (ie there are conflicts). This will be a noop if the current branch
 # is master.
@@ -27,6 +35,8 @@ export DISPLAY=:99
 if [ -z "$RUN_REGRESSION_TESTS" ]; then
   bundle exec govuk-lint-ruby \
     --format clang
+
+  RUN_REGRESSION_TESTS=`parse_git_branch` bundle exec ruby test/regression/smart_answers_regression_test.rb
 
   RAILS_ENV=test TEST_COVERAGE=true bundle exec rake test
 


### PR DESCRIPTION
## Description 

Given the lengthy period it takes to run the regression tests within this repo.
It appears that the jenkins.sh script has omitted running the regression tests.

This idea came up during the on of our developer retro.

The Idea is to add to the jenkins script ```RUN_REGRESSION_TESTS=<smart-answer> ruby test/regression/smart_answers_regression_test.rb``` where <smart-answer> can be obtained from the git branch name.

The git branch name should ideally be structured like this. 

``` <smart-answer>/<description-of-task-or-feature> ```



The unix script will then read the <smart-answer> part before the forward slash and then use this to run the regresstion test for the affected smart answer.

Hence this PR seeks to include the regression test as part of the jenkins script.

This is reliant on the git branch being setup with the name of the smart-answer first followed by a
forward slash and the the actually name of the branch (i.e some git work flow conventions have referred to this as a feature branching pattern).

This convention in effect provides the basis for sensible assumption to be made, that the part
before the forward slash is indeed the name of the smart answer flow (i.e ideal scenario).

This is then used to provide RUN_REGRESSION_TESTS environment variable with the required.

if the branch is named without the forward slash, the branch name is returned preceded by an
asterisk (*) from the parse_git_branch function.

if the value return from the parse_git_branch function does not match a smart answer flow

The aforementioned (i.e edge cases) will not invoke or run any regression tests (i.e gracefully).