### PR TITLE
Add 2015-2016 option for ESAP

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -8,18 +8,21 @@ module SmartAnswer::Calculators
         "2012-13": Date.new(2014, 1, 31),
         "2013-14": Date.new(2015, 1, 31),
         "2014-15": Date.new(2016, 1, 31),
+        "2015-16": Date.new(2017, 1, 31),
       },
       offline_filing_deadline: {
         "2011-12": Date.new(2012, 10, 31),
         "2012-13": Date.new(2013, 10, 31),
         "2013-14": Date.new(2014, 10, 31),
         "2014-15": Date.new(2015, 10, 31),
+        "2015-16": Date.new(2016, 10, 31),
       },
       payment_deadline: {
         "2011-12": Date.new(2013, 1, 31),
         "2012-13": Date.new(2014, 1, 31),
         "2013-14": Date.new(2015, 1, 31),
         "2014-15": Date.new(2016, 1, 31),
+        "2015-16": Date.new(2017, 1, 31),
       },
     }
 
@@ -30,8 +33,10 @@ module SmartAnswer::Calculators
         Date.new(2013, 4, 6)
       elsif tax_year == '2013-14'
         Date.new(2014, 4, 6)
-      else
+      elsif tax_year == '2014-15'
         Date.new(2015, 4, 6)
+      else
+        Date.new(2016, 4, 6)
       end
     end
 
@@ -42,8 +47,10 @@ module SmartAnswer::Calculators
         Date.new(2015, 2, 01)
       elsif tax_year == '2013-14'
         Date.new(2016, 2, 01)
-      else
+      elsif tax_year == '2014-15'
         Date.new(2017, 2, 01)
+      else
+        Date.new(2018, 2, 01)
       end
     end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -11,6 +11,7 @@ module SmartAnswer
         option :"2012-13"
         option :"2013-14"
         option :"2014-15"
+        option :"2015-16"
 
         on_response do |response|
           self.calculator = Calculators::SelfAssessmentPenalties.new

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
@@ -6,5 +6,6 @@
   "2011-12": "6 April 2011 to 5 April 2012",
   "2012-13": "6 April 2012 to 5 April 2013",
   "2013-14": "6 April 2013 to 5 April 2014",
-  "2014-15": "6 April 2014 to 5 April 2015"
+  "2014-15": "6 April 2014 to 5 April 2015",
+  "2015-16": "6 April 2015 to 5 April 2016"
 ) %>

--- a/test/artefacts/estimate-self-assessment-penalties/y.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/y.txt
@@ -8,6 +8,7 @@ For which tax year do you want the estimate?
   * 2012-13: 6 April 2012 to 5 April 2013
   * 2013-14: 6 April 2013 to 5 April 2014
   * 2014-15: 6 April 2014 to 5 April 2015
+  * 2015-16: 6 April 2015 to 5 April 2016
 
 
 

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/estimate-self-assessment-penalties.rb: c11afabc77193e30122b41441cb1ff14
+lib/smart_answer_flows/estimate-self-assessment-penalties.rb: 9d43452a4385053332161a4e982b0488
 test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 22157fec1db01301777ab651a8e6fe16
 test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 7cd14ec238d300bd2885dfef64f06440
 lib/smart_answer_flows/estimate-self-assessment-penalties/estimate_self_assessment_penalties.govspeak.erb: d35eaf0334a9e871fa14294682fb7322
@@ -9,5 +9,5 @@ lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_much_tax
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_submitted.govspeak.erb: c3fffa8a0386144630fae76250114191
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb: fd629bd5e95648f5a22246a423cfd026
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb: 590022eac4fbf8db1976da66d777f776
-lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: a77dd8bf04e80f877c22f246d787fed1
-lib/smart_answer/calculators/self_assessment_penalties.rb: bd90e1d33ee15ce63141fa9a266dc5a6
+lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: 8d662dbf003e922fd723cca19023266f
+lib/smart_answer/calculators/self_assessment_penalties.rb: e96418af21b594fe39f59e19a46942e2


### PR DESCRIPTION
Related to #2773 

[Trello card](https://trello.com/c/mZHU8O0K/202-add-2015-2016-tax-year-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments)

## Description 

The GOV.UK service for estimating the penalty for late submission of an Self Assessment return or late payment of an  Self Assessment bill needs to be set up to show returns for the 6 April 2015 to 5 April 2016 tax year.


## Factcheck

[Preview link](https://smart-answers-pr-2775.herokuapp.com/estimate-self-assessment-penalties/y)
[GOV.UK](https://www.gov.uk/estimate-self-assessment-penalties/y)

## Expected changes 

* 2015-2016 option will be available for selection


### Before 

![screen shot 2016-10-07 at 11 20 18](https://cloud.githubusercontent.com/assets/84896/19186835/0d83e238-8c80-11e6-836a-730b7b7079ff.png)


### After 

![screen shot 2016-10-07 at 11 19 20](https://cloud.githubusercontent.com/assets/84896/19186810/f5bfb230-8c7f-11e6-9159-134f497060bf.png)

