### PR TITLE
Add an outcome per path in marriage abroad: Italy

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -15,6 +15,28 @@ module SmartAnswer::Calculators
       @services_data = services_data || YAML.load_file(services_data_file)
     end
 
+    def path_to_outcome
+      ceremony_location = if resident_of_ceremony_country?
+                            'ceremony_country'
+                          elsif resident_of_third_country?
+                            'third_country'
+                          else
+                            'uk'
+                          end
+      partner_nationality = if partner_is_national_of_ceremony_country?
+                              'partner_local'
+                            elsif partner_british?
+                              'partner_british'
+                            else
+                              'partner_other'
+                            end
+
+      p "#{ceremony_country}/#{ceremony_location}/#{partner_nationality}/#{partner_is_same_sex? ? 'same_sex' : 'opposite_sex'}"
+
+      "#{ceremony_country}/#{ceremony_location}/#{partner_nationality}/#{partner_is_same_sex? ? 'same_sex' : 'opposite_sex'}"
+
+    end
+
     def partner_british?
       @partner_nationality == 'partner_british'
     end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -111,7 +111,9 @@ module SmartAnswer
         end
 
         next_node do
-          if calculator.ceremony_country == 'brazil' && calculator.resident_of_ceremony_country?
+          if calculator.ceremony_country == 'italy'
+            outcome :country
+          elsif calculator.ceremony_country == 'brazil' && calculator.resident_of_ceremony_country?
             outcome :outcome_marriage_in_brazil_when_residing_in_brazil
           elsif calculator.ceremony_country == 'brazil' && calculator.resident_of_third_country?
             outcome :outcome_marriage_in_brazil_when_residing_in_third_country
@@ -394,6 +396,7 @@ module SmartAnswer
       outcome :outcome_same_sex_marriage_and_civil_partnership_not_possible
       outcome :outcome_same_sex_marriage_in_dominican_republic
       outcome :outcome_same_sex_civil_partnership_in_greece
