### PR TITLE
Clarified postgraduates need to use DSA full form

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb
@@ -1,28 +1,35 @@
 <% content_for :title do %>
-  Disabled Students' Allowances
+  Disabled Students' Allowances (DSAs)
 <% end %>
 
 <% content_for :body do %>
 
-  There are 2 different forms.  You only need to complete one.
+  There are 2 different forms. You only need to complete one.
 
-  If you’re only applying for DSA and no other student finance, complete the DSA1 full.
+  Fill in the DSA1 full form if you're either:
+
+  - an undergraduate student and you haven't applied for any other student finance (like a Tuition Fee Loan)
+  - a postgraduate student
 
   Academic year | Form
   - | -
   2016 to 2017 | [DSA1 - full form (PDF, 662KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_form_1617_d.pdf)
   2016 to 2017 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_notes_1617_d.pdf)
 
-  If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
+  Fill in the DSA slim form if you're an undergraduate and you’ve already applied for other student finance (like a Tuition Fee Loan).
 
+  You'll need to put your Customer Reference Number (CRN) in the form.
 
   Academic year | Form
   - | -
   2016 to 2017 | [DSA - slim form (PDF, 125KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa_slimline_form_1617_d.pdf)
 
-
-
   <%= render partial: 'where_to_send_your_forms_uk.govspeak.erb' %>
+
+  *[DSAs]: Disabled Students Allowances
+  *[DSA]: Disabled Students Allowance
+  *[CRN]: Customer Reference Number 
+
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb
@@ -4,19 +4,17 @@
 
 <% content_for :body do %>
 
-  There are 2 different forms. You only need to complete one.
+  Fill in the DSA1 full form if for this academic year you've either:
 
-  Fill in the DSA1 full form if you're either:
-
-  - an undergraduate student and you haven't applied for any other student finance (like a Tuition Fee Loan)
-  - a postgraduate student
+  - not applied for any student finance
+  - applied for a Postgraduate Loan
 
   Academic year | Form
   - | -
   2016 to 2017 | [DSA1 - full form (PDF, 662KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_form_1617_d.pdf)
   2016 to 2017 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_notes_1617_d.pdf)
 
-  Fill in the DSA slim form if you're an undergraduate and you’ve already applied for other student finance (like a Tuition Fee Loan).
+  Fill in the DSA slim form if in this academic year you've already applied for any student finance that isn't a Postgraduate Loan.
 
   You'll need to put your Customer Reference Number (CRN) in the form.
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-dsa/year-1617.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-dsa/year-1617.txt
@@ -1,19 +1,17 @@
 Disabled Students' Allowances (DSAs)
 
 
-There are 2 different forms. You only need to complete one.
+Fill in the DSA1 full form if for this academic year you've either:
 
-Fill in the DSA1 full form if you're either:
-
-- an undergraduate student and you haven't applied for any other student finance (like a Tuition Fee Loan)
-- a postgraduate student
+- not applied for any student finance
+- applied for a Postgraduate Loan
 
 Academic year | Form
 - | -
 2016 to 2017 | [DSA1 - full form (PDF, 662KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_form_1617_d.pdf)
 2016 to 2017 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_notes_1617_d.pdf)
 
-Fill in the DSA slim form if you're an undergraduate and you’ve already applied for other student finance (like a Tuition Fee Loan).
+Fill in the DSA slim form if in this academic year you've already applied for any student finance that isn't a Postgraduate Loan.
 
 You'll need to put your Customer Reference Number (CRN) in the form.
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-dsa/year-1617.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-dsa/year-1617.txt
@@ -1,16 +1,21 @@
-Disabled Students' Allowances
+Disabled Students' Allowances (DSAs)
 
 
-There are 2 different forms.  You only need to complete one.
+There are 2 different forms. You only need to complete one.
 
-If you’re only applying for DSA and no other student finance, complete the DSA1 full.
+Fill in the DSA1 full form if you're either:
+
+- an undergraduate student and you haven't applied for any other student finance (like a Tuition Fee Loan)
+- a postgraduate student
 
 Academic year | Form
 - | -
 2016 to 2017 | [DSA1 - full form (PDF, 662KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_form_1617_d.pdf)
 2016 to 2017 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_dsa1_notes_1617_d.pdf)
 
-If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
+Fill in the DSA slim form if you're an undergraduate and you’ve already applied for other student finance (like a Tuition Fee Loan).
+
+You'll need to put your Customer Reference Number (CRN) in the form.
 
 Academic year | Form
 - | -
@@ -24,6 +29,10 @@ PO Box 210
 Darlington
 DL1 9HJ
 $A
+
+*[DSAs]: Disabled Students Allowances
+*[DSA]: Disabled Students Allowance
+*[CRN]: Customer Reference Number 
 
 
 [Disabled Student's Allowances](/disabled-students-allowances-dsas)

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -12,7 +12,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1617.govspeak.
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 7075a03f8fcf458e8cc8352d28136d89
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: 5dadef6e9f2457405f19272b32f1f398
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb: 4a2be819e1dee45b674e6566d4dbf97f
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb: 2c41ab80a6697f4b76586f4a812a7b8c
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb: eb39eb7dbd361f0649c94937a23cd8c3
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617_pt.govspeak.erb: a90406871ee2fe369f95614dac5ebf3e
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_expenses.govspeak.erb: bbdd69c80a5e362e58884923159902bc
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_continuing.govspeak.erb: d0b9d48332c04d025b06620ebf6d99a7

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -12,7 +12,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1617.govspeak.
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 7075a03f8fcf458e8cc8352d28136d89
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: 5dadef6e9f2457405f19272b32f1f398
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb: 4a2be819e1dee45b674e6566d4dbf97f
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb: 138af9f1d1bce252d5af9f95d166babd
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb: 2c41ab80a6697f4b76586f4a812a7b8c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617_pt.govspeak.erb: a90406871ee2fe369f95614dac5ebf3e
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_expenses.govspeak.erb: bbdd69c80a5e362e58884923159902bc
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_continuing.govspeak.erb: d0b9d48332c04d025b06620ebf6d99a7


### PR DESCRIPTION
Supersedes #2712

[Trello card](https://trello.com/c/rXMAYo30)

## Description

Rewording one outcome to make it clearer that postgraduates always need to fill in the full form if they want to apply for DSA.

## Factcheck

[Preview version for factcheck](https://smart-answers-pr-2737.herokuapp.com/student-finance-forms)
[Live version on gov.uk](https://www.gov.uk/student-finance-forms)

## Expected changes

### Before

https://www.gov.uk/student-finance-forms/y/uk-full-time/apply-dsa/year-1617

![screen shot 2016-09-30 at 16 25 50](https://cloud.githubusercontent.com/assets/657807/18997021/a58a2c32-872a-11e6-9faa-a5891b0698a4.png)

### After

https://smart-answers-pr-2737.herokuapp.com/student-finance-forms/y/uk-full-time/apply-dsa/year-1617

![screen shot 2016-09-30 at 16 25 54](https://cloud.githubusercontent.com/assets/657807/18997015/a0a3e28a-872a-11e6-8291-9e796a354d26.png)