### PR TITLE
Correct rummager rake task name

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,6 +1,6 @@
 namespace :rummager do
   desc "Indexes all smart answers in Rummager"
-  task index_all: :environment do
+  task index: :environment do
     flow_presenters = RegisterableSmartAnswers.new.flow_presenters
     RummagerNotifier.new(flow_presenters).notify
   end


### PR DESCRIPTION
This ensures the rummager:index task defined in govuk-app-deployment can·
correctly invoke this task.