### PR TITLE
Correct broken link to GRO for Scotland

### DIFF
--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -17,7 +17,7 @@
       It might be quicker to order a certified copy of your certificate from the:
 
       - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
-      - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+      - [GRO for Scotland](http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers)
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/general-register-office-for-northern-ireland)
 
       ^A photocopy of your document won’t be accepted.^
@@ -34,7 +34,7 @@
       It might be quicker to order a certified copy of your letter from the:
 
       - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
-      - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+      - [GRO for Scotland](http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers)
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/general-register-office-for-northern-ireland)
 
       ^A photocopy of your document won’t be accepted.^  
@@ -151,7 +151,7 @@
       It might be quicker to order a certified copy of your certificate from the:
 
       - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
-      - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+      - [GRO for Scotland](http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers)
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/order-life-event-certificates/order-a-marriage-certificate.htm)
 
       ^A photocopy of your GRO document won’t be accepted.^

--- a/test/artefacts/legalisation-document-checker/birth-certificate.txt
+++ b/test/artefacts/legalisation-document-checker/birth-certificate.txt
@@ -11,7 +11,7 @@ It can take longer to legalise a signature on an original certificate, especiall
 It might be quicker to order a certified copy of your certificate from the:
 
 - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
-- [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+- [GRO for Scotland](http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers)
 - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/general-register-office-for-northern-ireland)
 
 ^A photocopy of your document won’t be accepted.^

--- a/test/artefacts/legalisation-document-checker/marriage-certificate.txt
+++ b/test/artefacts/legalisation-document-checker/marriage-certificate.txt
@@ -15,7 +15,7 @@ It can take longer to legalise a signature on an original certificate, especiall
 It might be quicker to order a certified copy of your certificate from the:
 
 - [GRO (England and Wales)](https://www.gro.gov.uk/gro/content/certificates/default.asp)
-- [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
+- [GRO for Scotland](http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers)
 - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/order-life-event-certificates/order-a-marriage-certificate.htm)
 
 ^A photocopy of your GRO document won’t be accepted.^

--- a/test/data/legalisation-document-checker-files.yml
+++ b/test/data/legalisation-document-checker-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/legalisation-document-checker.rb: 222aad7d4d6213e1ba2333a
 test/data/legalisation-document-checker-questions-and-responses.yml: 37c99c68ba04e459447622b01938ce0b
 test/data/legalisation-document-checker-responses-and-expected-results.yml: d55ccccc64cc1f58b648e810e5fa07e5
 lib/smart_answer_flows/legalisation-document-checker/legalisation_document_checker.govspeak.erb: 4be67b8e3aeebe4f3b99a5153b92ccdf
-lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb: 0576974fff2274cf82f39124bff3f47e
+lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb: a7f47d29deffe1263b3e46b1b4110884
 lib/smart_answer_flows/legalisation-document-checker/questions/which_documents_do_you_want_legalised.govspeak.erb: 807d6bee48fd47731d066aab6ad50544
 lib/smart_answer/calculators/legalisation_documents_data_query.rb: 1506239dc7b75049361f98fcb29dde85
 lib/data/legalisation_documents_data.yml: 7b32249d4358d433be1dd57886555c34


### PR DESCRIPTION
Supersedes #2725

[Trello card](https://trello.com/c/uKSn3Xgz/329-broken-links-to-scotland-legalisation-document-checker-y-degree-certificate-uk-marriage-certificate)

## Description 

This PR Updates out of date (external) link in lines 20, 37 and 154. I've updated this to go
to the correct link [1]

[1] http://www.nrscotland.gov.uk/registration/how-to-order-an-official-extract-from-the-registers

## Factcheck

[Preview link](https://smart-answers-pr-2758.herokuapp.com/legalisation-document-checker/y/birth-certificate/)
[GOV.UK](//gov.uk/legalisation-document-checker/y/birth-certificate/)

## Expected changes

*  Replaced links that work.

### Before 
![screen shot 2016-09-30 at 15 53 42](https://cloud.githubusercontent.com/assets/84896/18995865/1c988026-8726-11e6-8cff-6697ffdcadfc.png)


### After

![screen shot 2016-09-30 at 15 53 24](https://cloud.githubusercontent.com/assets/84896/18995879/2272ef68-8726-11e6-9991-5a927af5507f.png)
