### PR TITLE
Change title for Minimum wage calculator

### DIFF
--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/am_i_getting_minimum_wage.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/am_i_getting_minimum_wage.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Minimum wage calculator for workers
+  National Minimum Wage and Living Wage calculator for workers
 <% end %>
 
 <% content_for :meta_description do %>

--- a/test/artefacts/am-i-getting-minimum-wage/am-i-getting-minimum-wage.txt
+++ b/test/artefacts/am-i-getting-minimum-wage/am-i-getting-minimum-wage.txt
@@ -1,4 +1,4 @@
-Minimum wage calculator for workers
+National Minimum Wage and Living Wage calculator for workers
 
 Check if:
 

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/am-i-getting-minimum-wage.rb: b92b356e4d587b2e98959fc35c5080a2
 test/data/am-i-getting-minimum-wage-questions-and-responses.yml: aa201473058ce2a80bc602b82932353e
 test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml: 53ed6e59740f06e2890bc3060f8ff9be
-lib/smart_answer_flows/am-i-getting-minimum-wage/am_i_getting_minimum_wage.govspeak.erb: 86c93ffa61a92bfd386e0e9f2957ac4c
+lib/smart_answer_flows/am-i-getting-minimum-wage/am_i_getting_minimum_wage.govspeak.erb: 2e535c37e9afccd91ee05c61f881eb5a
 lib/smart_answer_flows/am-i-getting-minimum-wage/outcomes/current_payment_above.govspeak.erb: 0307275df2e8913676fb967ffe0f0655
 lib/smart_answer_flows/am-i-getting-minimum-wage/outcomes/current_payment_below.govspeak.erb: 55a7da0fe47e873c1b01d6a631c9b67b
 lib/smart_answer_flows/am-i-getting-minimum-wage/outcomes/does_not_apply_to_historical_apprentices.govspeak.erb: bd846fa5585f32e995c74bb714f6d600


### PR DESCRIPTION
[Trello card](https://trello.com/c/kho3U56L/131-change-titles-of-minimum-wage-calculators)

## Description 

This PR changes the title for Minimum wage calculator

FROM

**Minimum wage calculator for workers**

TO

**National Minimum Wage and Living Wage calculator for workers**


## Factcheck 

[Preview link](https://smart-answers-pr-2769.herokuapp.com/am-i-getting-minimum-wage)
[GOV.UK](https://www.gov.uk/am-i-getting-minimum-wage)

### Expected changes

* Change in title as explained above.


### Before
![screen shot 2016-10-05 at 10 49 11](https://cloud.githubusercontent.com/assets/84896/19108607/62700c24-8ae9-11e6-8fb8-5bfa1de82d09.png)


### After
![screen shot 2016-10-05 at 10 52 09](https://cloud.githubusercontent.com/assets/84896/19108721/cc30218a-8ae9-11e6-832d-2c2c7c0d1aad.png)