+      outcome :country
     end
   end
 end

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/country.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/country.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+    <% if calculator.partner_is_same_sex? %>
+        Civil partnership in Italy
+    <% else %>
+        Marriage in Italy
+    <% end %>
+<% end %>
+
+<% content_for :body do %>
+    <%= render partial: calculator.path_to_outcome, locals: {calculator: calculator} %>
+<% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_british/_opposite_sex.erb
@@ -1,0 +1,59 @@
+Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended marriage at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^You’ll need to have been living in Italy for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+You or your partner will also need to provide evidence of nationality or residence in the country where the divorce or dissolution took place, if it was outside the UK. You’ll need to get it [translated](/government/publications/italy-list-of-translators-and-interpreters) if it’s not in English.
+
+^If you’re a woman you must wait 300 days after divorcing or the death of your husband before remarrying.^
+
+###What happens next
+
+The British embassy will display your notice of marriage publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+
+^You don't need to stay in the country while your notice is posted.^
+
+<%= render partial: 'services_and_fees.govspeak.erb',
+           locals: { calculator: calculator } %>
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_british/_same_sex.govspeak.erb
@@ -1,0 +1,64 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to register a civil partnership.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended civil partnership at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^ You’ll need to have been living in Italy for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. ^
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [notice for civil partnership](/government/publications/notice-for-registration-of-civil-partnership-under-italian-law) form and a [civil partnership declaration](/government/publications/declaration-for-formation-of-civil-partnership-under-italian-law) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English or Italian.^
+
+If you're a woman wishing to remarry or enter a new civil partnership, you must wait 300 days after:
+
+- divorcing or the dissolution of your civil partnership
+- the death of your husband or civil partner.
+
+###What happens next
+
+The British embassy will display your notice for civil partnership publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+## Fees
+
+Service | Fee
+-|-
+Receiving a notice of civil partnership | £65
+Issuing a CNI, Nulla Osta or equivalent | £65
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_local/_opposite_sex.erb
@@ -1,0 +1,65 @@
+Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended marriage at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^You’ll need to have been living in Italy for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+You or your partner will also need to provide evidence of nationality or residence in the country where the divorce or dissolution took place, if it was outside the UK. You’ll need to get it [translated](/government/publications/italy-list-of-translators-and-interpreters) if it’s not in English.
+
+^If you’re a woman you must wait 300 days after divorcing or the death of your husband before remarrying.^
+
+###What happens next
+
+The British embassy will display your notice of marriage publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+
+^You don't need to stay in the country while your notice is posted.^
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+## Fees
+
+<%= render partial: 'services_and_fees.govspeak.erb',
+           locals: { calculator: calculator } %>
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_local/_same_sex.erb
@@ -1,0 +1,66 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to register a civil partnership.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended civil partnership at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^ You’ll need to have been living in Italy for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. ^
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [notice for civil partnership](/government/publications/notice-for-registration-of-civil-partnership-under-italian-law) form and a [civil partnership declaration](/government/publications/declaration-for-formation-of-civil-partnership-under-italian-law) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English or Italian.^
+
+If you're a woman wishing to remarry or enter a new civil partnership, you must wait 300 days after:
+
+- divorcing or the dissolution of your civil partnership
+- the death of your husband or civil partner.
+
+###What happens next
+
+The British embassy will display your notice for civil partnership publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+^You don't need to stay in the country while your notice is posted.^
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+<%= render partial: 'services_and_fees.govspeak.erb',
+           locals: { calculator: calculator } %>
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_other/_opposite_sex.erb
@@ -1,0 +1,63 @@
+Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended marriage at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^You’ll need to have been living in Italy for at least 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+You or your partner will also need to provide evidence of nationality or residence in the country where the divorce or dissolution took place, if it was outside the UK. You’ll need to get it [translated](/government/publications/italy-list-of-translators-and-interpreters) if it’s not in English.
+
+^If you’re a woman you must wait 300 days after divorcing or the death of your husband before remarrying.^
+
+###What happens next
+
+The British embassy will display your notice of marriage publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+
+^You don't need to stay in the country while your notice is posted.^
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+<%= render partial: 'services_and_fees.govspeak.erb',
+           locals: { calculator: calculator } %>
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/ceremony_country/partner_other/_same_sex.erb
@@ -1,0 +1,66 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to register a civil partnership.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended civil partnership at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^ You’ll need to have been living in Italy for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. ^
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [notice for civil partnership](/government/publications/notice-for-registration-of-civil-partnership-under-italian-law) form and a [civil partnership declaration](/government/publications/declaration-for-formation-of-civil-partnership-under-italian-law) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English or Italian.^
+
+If you're a woman wishing to remarry or enter a new civil partnership, you must wait 300 days after:
+
+- divorcing or the dissolution of your civil partnership
+- the death of your husband or civil partner.
+
+###What happens next
+
+The British embassy will display your notice for civil partnership publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+^You don't need to stay in the country while your notice is posted.^
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+<%= render partial: 'services_and_fees.govspeak.erb',
+           locals: { calculator: calculator } %>
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_british/_opposite_sex.erb
@@ -1,0 +1,17 @@
+Contact the relevant local authorities in Italy to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Italy](/foreign-travel-advice/italy) before making any plans.
+
+##What you need to do
+
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+
+There are 2 ways you can get a CNI:
+
+- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/italy/uk/partner_british/opposite_sex)
+- [go to Italy and post notice at the embassy or consulate there](/marriage-abroad/y/italy/ceremony_country/partner_british/opposite_sex)
+
+*[CNI]:Certificate of no impediment
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_british/_same_sex.erb
@@ -1,0 +1,60 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to register a civil partnership.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended civil partnership at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^ You’ll need to have been living in Italy for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. ^
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [notice for civil partnership](/government/publications/notice-for-registration-of-civil-partnership-under-italian-law) form and a [civil partnership declaration](/government/publications/declaration-for-formation-of-civil-partnership-under-italian-law) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English or Italian.^
+
+If you're a woman wishing to remarry or enter a new civil partnership, you must wait 300 days after:
+
+- divorcing or the dissolution of your civil partnership
+- the death of your husband or civil partner.
+
+###What happens next
+
+The British embassy will display your notice for civil partnership publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+<%= render partial: 'services_and_fees.govspeak.erb',
+           locals: { calculator: calculator } %>
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_local/_opposite_sex.erb
@@ -1,0 +1,17 @@
+Contact the relevant local authorities in Italy to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Italy](/foreign-travel-advice/italy) before making any plans.
+
+##What you need to do
+
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+
+There are 2 ways you can get a CNI:
+
+- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/italy/uk/partner_local/opposite_sex)
+- [go to Italy and post notice at the embassy or consulate there](/marriage-abroad/y/italy/ceremony_country/partner_local/opposite_sex)
+
+*[CNI]:Certificate of no impediment
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_local/_same_sex.erb
@@ -1,0 +1,66 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to register a civil partnership.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended civil partnership at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^ You’ll need to have been living in Italy for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. ^
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [notice for civil partnership](/government/publications/notice-for-registration-of-civil-partnership-under-italian-law) form and a [civil partnership declaration](/government/publications/declaration-for-formation-of-civil-partnership-under-italian-law) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English or Italian.^
+
+If you're a woman wishing to remarry or enter a new civil partnership, you must wait 300 days after:
+
+- divorcing or the dissolution of your civil partnership
+- the death of your husband or civil partner.
+
+###What happens next
+
+The British embassy will display your notice for civil partnership publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+^You don't need to stay in the country while your notice is posted.^
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+<%= render partial: 'services_and_fees.govspeak.erb',
+           locals: { calculator: calculator } %>
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_other/_opposite_sex.erb
@@ -1,0 +1,17 @@
+Contact the relevant local authorities in Italy to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Italy](/foreign-travel-advice/italy) before making any plans.
+
+##What you need to do
+
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+
+There are 2 ways you can get a CNI:
+
+- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/italy/uk/partner_other/opposite_sex)
+- [go to Italy and post notice at the embassy or consulate there](/marriage-abroad/y/italy/ceremony_country/partner_other/opposite_sex)
+
+*[CNI]:Certificate of no impediment
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/third_country/partner_other/_same_sex.erb
@@ -1,0 +1,70 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to register a civil partnership.
+
+To get a Nulla Osta, you’ll first need to post notice of your intended civil partnership at the British Embassy in Rome.
+
+[Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+
+^ You’ll need to have been living in Italy for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. ^
+
+###Applying for a Nulla Osta
+
+You’ll need to complete a [notice for civil partnership](/government/publications/notice-for-registration-of-civil-partnership-under-italian-law) form and a [civil partnership declaration](/government/publications/declaration-for-formation-of-civil-partnership-under-italian-law) form.
+
+You can download and fill in (but not sign) the forms in advance.
+
+You must take the forms with you to your appointment.
+
+You will need to provide supporting documents, including:
+
+- you and your partner’s passport
+- your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
+- a utility bill, bank statement, official residency certificate, or driving license showing your name and Italian address (if you don’t normally live in Italy you can show a flight ticket or boarding pass with your date of entry or evidence of your hotel check-in)
+- evidence if you’ve changed your name by deed poll
+
+If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+- a [decree absolute or final order](/copy-decree-absolute-final-order)
+- a civil partnership dissolution or annulment certificate
+- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English or Italian.^
+
+If you're a woman wishing to remarry or enter a new civil partnership, you must wait 300 days after:
+
+- divorcing or the dissolution of your civil partnership
+- the death of your husband or civil partner.
+
+###What happens next
+
+The British embassy will display your notice for civil partnership publicly for 7 days.
+
+They'll issue your CNI within 5 working days of the end of the 7-day notice period (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+^You don't need to stay in the country while your notice is posted.^
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+## Fees
+
+Service | Fee
+-|-
+Receiving a notice of civil partnership | £65
+Issuing a CNI, Nulla Osta or equivalent | £65
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Italy](/government/publications/italy-consular-fees).
+
+You can pay by cash (in euro and pounds sterling) or credit card (not American Express), but not by personal cheque.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_british/_opposite_sex.erb
@@ -1,0 +1,33 @@
+Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to marry.
+
+^Your partner will need to follow the same process to get their own CNI.^
+
+You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
+
+###Getting a statutory declaration
+
+While you’re waiting for your CNI, you and your partner will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/) in the UK. The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+$D
+[Download ‘Bilingual statutory declaration for marriage in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
+$D
+
+###Legalisation and translation
+
+You’ll need to get your statutory declaration and CNI ’[legalised](/get-document-legalised)’ (certified as genuine) by the Foreign & Commonwealth Office (FCO).
+
+You’ll also need to get your CNI [translated](/government/publications/italy-list-of-translators-and-interpreters) and sworn before the Italian courts or an Italian Justice of the Peace.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_british/_same_sex.erb
@@ -1,0 +1,33 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to register a civil partnership.
+
+^Your partner will need to follow the same process to get their own CNI.^
+
+You can normally get a CNI by giving a notice of civil partnership at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
+
+###Getting a statutory declaration
+
+While you’re waiting for your CNI, you and your partner will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/) in the UK. The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+$D
+[Download ‘Bilingual statutory declaration for civil partnership in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
+$D
+
+###Legalisation and translation
+
+You’ll need to get your statutory declaration and CNI ’[legalised](/get-document-legalised)’ (certified as genuine) by the Foreign & Commonwealth Office (FCO).
+
+You’ll also need to get your CNI [translated](/government/publications/italy-list-of-translators-and-interpreters) and sworn before the Italian courts or an Italian Justice of the Peace.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_local/_opposite_sex.erb
@@ -1,0 +1,37 @@
+Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to marry.
+
+You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
+
+###Getting a statutory declaration
+
+While you’re waiting for your CNI, you will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+$D
+[Download ‘Bilingual statutory declaration for marriage in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
+$D
+
+^Your partner should check what they need to do with their own consulate.^
+
+###Legalisation and translation
+
+You’ll need to get your statutory declaration and CNI ’[legalised](/get-document-legalised)’ (certified as genuine) by the Foreign & Commonwealth Office (FCO).
+
+You’ll also need to get your CNI [translated](/government/publications/italy-list-of-translators-and-interpreters) and sworn before the Italian courts or an Italian Justice of the Peace.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_local/_same_sex.erb
@@ -1,0 +1,37 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to register a civil partnership.
+
+You can normally get a CNI by giving a notice of civil partnership at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
+
+###Getting a statutory declaration
+
+While you’re waiting for your CNI, you will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+$D
+[Download ‘Bilingual statutory declaration for civil partnership in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
+$D
+
+^Your partner should check what they need to do with their own consulate.^
+
+###Legalisation and translation
+
+You’ll need to get your statutory declaration and CNI ’[legalised](/get-document-legalised)’ (certified as genuine) by the Foreign & Commonwealth Office (FCO).
+
+You’ll also need to get your CNI [translated](/government/publications/italy-list-of-translators-and-interpreters) and sworn before the Italian courts or an Italian Justice of the Peace.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_other/_opposite_sex.erb
@@ -1,0 +1,37 @@
+Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to marry.
+
+You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
+
+###Getting a statutory declaration
+
+While you’re waiting for your CNI, you will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+$D
+[Download ‘Bilingual statutory declaration for marriage in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
+$D
+
+^Your partner should check what they need to do with their own consulate.^
+
+###Legalisation and translation
+
+You’ll need to get your statutory declaration and CNI ’[legalised](/get-document-legalised)’ (certified as genuine) by the Foreign & Commonwealth Office (FCO).
+
+You’ll also need to get your CNI [translated](/government/publications/italy-list-of-translators-and-interpreters) and sworn before the Italian courts or an Italian Justice of the Peace.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/italy/uk/partner_other/_same_sex.erb
@@ -1,0 +1,37 @@
+Contact the local comune (town hall) before making any plans to find out about local civil partnership laws, including what documents you’ll need.
+
+##What you need to do
+
+You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to register a civil partnership.
+
+You can normally get a CNI by giving a notice of civil partnership at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+
+^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
+
+###Getting a statutory declaration
+
+While you’re waiting for your CNI, you will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+$D
+[Download ‘Bilingual statutory declaration for civil partnership in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
+$D
+
+^Your partner should check what they need to do with their own consulate.^
+
+###Legalisation and translation
+
+You’ll need to get your statutory declaration and CNI ’[legalised](/get-document-legalised)’ (certified as genuine) by the Foreign & Commonwealth Office (FCO).
+
+You’ll also need to get your CNI [translated](/government/publications/italy-list-of-translators-and-interpreters) and sworn before the Italian courts or an Italian Justice of the Peace.
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+*[FCO]:Foreign &amp; Commonwealth Office
+
+
+


### PR DESCRIPTION
Temporary commit to start a discussion with live code with content 
designers and developers about ways to improve marriage abroad in 
smart-answers.

In this commit, we create a different outcome per path. To
do it, we have done the following:
1. Create a new outcome for a generic country.
2. Infer the path to the outcome from the calculator in the method
   `path_to_outcome`
3. Copy content and folder structure from the artefacts

The code is not production ready at all, this is just a spike to start an
open discussion around ways to improve marriage-abroad.

Related links:
1. [Current process to update marriage-abroad and issues](https://gov-uk.atlassian.net/wiki/display/CT/Marriage+Abroad+-+Oct+-+2016+-+Current+process+and+issues)
2. [Collaboration session to improve smart-answers](https://gov-uk.atlassian.net/wiki/display/CT/Marriage-aborad%3A+a+development+approach+to+reduce+complexity)
3. [Trello card for this spike](https://trello.com/c/e2HMopWF/354-spike-use-an-outcome-per-path-for-italy-in-marriage-abroad)
