### PR TITLE
Change title for Minimum wage calc for employers

### DIFF
--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/minimum_wage_calculator_employers.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/minimum_wage_calculator_employers.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Minimum wage calculator for employers
+  National Minimum Wage and Living Wage calculator for employers
 <% end %>
 
 <% content_for :meta_description do %>

--- a/test/artefacts/minimum-wage-calculator-employers/minimum-wage-calculator-employers.txt
+++ b/test/artefacts/minimum-wage-calculator-employers/minimum-wage-calculator-employers.txt
@@ -1,4 +1,4 @@
-Minimum wage calculator for employers
+National Minimum Wage and Living Wage calculator for employers
 
 Check if:
 

--- a/test/data/minimum-wage-calculator-employers-files.yml
+++ b/test/data/minimum-wage-calculator-employers-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/minimum-wage-calculator-employers.rb: 16560e10f0491911e1bed528e37855e2
 test/data/minimum-wage-calculator-employers-questions-and-responses.yml: aa201473058ce2a80bc602b82932353e
 test/data/minimum-wage-calculator-employers-responses-and-expected-results.yml: 53ed6e59740f06e2890bc3060f8ff9be
-lib/smart_answer_flows/minimum-wage-calculator-employers/minimum_wage_calculator_employers.govspeak.erb: 4785f414ecc1fbab2a234582e4a12eed
+lib/smart_answer_flows/minimum-wage-calculator-employers/minimum_wage_calculator_employers.govspeak.erb: 76db23a801c20285eb34e4c64969cca6
 lib/smart_answer_flows/minimum-wage-calculator-employers/outcomes/current_payment_above.govspeak.erb: 213bc34a9df44bccd60642655f165eed
 lib/smart_answer_flows/minimum-wage-calculator-employers/outcomes/current_payment_below.govspeak.erb: 19282268790be35937da775f3abcc507
 lib/smart_answer_flows/minimum-wage-calculator-employers/outcomes/does_not_apply_to_historical_apprentices.govspeak.erb: b7db231cc648b8b6abc846efd5a840ff


### PR DESCRIPTION
[Trello card](https://trello.com/c/kho3U56L/131-change-titles-of-minimum-wage-calculators)

## Description 

This PR changes the title for Minimum wage calculator
FROM

**Minimum wage calculator for employers**

TO

**National Minimum Wage and Living Wage calculator for employers**


## Factcheck 

[Preview link](https://smart-answers-pr-2770.herokuapp.com/minimum-wage-calculator-employers)
[GOV.UK](https://www.gov.uk/minimum-wage-calculator-employers)

### Expected changes

* Change in title as explained above.


### Before

![screen shot 2016-10-05 at 11 04 31](https://cloud.githubusercontent.com/assets/84896/19109047/86040008-8aeb-11e6-9c0a-fe76e5ac2047.png)

### After
![screen shot 2016-10-05 at 11 06 40](https://cloud.githubusercontent.com/assets/84896/19109099/d26890a8-8aeb-11e6-8bd0-a3e9532a042c.png)

