### PR TITLE
State pension through partner content edits 21092016

### DIFF
--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/age_dependent_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/age_dependent_pension_outcome.govspeak.erb
@@ -33,7 +33,7 @@
 
   You’ll reach State Pension age on 6 March 2018. This is in the tax year 6 April 2017 to 5 April 2018.
 
-  You got married in 1975 and chose to to pay National Insurance contributions at a reduced rate.
+  You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
   Your State Pension will be worked out differently if your reduced rate election still applied to you in 1982.
 
@@ -57,7 +57,7 @@
 
   You’ll get this when either you or your new spouse or civil partner reach [State Pension age](/state-pension-age), whichever is later.
 
-  If your spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
+  If your new spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
 
   <%= format_money(calculator.lower_basic_state_pension_rate) %> is the maximum rate of basic State Pension a married person or civil partner who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record.
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/age_dependent_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/age_dependent_pension_outcome.govspeak.erb
@@ -51,19 +51,17 @@
 
   You’ll get more if your [State Pension](/new-state-pension) is higher under your own National Insurance contributions.
 
-  ###If you remarry or form a new civil partnership before you reach State Pension age
+###If you remarry or form a new civil partnership before you reach State Pension age
 
   You’ll get a pension of about <%= format_money(calculator.lower_basic_state_pension_rate) %> a week plus any Additional State Pension and Graduated Retirement Benefit you built up before 6 April 2016.
 
-  <%= format_money(calculator.lower_basic_state_pension_rate) %> is the maximum rate of basic State Pension a married person or civil partner who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record.
-
-  You'll get more if your [State Pension](/new-state-pension) is higher under your own National Insurance contributions.
-
-  ^Your pension must have been calculated under the reduced rate election rules for this to apply.^
-
-  You’ll get the increase when either you or your new spouse or civil partner reach [State Pension age](/state-pension-age), whichever is later.
+  You’ll get this when either you or your new spouse or civil partner reach [State Pension age](/state-pension-age), whichever is later.
 
   If your spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
+
+  <%= format_money(calculator.lower_basic_state_pension_rate) %> is the maximum rate of basic State Pension a married person or civil partner who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record.
+
+If your [State Pension](/new-state-pension) is higher under your own National Insurance contributions, you’ll get that instead.
 
   ##Shared additional State Pension or Protected Payment
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/age_dependent_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/age_dependent_pension_outcome.govspeak.erb
@@ -25,7 +25,7 @@
 
   ^Your State Pension may be higher if the reduced rate election applies to you.^
 
-  The Reduced Rate Election must have applied to you at some point within the 35 years before you reached State Pension age (not including the year you reach State Pension age). These must be tax years.
+  The reduced rate election must have applied to you at some point within the 35 years before you reached State Pension age (not including the year you reach State Pension age). These must be tax years.
 
   $E
 
@@ -41,13 +41,13 @@
 
   ##What you may get if you have a reduced rate election
 
+  You won’t need to have the usual minimum of 10 qualifying years on your National Insurance record to get a State Pension.
+
   You’ll get a pension of about <%= format_money(calculator.higher_basic_state_pension_rate) %> a week plus any Additional State Pension and Graduated Retirement Benefit you built up before 6 April 2016.
 
-  <%= format_money(calculator.higher_basic_state_pension_rate) %> is the maximum rate of basic State Pension a divorced person who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record
+  <%= format_money(calculator.higher_basic_state_pension_rate) %> is the maximum rate of basic State Pension a divorced person who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record.
 
   You’ll get this when you’re divorced or when you claim your State Pension, if later.
-
-  ^You won’t need to have the minimum of 10 qualifying years on your National Insurance record to get a State Pension if you’re eligible under these different rules.^
 
   You’ll get more if your [State Pension](/new-state-pension) is higher under your own National Insurance contributions.
 
@@ -55,13 +55,15 @@
 
   You’ll get a pension of about <%= format_money(calculator.lower_basic_state_pension_rate) %> a week plus any Additional State Pension and Graduated Retirement Benefit you built up before 6 April 2016.
 
-  <%= format_money(calculator.lower_basic_state_pension_rate) %> is the maximum rate of basic State Pension a married person or civil partner who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record
+  <%= format_money(calculator.lower_basic_state_pension_rate) %> is the maximum rate of basic State Pension a married person or civil partner who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record.
 
   You'll get more if your [State Pension](/new-state-pension) is higher under your own National Insurance contributions.
 
   ^Your pension must have been calculated under the reduced rate election rules for this to apply.^
 
   You’ll get the increase when either you or your new spouse or civil partner reach [State Pension age](/state-pension-age), whichever is later.
+
+  If your spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
 
   ##Shared additional State Pension or Protected Payment
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_and_state_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_and_state_pension_outcome.govspeak.erb
@@ -10,7 +10,7 @@
 
   ^Your State Pension may be higher if the reduced rate election applies to you.^
 
