### PR TITLE
Remove outcome for Iran in 'help-if-you-are-arrested-abroad' smart answer.

### DIFF
--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
@@ -77,7 +77,9 @@ module SmartAnswer
         end
 
         next_node do |response|
-          if response == "syria"
+          if response == "iran"
+            outcome :answer_two_iran
+          elsif response == "syria"
             outcome :answer_three_syria
           else
             outcome :answer_one_generic
@@ -94,6 +96,8 @@ module SmartAnswer
           region_links.join("\n")
         end
       end
+
+      outcome :answer_two_iran
 
       outcome :answer_three_syria
     end

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_two_iran.govspeak.erb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_two_iran.govspeak.erb
@@ -1,0 +1,20 @@
+<% content_for :body do %>
+  %There are no British consular services in Iran.  British nationals who need help should contact the Swedish Embassy in Tehran.%
+
+  $C
+  **The Swedish Embassy**
+  021-2371 2200
+  <ambassaden.teheran@foreign.ministry.se>
+  $C
+
+  $A
+  The Swedish Embassy
+  Boostan Avenue,
+  Nastaran Street No 27.
+  Tehran
+  $A
+
+  <%= render partial: 'common_downloads.govspeak.erb', locals: { transfer_back: false } %>
+
+  <%= render partial: 'further_links.govspeak.erb' %>
+<% end %>

--- a/test/artefacts/help-if-you-are-arrested-abroad/iran.txt
+++ b/test/artefacts/help-if-you-are-arrested-abroad/iran.txt
@@ -1,0 +1,30 @@
+
+
+%There are no British consular services in Iran.  British nationals who need help should contact the Swedish Embassy in Tehran.%
+
+$C
+**The Swedish Embassy**
+021-2371 2200
+<ambassaden.teheran@foreign.ministry.se>
+$C
+
+$A
+The Swedish Embassy
+Boostan Avenue,
+Nastaran Street No 27.
+Tehran
+$A
+
+Read more about how the FCO can help someone arrested abroad.
+
+- [Support for British nationals](/government/publications/support-for-british-nationals-abroad-a-guide)
+- [In prison abroad](/government/publications/arrest-or-detention)
+
+Further help and advice is available from:
+
+- [Fair Trials International](http://www.fairtrials.net/ "Fair Trials International"){:rel="external"}
+- [Prisoners Abroad](http://www.prisonersabroad.org.uk "Prisoners Abroad"){:rel="external"}
+- [Reprieve](http://www.reprieve.org.uk/ "Reprieve"){:rel="external"}
+
+
+

--- a/test/data/help-if-you-are-arrested-abroad-files.yml
+++ b/test/data/help-if-you-are-arrested-abroad-files.yml
@@ -1,12 +1,13 @@
 ---
-lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: 063a7cc0a031aee1c28787a649809972
-test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml: fa03d5879fb2a45ae5b1be91c0d54673
-test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml: 8c62a6c6ff1e6923f260271378c84ef6
+lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: 7a4e096739c1652c223b0c2805557f13
+test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml: c007b0dd259d1c09ccc2dd3163fa1e56
+test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml: 3e3aeca8a1af7c147b8f62af365f650d
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/help_if_you_are_arrested_abroad.govspeak.erb: cb923645274b287ba93af8c7118d7f88
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/_common_downloads.govspeak.erb: a1e2ddafdf6dafb6607a9859d2a63e31
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/_further_links.govspeak.erb: c9d3520db7b56be01240c9dd96bf979d
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_one_generic.govspeak.erb: 93afdbcc5efb713ec6d81bda3fd5a1f8
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_three_syria.govspeak.erb: 0b22adb7456839f2445b2f7c36936d84
+lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_two_iran.govspeak.erb: e1517e9473ba37acb7bc4558e973edbc
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/questions/which_country.govspeak.erb: 913b5637a2814cbd529affffc55b1f72
 lib/smart_answer/calculators/arrested_abroad.rb: 6b127f4dbdfd258cc9be5957c0f43352
 lib/data/prisoner_packs.yml: 821fb0e9f893354f647d5b97453ce322

--- a/test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml
+++ b/test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml
@@ -5,5 +5,6 @@
 - austria # additional download links: pdf, lawyer, benefits, prison, consul
 - cyprus  # has region links
 - greece  # additional download links: police
+- iran    # outcome: answer_two_iran
 - spain   # additional download links: pdf, lawyer, benefits, judicial
 - syria   # outcome: answer_three_syria

--- a/test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml
+++ b/test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml
@@ -26,6 +26,11 @@
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
+  - iran
+  :next_node: :answer_two_iran
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
   - spain
   :next_node: :answer_one_generic
   :outcome_node: true

--- a/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
+++ b/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
@@ -69,6 +69,16 @@ class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
     end # context: country with specific info
   end # context: non special case
 
+  context "In Iran" do
+    setup do
+      add_response :iran
+    end
+
+    should "take them to the special Iran outcome" do
+      assert_current_node :answer_two_iran
+    end
+  end
+
   context "In Syria" do
     setup do
       add_response :syria


### PR DESCRIPTION
Supersedes #2728

[Trello card](https://trello.com/c/fWfRgZOX/335-help-if-you-re-arrested-abroad-iran-outcome-content-change-request)

## Motivation 

This has become necessary as FCO have reopened the British embassy
in Tehran and customers should now contact our offices there.

## Factcheck 

[Preview link](//smart-answers-pr-2760.herokuapp.com/help-if-you-are-arrested-abroad/y/iran)
[Gov.UK](//gov.uk/help-if-you-are-arrested-abroad/y/iran)

### Expected changes

* Iran outcome will be the same like other countries and no more content that advises contacting the Swedish embassy

#### Before 
![screen shot 2016-09-30 at 17 14 45](https://cloud.githubusercontent.com/assets/84896/18998633/6ac36a30-8731-11e6-8233-2a3a491b859b.png)


#### After

![screen shot 2016-09-30 at 17 14 36](https://cloud.githubusercontent.com/assets/84896/18998638/6f8a4188-8731-11e6-9cca-428ac802adab.png)
