### PR TITLE
Remove online option for 2015-16 students

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb
@@ -8,7 +8,6 @@
 
   Academic Year | Form
   - | -
-  2015 to 2016 | [apply online](/apply-online-for-student-finance)
   2015 to 2016 | [PR1 - form (PDF, 573KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_form_1516_d.pdf)
   2015 to 2016 | [PR1 - guidance notes (PDF, 189KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_notes_1516_d.pdf)
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb
@@ -4,9 +4,7 @@
 
 <% content_for :body do %>
 
-  You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
-
-  If you can't apply online, use form PR1.
+  To apply for help with your tuition and living costs, use form PR1.
 
   Academic Year | Form
   - | -

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb
@@ -4,13 +4,10 @@
 
 <% content_for :body do %>
 
-  You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
-
-  If you can't apply online, use form PN1.
+  To apply for help with your tuition and living costs, use form PN1.
 
   Academic Year | Form
   - | -
-  2015 to 2016 | [apply online](/apply-online-for-student-finance)
   2015 to 2016 | [PN1 - form (PDF, 465KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_form_1516_d.pdf)
   2015 to 2016 | [PN1 - guidance notes (PDF, 300KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_notes_1516_d.pdf)
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb
@@ -4,11 +4,10 @@
 
 <% content_for :body do %>
 
-  You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTLC.
+  To apply for a Tuition Fee Loan, use form PTLC.
 
   Academic Year | Form
   - | -
-  2015 to 2016 | [Apply online](/apply-online-for-student-finance)
   2015 to 2016 | [PTLC - form (PDF, 609KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptlc_form_1516_d.pdf)
   2015 to 2016 | [PTLC - guidance notes (PDF, 98KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptlc_notes_1516_d.pdf)
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb
@@ -4,7 +4,7 @@
 
 <% content_for :body do %>
 
-  To apply for a Tuition Fee Loan, use form PTLC.
+  To apply for a Tuition Fee Loan use form PTLC.
 
   Academic Year | Form
   - | -

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb
@@ -4,11 +4,10 @@
 
 <% content_for :body do %>
 
-  You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTL1.
+  To apply for a Tuition Fee Loan, use form PTL1.
 
   Academic Year | Form
   - | -
-  2015 to 2016 | [Apply online](/apply-online-for-student-finance)
   2015 to 2016 | [PTL1 - form (PDF, 728KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_form_1516_d.pdf)
   2015 to 2016 | [PTL1 - guidance notes (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_notes_1516_d.pdf)
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb
@@ -4,7 +4,7 @@
 
 <% content_for :body do %>
 
-  To apply for a Tuition Fee Loan, use form PTL1.
+  To apply for a Tuition Fee Loan use form PTL1.
 
   Academic Year | Form
   - | -


### PR DESCRIPTION
https://govuk.zendesk.com/agent/#/tickets/1415482

On 26 September, students applying for 2015-16 finance will no longer be able to use the online service - they can only use the forms. I've removed references and links to the online service in the four 2015-16 outcomes.

---
outcome_uk_ft_1516_continuing.govspeak.erb
---

CHANGED
You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
If you can't apply online, use form PR1.

TO
To apply for help with your tuition and living costs, use form PR1.

REMOVED
2015 to 2016 | [apply online](/apply-online-for-student-finance)

---
outcome_uk_ft_1516_new.govspeak.erb
---

CHANGED
You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
If you can't apply online, use form PN1.

TO
To apply for help with your tuition and living costs, use form PN1.
 
REMOVED
2015 to 2016 | [apply online](/apply-online-for-student-finance)

---
outcome_uk_pt_1516_continuing.govspeak.erb
---

CHANGED
You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTLC.

TO
To apply for a Tuition Fee Loan use form PTLC.

REMOVED
2015 to 2016 | [Apply online](/apply-online-for-student-finance)

---
outcome_uk_pt_1516_new.govspeak.erb
---

CHANGED
You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. 
If you can't apply online, use form PTL1.

TO
To apply for a Tuition Fee Loan use form PTL1.

REMOVED
2015 to 2016 | [Apply online](/apply-online-for-student-finance)