-  The Reduced Rate Election must have applied to you at some point within the 35 years before you reached State Pension age (not including the year you reach State Pension age). These must be tax years.
+  The reduced rate election must have applied to you at some point within the 35 years before you reached State Pension age (not including the year you reach State Pension age). These must be tax years.
 
   $E
 
@@ -18,7 +18,7 @@
 
   You’ll reach State Pension age on 6 March 2018. This is in the tax year 6 April 2017 to 5 April 2018.
 
-  You got married in 1975 and chose to to pay National Insurance contributions at a reduced rate.
+  You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
   Your State Pension will be worked out differently if your reduced rate election still applied to you in 1982.
 
@@ -26,14 +26,14 @@
 
 
   ##What you may get if you have a reduced rate election
+  
+  You won’t need to have the usual minimum of 10 qualifying years on your National Insurance record to get a State Pension.
 
   You’ll get a pension of about <%= format_money(calculator.higher_basic_state_pension_rate) %> a week plus any Additional State Pension and Graduated Retirement Benefit you built up before 6 April 2016.
 
   <%= format_money(calculator.higher_basic_state_pension_rate) %> is the maximum rate of basic State Pension a widowed person who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record..
 
   You’ll get this when you’re widowed or when you [claim your State Pension](/deferring-state-pension/tax-and-inheritance), if later.
-
-  ^You won’t need to have the minimum of 10 qualifying years on your National Insurance record to get a State Pension if you’re eligible under these different rules.^
 
   You’ll get more if your [State Pension](/new-state-pension) is higher under your own National Insurance contributions.
 
@@ -57,8 +57,9 @@
 
   ##Your spouse or civil partner died under State Pension age before 6 April 2016
 
-  You may be able to inherit a portion of their [Additional State Pension](/additional-state-pension/further-information). and half their Graduated Retirement Benefit. This was the earnings-related State Pension people could build up between 1961 and 1975.
+  You may be able to inherit a portion of their [Additional State Pension](/additional-state-pension/further-information) and half their Graduated Retirement Benefit. This was the earnings-related State Pension people could build up between 1961 and 1975.
 
+  If your spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
 
   ##Your spouse or civil partner reached State Pension age before 6 April 2016
 
@@ -80,7 +81,7 @@
 
   You might be eligible for a [Bereavement payment](/bereavement-payment), [Widowed Parent’s Allowance](/widowed-parents-allowance), or [Bereavement Allowance](/bereavement-allowance) if you haven’t yet reached State Pension age. You might be eligible for a bereavement payment if you’re over State Pension age but your late spouse or civil partner wasn’t getting any State Pension when they died.
 
-  ^You can contact the [future pension centre](/future-pension-centre) for help and advice.^
+  ^You can contact the [Future Pension Centre](/future-pension-centre) for help and advice.^
 
   ##If you remarry or form a new civil partnership after State Pension age
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_and_state_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_and_state_pension_outcome.govspeak.erb
@@ -31,7 +31,7 @@
 
   You’ll get a pension of about <%= format_money(calculator.higher_basic_state_pension_rate) %> a week plus any Additional State Pension and Graduated Retirement Benefit you built up before 6 April 2016.
 
-  <%= format_money(calculator.higher_basic_state_pension_rate) %> is the maximum rate of basic State Pension a widowed person who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record..
+  <%= format_money(calculator.higher_basic_state_pension_rate) %> is the maximum rate of basic State Pension a widowed person who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record.
 
   You’ll get this when you’re widowed or when you [claim your State Pension](/deferring-state-pension/tax-and-inheritance), if later.
 
@@ -41,13 +41,13 @@
 
   You’ll get a pension of about <%= format_money(calculator.lower_basic_state_pension_rate) %> a week plus any Additional State Pension and Graduated Retirement Benefit you built up before 6 April 2016.
 
+  You’ll get this when either you or your new spouse or civil partner reach [State Pension age](/state-pension-age), whichever is later.
+
+  If your spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
+
   <%= format_money(calculator.lower_basic_state_pension_rate) %> is the maximum rate of basic State Pension a married person or civil partner who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record.
 
-  You'll get more if your [State Pension](/new-state-pension) is higher under your own National Insurance contributions.
-
-  ^Your pension must have been calculated under the reduced rate election rules for this to apply.^
-
-  You’ll get this when you or your spouse or civil partner reach State Pension age, whichever is later.
+  If your [State Pension](/new-state-pension) is higher under your own National Insurance contributions, you’ll get that instead.
 
   ##Inheriting State Pension
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_and_state_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_and_state_pension_outcome.govspeak.erb
@@ -43,7 +43,7 @@
 
   You’ll get this when either you or your new spouse or civil partner reach [State Pension age](/state-pension-age), whichever is later.
 
