### PR TITLE
Check state pension age: update copy

### DIFF
--- a/lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb
@@ -7,9 +7,16 @@
 <% end %>
 
 <% content_for :body do %>
-  You can check:
+Your State Pension age is the earliest age you can start receiving your State Pension. It may be different to the age you can get a [workplace or personal pension](/early-retirement-pension/personal-and-workplace-pensions).  
 
-  - when you'll reach State Pension age
-  - your Pension Credit qualifying age
-  - when you'll be eligible for free bus travel
+Your State Pension age is worked out based on your gender and date of birth. 
+
+You can [keep working after you reach State Pension age](/working-retirement-pension-age). ‘Default retirement age’ (a forced retirement age of 65) no longer exists.
+
+Use this tool to check: 
+
+- when you'll reach State Pension age
+- your Pension Credit qualifying age
+- when you'll be eligible for free bus travel
+
 <% end %>

--- a/test/artefacts/state-pension-age/state-pension-age.txt
+++ b/test/artefacts/state-pension-age/state-pension-age.txt
@@ -1,6 +1,12 @@
 Check your State Pension age
 
-You can check:
+Your State Pension age is the earliest age you can start receiving your State Pension. It may be different to the age you can get a [workplace or personal pension](/early-retirement-pension/personal-and-workplace-pensions).  
+
+Your State Pension age is worked out based on your gender and date of birth. 
+
+You can [keep working after you reach State Pension age](/working-retirement-pension-age). ‘Default retirement age’ (a forced retirement age of 65) no longer exists.
+
+Use this tool to check: 
 
 - when you'll reach State Pension age
 - your Pension Credit qualifying age

--- a/test/data/state-pension-age-files.yml
+++ b/test/data/state-pension-age-files.yml
@@ -8,7 +8,7 @@ lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspea
 lib/smart_answer_flows/state-pension-age/questions/dob_age.govspeak.erb: 336a91fc32e8fc66011a9ae504111ae0
 lib/smart_answer_flows/state-pension-age/questions/gender.govspeak.erb: 4624dfdac5be156a8573cbc21245e36d
 lib/smart_answer_flows/state-pension-age/questions/which_calculation.govspeak.erb: 047d48d2d752d7b53c0b78f0eaedac3f
-lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb: 84df7264d442e78955023ab6357910a4
+lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb: 0a50ea49131a4bcd8f07c0110d94a89b
 lib/smart_answer/calculators/state_pension_age_calculator.rb: ca0fb1fc157b18afa7eaa8c03137920e
 lib/data/rates/state_pension.yml: a9beaaf4eea7e2df87ccf7fcca7440f9
 lib/data/state_pension_date_query.rb: 6a5bc3072ae8b986f7ee6d47ecd5da41


### PR DESCRIPTION
### Trello card
* [check-state-pension-information-request](https://trello.com/c/MZA1qk94/367-13-oct-check-state-pension-age-more-information-content-change-request) 

## Description
There aren't any changes to the logic - just to the start page for the calculator. I've added extra information based on Feedex comments DWP have compiled. 

## Factcheck 
[fact-check](https://smart-answers-pr-2781.herokuapp.com/state-pension-age)

## Expected changes

* [URL on GOV.UK](https://gov.uk/state-pension-age)

### Before

* https://gov.uk/state-pension-age

![image](https://cloud.githubusercontent.com/assets/227328/19318000/d2cf2a12-909e-11e6-8030-a2831d082596.png)

### After

* https://smart-answers-pr-2781.herokuapp.com/state-pension-age

![image](https://cloud.githubusercontent.com/assets/227328/19318008/d9edf27e-909e-11e6-895f-c79590dceda7.png)

