### PR TITLE
External links dsl

### DIFF
--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -9,7 +9,9 @@ class FlowContentItem
     {
       base_path: base_path,
       title: flow_presenter.title,
-      details: {},
+      details: {
+          external_related_links: external_related_links
+      },
       schema_name: 'placeholder_smart_answer',
       document_type: 'smartanswer_document',
       publishing_app: 'smartanswers',
@@ -30,5 +32,9 @@ private
 
   def base_path
     '/' + flow_presenter.slug
+  end
+
+  def external_related_links
+    flow_presenter.external_related_links
   end
 end

--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -31,6 +31,10 @@ class FlowRegistrationPresenter
     start_node.meta_description
   end
 
+  def external_related_links
+    @flow.external_related_links || []
+  end
+
   module MethodMissingHelper
     OVERRIDES = {
       'calculator.services_payment_partial_name' => 'pay_by_cash_only',

--- a/doc/flow-definition.md
+++ b/doc/flow-definition.md
@@ -52,12 +52,16 @@ module SmartAnswer
       content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207" # a UUID used by v2 of the Publishing API (?)
       status :published # this indicates whether or not the flow should appear on gov.uk (i.e. production); those with `:draft` status will not appear
       satisfies_need "123456" # may relate the Smart Answer to the original user need in the Need-o-tron app (?)
+      external_related_links { title: "Child Maintenance Options - How much should be paid",
+                               url: "http://www.cmoptions.org/en/maintenance/how-much.asp" } # External links associated to the Smart-Answer                                      
 
       # question & outcome definitions specified here
     end
   end
 end
 ```
+
+* `external_related_links` will be stored in [content-tagger](https://github.com/alphagov/content-tagger) with the objective of retrieving them from there. This is a temporary fix, we want to be able to set external related links via a publishing tool like `content-tagger` rather than hardcoding them. 
 
 ### Arbitrary Ruby code
 

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -37,6 +37,11 @@ module SmartAnswer
       self.need_id = need_id
     end
 
+    def external_related_links(external_related_links = nil)
+      @external_related_links = external_related_links unless external_related_links.nil?
+      @external_related_links
+    end
+
     def draft?
       status == :draft
     end

--- a/lib/smart_answer_flows/calculate-your-child-maintenance.rb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance.rb
@@ -5,6 +5,16 @@ module SmartAnswer
       name 'calculate-your-child-maintenance'
       status :published
       satisfies_need "100147"
+      external_related_links [
+        {
+          title: "Child Maintenance Options - How much should be paid",
+          url: "http://www.cmoptions.org/en/maintenance/how-much.asp"
+        },
+        {
+          title: "Child Maintenance Options - Ways to pay",
+          url: "http://www.cmoptions.org/en/maintenance/ways-to-pay.asp"
+        },
+      ]
 
       ## Q0
       multiple_choice :are_you_paying_or_receiving? do

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-your-child-maintenance.rb: 8cb70c20585a04e66925a4de25626980
+lib/smart_answer_flows/calculate-your-child-maintenance.rb: 857fa09bc3c8dcc5bd7f87e229cb0506
 test/data/calculate-your-child-maintenance-questions-and-responses.yml: 4534340cf82c2d7f24a865a8b70855fd
 test/data/calculate-your-child-maintenance-responses-and-expected-results.yml: e5f2d15987daf89c77c28fc4b4b82042
 lib/smart_answer_flows/calculate-your-child-maintenance/_disclaimer.govspeak.erb: 4c59b8e3ac5f5071d11ee84e0d6a508b

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -10,7 +10,16 @@ module SmartAnswer
     end
 
     test '#payload returns a valid content-item' do
-      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685'))
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: nil))
+      content_item = FlowContentItem.new(presenter)
+
+      payload = content_item.payload
+
+      assert_valid_against_schema(payload, 'placeholder')
+    end
+
+    test '#payload returns a valid content-item with external related links' do
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: [{ title: "hmrc", url: "https://hmrc.gov.uk" }]))
       content_item = FlowContentItem.new(presenter)
 
       payload = content_item.payload
@@ -19,7 +28,7 @@ module SmartAnswer
     end
 
     test '#base_path is the name of the flow' do
-      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '25b98dfb-fabe-4b16-b587-072c8233f6bc'))
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '25b98dfb-fabe-4b16-b587-072c8233f6bc', external_related_links: nil))
       content_item = FlowContentItem.new(presenter)
 
       base_path = content_item.payload[:base_path]

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -58,6 +58,18 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
     end
   end
 
+  context "#external_related_links" do
+    should "return the external_related_links" do
+      @flow.external_related_links([title: 'a-title', url: 'a-description'])
+
+      assert_equal [title: 'a-title', url: 'a-description'], @presenter.external_related_links
+    end
+
+    should "return empty list if no external links" do
+      assert_equal [], @presenter.external_related_links
+    end
+  end
+
   context "indexable_content" do
     should "include all question node titles" do
       @content = @presenter.indexable_content

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -18,6 +18,24 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal "587920ff-b854-4adb-9334-451b45652467", s.content_id
   end
 
+  test "Defaults the external_related_links to nil" do
+    s = SmartAnswer::Flow.new
+
+    assert_equal nil, s.external_related_links
+  end
+
+  test "Can set the external_related_links" do
+    links = [
+      { title: "Book appointment", url: "https://www.booking-an-appointment.gov.uk" },
+      { title: "Buy stamps", url: "https://www.stamps.uk" },
+    ]
+    s = SmartAnswer::Flow.new do
+      external_related_links links
+    end
+
+    assert_equal links, s.external_related_links
+  end
+
   test "Can build outcome nodes" do
     s = SmartAnswer::Flow.new do
       outcome :you_dont_have_a_sweet_tooth

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -10,7 +10,7 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
     draft_request = stub_request(:put, "http://publishing-api.dev.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685")
     publishing_request = stub_request(:post, "http://publishing-api.dev.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685/publish")
 
-    presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685'))
+    presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: nil))
 
     ContentItemPublisher.new.publish([presenter])
 


### PR DESCRIPTION
paired with @jackscotti 

Panopticon is currently storing external links for smart answers.

Panopticon is going to be retired and we are going to store them into 
the [content-store][1], via the [publishing-api][2].
This commit extends the flow DSL to incorporate into the flow definition
the list of external links that could be displayed linked to the smart-answer.

This is a TEMPORARY UPDATE because this information will eventually be set 
via a publishing tool that will use content-store.

As a side note, the method `Flow#external_related_links` is used at the
same time as a `getter` and a `setter`, for this reason its implementation
feels a bit out of Ruby usual coding practices.

[1]: https://github.com/alphagov/content-store
[2]: https://github.com/alphagov/publishing-api