-  If your spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
+  If your new spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
 
   <%= format_money(calculator.lower_basic_state_pension_rate) %> is the maximum rate of basic State Pension a married person or civil partner who reached State Pension age before 6 April 2016 can get through their spouse or civil partner’s National Insurance record.
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_no_state_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_no_state_pension_outcome.govspeak.erb
@@ -10,7 +10,7 @@
 
   ^Your State Pension may be higher if the reduced rate election applies to you.^
 
-  The Reduced Rate Election must have applied to you at some point within the 35 years before you reached State Pension age (not including the year you reach State Pension age). These must be tax years.
+  The reduced rate election must have applied to you at some point within the 35 years before you reached State Pension age (not including the year you reach State Pension age). These must be tax years.
 
   $E
   **Example**
@@ -24,6 +24,8 @@
   $E
 
   ##What you may get if you have a reduced rate election
+
+  You won’t need to have the usual minimum of 10 qualifying years on your National Insurance record to get a State Pension.
 
   You’ll get a State Pension of around:
 
@@ -39,8 +41,6 @@
   - you or your spouse or civil partner reach State Pension age (whichever is later)
   - you reach State Pension age (if widowed or divorced)
   - you’re widowed, divorced or your civil partnership is dissolved after you reach State Pension age
-
-  ^You won’t need to have the minimum of 10 qualifying years on your National Insurance record to get a State Pension if you’re eligible under these different rules.^
 
   You’ll get more if your [State Pension](/new-state-pension) is higher under your own National Insurance contributions.
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_no_state_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_no_state_pension_outcome.govspeak.erb
@@ -17,7 +17,7 @@
 
   You’ll reach State Pension age on 6 March 2018. This is in the tax year 6 April 2017 to 5 April 2018.
 
-  You got married in 1975 and chose to to pay National Insurance contributions at a reduced rate.
+  You got married in 1975 and chose to pay National Insurance contributions at a reduced rate.
 
   Your State Pension will be worked out differently if your reduced rate election still applied to you in 1982.
 
@@ -42,7 +42,9 @@
   - you reach State Pension age (if widowed or divorced)
   - you’re widowed, divorced or your civil partnership is dissolved after you reach State Pension age
 
-  You’ll get more if your [State Pension](/new-state-pension) is higher under your own National Insurance contributions.
+  If you’re married or in a civil partnership and your spouse or civil partner reaches State Pension age after you, you’ll get your State Pension based on your own National Insurance contributions until they reach State Pension age.
+
+  If your State Pension is higher under your own National Insurance contributions, you’ll get that instead.
 
   ##If you become widowed
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/widow_and_old_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/widow_and_old_pension_outcome.govspeak.erb
@@ -16,7 +16,7 @@
 
   You may be able to inherit a portion of your late spouse or civil partner’s [Additional State Pension](/additional-state-pension) and [State Pension top up](/voluntary-national-insurance-contributions/top-up-your-state-pension). They may have some State Pension top up if they reached State Pension age before 6 April 2016.
 
-  You’ll inherit this when you’re widowed or when you claim your State Pension, whichever is later If you were widowed before State Pension age you may also have received it as part of [Widowed Parent’s Allowance](/widowed-parents-allowance).
+  You’ll inherit this when you’re widowed or when you claim your State Pension, whichever is later. If you were widowed before State Pension age you may also have received it as part of [Widowed Parent’s Allowance](/widowed-parents-allowance).
 
   ##Inheriting Graduated Retirement Benefit
 


### PR DESCRIPTION
This PR makes content changes to 4 erb files: 

- age_dependent_pension_outcome.govspeak.erb
- married_woman_and_state_pension_outcome.govspeak.erb
- married_woman_no_state_pension_outcome.govspeak.erb
- widow_and_old_pension_outcome.govspeak.erb

The files are in smart-answers/lib/smart_answer_flows/state-pension-through-partner/outcomes/

The changes were requested by the Department for Work and Pensions (DWP) in Zendesk ticket https://govuk.zendesk.com/agent/tickets/1405312.

The Trello ticket for these changes is here: https://trello.com/c/jVxRQVUn

Briefly:

- content in each of these files was wrong about the rules for women who paid less National Insurance earlier in life - I've corrected these
- content in the files was unclear - I've made the specified sections clearer
- there were several typos in these files - I've corrected these

Detailed line-by-line reasons for each change are in the commit notes.

I sent a Heroku preview of my changes to the DWP for fact check on 21 Sept 2016 and they requested some further changes.

I sent a second preview on 4 Oct 2016 and they requested some additional minor changes.

All these changes are made in this PR so this doesn't need a fact check.

The content in this smart answer needs a significant re-write. I've created an improvement ticket for this in the Team 4 triage board.