### PR TITLE
Student finance forms update - 2015 2016

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb
@@ -8,7 +8,6 @@
 
   Academic Year | Form
   - | -
-  2015 to 2016 | [apply online](/apply-online-for-student-finance)
   2015 to 2016 | [PR1 - form (PDF, 573KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_form_1516_d.pdf)
   2015 to 2016 | [PR1 - guidance notes (PDF, 189KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_notes_1516_d.pdf)
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb
@@ -4,9 +4,7 @@
 
 <% content_for :body do %>
 
-  You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
-
-  If you can't apply online, use form PR1.
+  To apply for help with your tuition and living costs, use form PR1.
 
   Academic Year | Form
   - | -

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb
@@ -4,13 +4,10 @@
 
 <% content_for :body do %>
 
-  You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
-
-  If you can't apply online, use form PN1.
+  To apply for help with your tuition and living costs, use form PN1.
 
   Academic Year | Form
   - | -
-  2015 to 2016 | [apply online](/apply-online-for-student-finance)
   2015 to 2016 | [PN1 - form (PDF, 465KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_form_1516_d.pdf)
   2015 to 2016 | [PN1 - guidance notes (PDF, 300KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_notes_1516_d.pdf)
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb
@@ -4,11 +4,10 @@
 
 <% content_for :body do %>
 
-  You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTLC.
+  To apply for a Tuition Fee Loan, use form PTLC.
 
   Academic Year | Form
   - | -
-  2015 to 2016 | [Apply online](/apply-online-for-student-finance)
   2015 to 2016 | [PTLC - form (PDF, 609KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptlc_form_1516_d.pdf)
   2015 to 2016 | [PTLC - guidance notes (PDF, 98KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptlc_notes_1516_d.pdf)
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb
@@ -4,7 +4,7 @@
 
 <% content_for :body do %>
 
-  To apply for a Tuition Fee Loan, use form PTLC.
+  To apply for a Tuition Fee Loan use form PTLC.
 
   Academic Year | Form
   - | -

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb
@@ -4,11 +4,10 @@
 
 <% content_for :body do %>
 
-  You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTL1.
+  To apply for a Tuition Fee Loan, use form PTL1.
 
   Academic Year | Form
   - | -
-  2015 to 2016 | [Apply online](/apply-online-for-student-finance)
   2015 to 2016 | [PTL1 - form (PDF, 728KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_form_1516_d.pdf)
   2015 to 2016 | [PTL1 - guidance notes (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_notes_1516_d.pdf)
 

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb
@@ -4,7 +4,7 @@
 
 <% content_for :body do %>
 
-  To apply for a Tuition Fee Loan, use form PTL1.
+  To apply for a Tuition Fee Loan use form PTL1.
 
   Academic Year | Form
   - | -

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/continuing-student.txt
@@ -5,7 +5,6 @@ To apply for help with your tuition and living costs, use form PR1.
 
 Academic Year | Form
 - | -
-2015 to 2016 | [apply online](/apply-online-for-student-finance)
 2015 to 2016 | [PR1 - form (PDF, 573KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_form_1516_d.pdf)
 2015 to 2016 | [PR1 - guidance notes (PDF, 189KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_notes_1516_d.pdf)
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/continuing-student.txt
@@ -1,9 +1,7 @@
 Student finance - application form
 
 
-You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
-
-If you can't apply online, use form PR1.
+To apply for help with your tuition and living costs, use form PR1.
 
 Academic Year | Form
 - | -

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/new-student.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516/new-student.txt
@@ -1,13 +1,10 @@
 Student finance - application form
 
 
-You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
-
-If you can't apply online, use form PN1.
+To apply for help with your tuition and living costs, use form PN1.
 
 Academic Year | Form
 - | -
-2015 to 2016 | [apply online](/apply-online-for-student-finance)
 2015 to 2016 | [PN1 - form (PDF, 465KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_form_1516_d.pdf)
 2015 to 2016 | [PN1 - guidance notes (PDF, 300KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_notes_1516_d.pdf)
 

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/continuing-student/course-start-after-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/continuing-student/course-start-after-01092012.txt
@@ -1,7 +1,7 @@
 Student finance - application form
 
 
-To apply for a Tuition Fee Loan, use form PTLC.
+To apply for a Tuition Fee Loan use form PTLC.
 
 Academic Year | Form
 - | -

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/continuing-student/course-start-after-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/continuing-student/course-start-after-01092012.txt
@@ -1,11 +1,10 @@
 Student finance - application form
 
 
-You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTLC.
+To apply for a Tuition Fee Loan, use form PTLC.
 
 Academic Year | Form
 - | -
-2015 to 2016 | [Apply online](/apply-online-for-student-finance)
 2015 to 2016 | [PTLC - form (PDF, 609KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptlc_form_1516_d.pdf)
 2015 to 2016 | [PTLC - guidance notes (PDF, 98KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptlc_notes_1516_d.pdf)
 

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/new-student/course-start-after-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/new-student/course-start-after-01092012.txt
@@ -1,7 +1,7 @@
 Student finance - application form
 
 
-To apply for a Tuition Fee Loan, use form PTL1.
+To apply for a Tuition Fee Loan use form PTL1.
 
 Academic Year | Form
 - | -

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/new-student/course-start-after-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/new-student/course-start-after-01092012.txt
@@ -1,11 +1,10 @@
 Student finance - application form
 
 
-You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTL1.
+To apply for a Tuition Fee Loan, use form PTL1.
 
 Academic Year | Form
 - | -
-2015 to 2016 | [Apply online](/apply-online-for-student-finance)
 2015 to 2016 | [PTL1 - form (PDF, 728KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_form_1516_d.pdf)
 2015 to 2016 | [PTL1 - guidance notes (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_notes_1516_d.pdf)
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -32,7 +32,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continu
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb: b5c73ee3f5399864758cf2e6de41e6df
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_continuing.govspeak.erb: 73eb8eb9836d73ffed880e2bba8a8db0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_new.govspeak.erb: a7549f7e6b594587f088e299bb715f8c
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb: d1e74e9c1aace5ead9340413b3743c2a
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb: 695f258797a01260909c4bc20fba975f
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb: 68db774255a61534c8d1e4d0e7835aad
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_continuing.govspeak.erb: dc1540087c19c54be6180d0652922571
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_continuing.govspeak.erb: fc3eda325266715d172ec0a7cd9fdbc0

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -33,7 +33,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.gov
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_continuing.govspeak.erb: 73eb8eb9836d73ffed880e2bba8a8db0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_new.govspeak.erb: a7549f7e6b594587f088e299bb715f8c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb: 695f258797a01260909c4bc20fba975f
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb: 68db774255a61534c8d1e4d0e7835aad
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb: 3bfe6b6d03a8c28957d12e37374b4476
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_continuing.govspeak.erb: dc1540087c19c54be6180d0652922571
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_continuing.govspeak.erb: fc3eda325266715d172ec0a7cd9fdbc0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_new.govspeak.erb: 1794d81c3f1eb1ebf9ace499b6dd7228

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -28,7 +28,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_161
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1516.govspeak.erb: 1503d5117dc579523d0ffb3b627175c1
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1617.govspeak.erb: 6a57b5c992b299981e407b3c08894848
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_travel.govspeak.erb: 8ab8bf619e564b1232aebd4b43ae16e4
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb: 652f550176fb940aba6c498713956927
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb: 42c2ec017bce5dd86a0ff2e8869510f7
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb: 6649dde6a4b4e9c973871b753848a28c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_continuing.govspeak.erb: 73eb8eb9836d73ffed880e2bba8a8db0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_new.govspeak.erb: a7549f7e6b594587f088e299bb715f8c

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -33,7 +33,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.gov
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_continuing.govspeak.erb: 73eb8eb9836d73ffed880e2bba8a8db0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_new.govspeak.erb: a7549f7e6b594587f088e299bb715f8c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb: d1e74e9c1aace5ead9340413b3743c2a
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb: eb4b7d72d488a1bef19c4a38fba2699a
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb: 68db774255a61534c8d1e4d0e7835aad
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_continuing.govspeak.erb: dc1540087c19c54be6180d0652922571
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_continuing.govspeak.erb: fc3eda325266715d172ec0a7cd9fdbc0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_new.govspeak.erb: 1794d81c3f1eb1ebf9ace499b6dd7228

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -29,7 +29,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_151
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1617.govspeak.erb: 6a57b5c992b299981e407b3c08894848
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_travel.govspeak.erb: 8ab8bf619e564b1232aebd4b43ae16e4
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb: 42c2ec017bce5dd86a0ff2e8869510f7
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb: 6649dde6a4b4e9c973871b753848a28c
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb: b5c73ee3f5399864758cf2e6de41e6df
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_continuing.govspeak.erb: 73eb8eb9836d73ffed880e2bba8a8db0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_new.govspeak.erb: a7549f7e6b594587f088e299bb715f8c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb: c05b8ffbe69a266baeabf8e5f21e5a82

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -28,7 +28,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_161
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1516.govspeak.erb: 1503d5117dc579523d0ffb3b627175c1
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1617.govspeak.erb: 6a57b5c992b299981e407b3c08894848
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_travel.govspeak.erb: 8ab8bf619e564b1232aebd4b43ae16e4
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb: 42c2ec017bce5dd86a0ff2e8869510f7
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.govspeak.erb: a35dece8f0b8879ce0f75f254d5b77ba
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb: b5c73ee3f5399864758cf2e6de41e6df
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_continuing.govspeak.erb: 73eb8eb9836d73ffed880e2bba8a8db0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_new.govspeak.erb: a7549f7e6b594587f088e299bb715f8c

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -32,7 +32,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continu
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.govspeak.erb: b5c73ee3f5399864758cf2e6de41e6df
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_continuing.govspeak.erb: 73eb8eb9836d73ffed880e2bba8a8db0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_ft_1617_new.govspeak.erb: a7549f7e6b594587f088e299bb715f8c
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb: c05b8ffbe69a266baeabf8e5f21e5a82
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.govspeak.erb: d1e74e9c1aace5ead9340413b3743c2a
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.govspeak.erb: eb4b7d72d488a1bef19c4a38fba2699a
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_continuing.govspeak.erb: dc1540087c19c54be6180d0652922571
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_continuing.govspeak.erb: fc3eda325266715d172ec0a7cd9fdbc0


### PR DESCRIPTION
Supersedes https://github.com/alphagov/smart-answers/pull/2736

### Trello card
* [student-finance-forms-update](https://trello.com/c/e15t5Z9g/343-26-sep-student-finance-forms-remove-online-option-for-2015-16-students) 

## Description

Update four outcomes on the student finance forms smart answer.

## Factcheck 
[apply-loan-grants](https://smart-answers-pr-2755.herokuapp.com/student-finance-forms/y/uk-full-time/apply-loans-grants/year-1516/new-student)

## Expected changes

* [URL on GOV.UK](https://www.gov.uk/student-finance-forms/y/uk-full-time/apply-loans-grants/year-1516/new-student)

### Before

* https://www.gov.uk/student-finance-forms/y/uk-full-time/apply-loans-grants/year-1516/new-student

![image](https://cloud.githubusercontent.com/assets/227328/18951485/59b2396e-863d-11e6-8336-8f487f8e9b72.png)

### After

* https://smart-answers-pr-2755.herokuapp.com/student-finance-forms/y/uk-full-time/apply-loans-grants/year-1516/new-student

![image](https://cloud.githubusercontent.com/assets/227328/18951474/51f65d2c-863d-11e6-8f5d-5d812a16b3e3.png)
