### PR TITLE
Add 2015-2016 option for ESAP

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -30,7 +30,7 @@ module SmartAnswer::Calculators
         Date.new(2013, 4, 6)
       elsif tax_year == '2013-14'
         Date.new(2014, 4, 6)
-      else
+      elsif tax_year == '2014-15'
         Date.new(2015, 4, 6)
       end
     end
@@ -42,7 +42,7 @@ module SmartAnswer::Calculators
         Date.new(2015, 2, 01)
       elsif tax_year == '2013-14'
         Date.new(2016, 2, 01)
-      else
+      elsif tax_year == '2014-15'
         Date.new(2017, 2, 01)
       end
     end

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -8,18 +8,21 @@ module SmartAnswer::Calculators
         "2012-13": Date.new(2014, 1, 31),
         "2013-14": Date.new(2015, 1, 31),
         "2014-15": Date.new(2016, 1, 31),
+        "2015-16": Date.new(2017, 1, 31)
       },
       offline_filing_deadline: {
         "2011-12": Date.new(2012, 10, 31),
         "2012-13": Date.new(2013, 10, 31),
         "2013-14": Date.new(2014, 10, 31),
         "2014-15": Date.new(2015, 10, 31),
+        "2015-16": Date.new(2016, 10, 31)
       },
       payment_deadline: {
         "2011-12": Date.new(2013, 1, 31),
         "2012-13": Date.new(2014, 1, 31),
         "2013-14": Date.new(2015, 1, 31),
         "2014-15": Date.new(2016, 1, 31),
+        "2015-16": Date.new(2017, 1, 31)
       },
     }
 
@@ -32,6 +35,8 @@ module SmartAnswer::Calculators
         Date.new(2014, 4, 6)
       elsif tax_year == '2014-15'
         Date.new(2015, 4, 6)
+      elsif tax_year == '2015-16'
+        Date.new(2016, 4, 6)
       end
     end
 
@@ -44,6 +49,8 @@ module SmartAnswer::Calculators
         Date.new(2016, 2, 01)
       elsif tax_year == '2014-15'
         Date.new(2017, 2, 01)
+      elsif tax_year == '2015-16'
+        Date.new(2018, 2, 01)
       end
     end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -11,6 +11,7 @@ module SmartAnswer
         option :"2012-13"
         option :"2013-14"
         option :"2014-15"
+        option :"2015-16"
 
         on_response do |response|
           self.calculator = Calculators::SelfAssessmentPenalties.new

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
@@ -6,5 +6,6 @@
   "2011-12": "6 April 2011 to 5 April 2012",
   "2012-13": "6 April 2012 to 5 April 2013",
   "2013-14": "6 April 2013 to 5 April 2014",
-  "2014-15": "6 April 2014 to 5 April 2015"
+  "2014-15": "6 April 2014 to 5 April 2015",
+  "2015-16": "6 April 2015 to 5 April 2016"
 ) %>

--- a/test/artefacts/estimate-self-assessment-penalties/2015-16/online/2016-04-07/2016-04-08.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/2015-16/online/2016-04-07/2016-04-08.txt
@@ -1,0 +1,8 @@
+You don't have to pay a penalty
+
+You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
+
+You paid your bill on time, so there is no interest or penalty for late payment.
+
+
+

--- a/test/artefacts/estimate-self-assessment-penalties/2015-16/paper/2016-04-07/2016-04-08.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/2015-16/paper/2016-04-07/2016-04-08.txt
@@ -1,0 +1,8 @@
+You don't have to pay a penalty
+
+You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
+
+You paid your bill on time, so there is no interest or penalty for late payment.
+
+
+

--- a/test/artefacts/estimate-self-assessment-penalties/y.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/y.txt
@@ -8,6 +8,7 @@ For which tax year do you want the estimate?
   * 2012-13: 6 April 2012 to 5 April 2013
   * 2013-14: 6 April 2013 to 5 April 2014
   * 2014-15: 6 April 2014 to 5 April 2015
+  * 2015-16: 6 April 2015 to 5 April 2016
 
 
 

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -1,7 +1,7 @@
 ---
-lib/smart_answer_flows/estimate-self-assessment-penalties.rb: c11afabc77193e30122b41441cb1ff14
-test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 22157fec1db01301777ab651a8e6fe16
-test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 7cd14ec238d300bd2885dfef64f06440
+lib/smart_answer_flows/estimate-self-assessment-penalties.rb: 9d43452a4385053332161a4e982b0488
+test/data/estimate-self-assessment-penalties-questions-and-responses.yml: c2beb865ccaa0a2611c3bcbab41834b4
+test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: d592fa138a4391603c784351f18b42f1
 lib/smart_answer_flows/estimate-self-assessment-penalties/estimate_self_assessment_penalties.govspeak.erb: d35eaf0334a9e871fa14294682fb7322
 lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/filed_and_paid_on_time.govspeak.erb: c7c2b164d05b3f757bc9ee9439aa560a
 lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb: b88d8257149cb0af87681e03493ace43
@@ -9,5 +9,5 @@ lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_much_tax
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_submitted.govspeak.erb: c3fffa8a0386144630fae76250114191
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb: fd629bd5e95648f5a22246a423cfd026
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb: 590022eac4fbf8db1976da66d777f776
-lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: a77dd8bf04e80f877c22f246d787fed1
-lib/smart_answer/calculators/self_assessment_penalties.rb: bd90e1d33ee15ce63141fa9a266dc5a6
+lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: 8d662dbf003e922fd723cca19023266f
+lib/smart_answer/calculators/self_assessment_penalties.rb: 3d786c100838cf9f561cc9151d733685

--- a/test/data/estimate-self-assessment-penalties-questions-and-responses.yml
+++ b/test/data/estimate-self-assessment-penalties-questions-and-responses.yml
@@ -4,6 +4,7 @@
 - 2012-13
 - 2013-14
 - 2014-15
+- 2015-16
 :how_submitted?:
 - online
 - paper
@@ -16,6 +17,7 @@
 - 2013-04-07 # 2012-13 - After start of next tax year (2013-04-06)
 - 2014-04-07 # 2013-14 - After start of next tax year (2014-04-06)
 - 2015-04-07 # 2014-15 - After start of next tax year (2015-04-06)
+- 2016-04-07 # 2015-16 - After start of next tax year (2016-04-06)
 :when_paid?:
 - 2012-04-06 # 2011-12 - Paid before submitted (2012-04-07)
 - 2012-04-08 # 2011-12 - Paid after submitted (2012-04-07)
@@ -25,6 +27,7 @@
 - 2013-04-08 # 2012-13 - Paid after submitted
 - 2014-04-08 # 2013-14 - Paid after submitted
 - 2015-04-08 # 2014-15 - Paid after submitted
+- 2016-04-08 # 2015-16 - Paid after submitted
 :how_much_tax?:
 - 500
 - 6003 # Estimated bill value greater than £6002

--- a/test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml
+++ b/test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml
@@ -2361,3 +2361,50 @@
   - '2015-04-08'
   :next_node: :filed_and_paid_on_time
   :outcome_node: true
+- :current_node: :which_year?
+  :responses:
+  - 2015-16
+  :next_node: :how_submitted?
+  :outcome_node: false
+- :current_node: :how_submitted?
+  :responses:
+  - 2015-16
+  - online
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2015-16
+  - online
+  - '2016-04-07'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2015-16
+  - online
+  - '2016-04-07'
+  - '2016-04-08'
+  :next_node: :filed_and_paid_on_time
+  :outcome_node: true
+- :current_node: :how_submitted?
+  :responses:
+  - 2015-16
+  - paper
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2015-16
+  - paper
+  - '2016-04-07'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2015-16
+  - paper
+  - '2016-04-07'
+  - '2016-04-08'
+  :next_node: :filed_and_paid_on_time
+  :outcome_node: true

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -8,16 +8,20 @@ module SmartAnswer::Calculators
           "2011-12": Date.new(2013, 1, 31),
           "2012-13": Date.new(2014, 1, 31),
           "2013-14": Date.new(2015, 1, 31),
+          "2014-15": Date.new(2015, 1, 31),
+          "2015-16": Date.new(2017, 1, 31)
         },
         offline_filing_deadline: {
           "2011-12": Date.new(2012, 10, 31),
           "2012-13": Date.new(2013, 10, 31),
           "2013-14": Date.new(2014, 10, 31),
+          "2015-16": Date.new(2016, 10, 31)
         },
         payment_deadline: {
           "2011-12": Date.new(2013, 1, 31),
           "2012-13": Date.new(2014, 1, 31),
           "2013-14": Date.new(2015, 1, 31),
+          "2015-16": Date.new(2017, 1, 31)
         },
       }
 
@@ -51,6 +55,11 @@ module SmartAnswer::Calculators
 
         assert_equal Date.new(2015, 4, 6), @calculator.start_of_next_tax_year
       end
+      should 'return 2016-04-06 if tax-year is 2016-15' do
+        @calculator.tax_year = '2015-16'
+
+        assert_equal Date.new(2016, 4, 6), @calculator.start_of_next_tax_year
+      end
     end
 
     context 'one_year_after_start_date_for_penalties' do
@@ -74,6 +83,11 @@ module SmartAnswer::Calculators
         @calculator.tax_year = '2014-15'
 
         assert_equal Date.new(2017, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should 'return 2018-02-01 if tax-year is 2015-16' do
+        @calculator.tax_year = '2015-16'
+
+        assert_equal Date.new(2018, 2, 1), @calculator.one_year_after_start_date_for_penalties
       end
     end
 

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -25,7 +25,7 @@ module SmartAnswer::Calculators
         submission_method: "online", filing_date: Date.parse("2013-01-10"),
         payment_date: Date.parse("2013-03-10"), estimated_bill: SmartAnswer::Money.new(5000),
         dates: test_calculator_dates,
-        tax_year: :"2011-12"
+        tax_year: "2011-12"
       )
     end
 

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -53,6 +53,30 @@ module SmartAnswer::Calculators
       end
     end
 
+    context 'one_year_after_start_date_for_penalties' do
+      should 'return 2014-02-01 if tax-year is 2011-12' do
+        @calculator.tax_year = '2011-12'
+
+        assert_equal Date.new(2014, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+
+      should 'return 2015-02-01 if tax-year is 2012-13' do
+        @calculator.tax_year = '2012-13'
+
+        assert_equal Date.new(2015, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should 'return 2016-02-01 if tax-year is 2013-14' do
+        @calculator.tax_year = '2013-14'
+
+        assert_equal Date.new(2016, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should 'return 2017-02-01 if tax-year is 2014-15' do
+        @calculator.tax_year = '2014-15'
+
+        assert_equal Date.new(2017, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+    end
+
     context "valid_filing_date?" do
       should "be valid if filing date is on or after start of next tax year" do
         @calculator.filing_date = @calculator.start_of_next_tax_year

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -29,6 +29,30 @@ module SmartAnswer::Calculators
       )
     end
 
+    context '#start_of_next_year' do
+      should 'return 2012-04-06 if tax-year is 2011-12' do
+        @calculator.tax_year = '2011-12'
+
+        assert_equal Date.new(2012, 4, 6), @calculator.start_of_next_tax_year
+      end
+
+      should 'return 2013-04-06 if tax-year is 2012-13' do
+        @calculator.tax_year = '2012-13'
+
+        assert_equal Date.new(2013, 4, 6), @calculator.start_of_next_tax_year
+      end
+      should 'return 2014-04-06 if tax-year is 2013-14' do
+        @calculator.tax_year = '2013-14'
+
+        assert_equal Date.new(2014, 4, 6), @calculator.start_of_next_tax_year
+      end
+      should 'return 2015-04-06 if tax-year is 2014-15' do
+        @calculator.tax_year = '2014-15'
+
+        assert_equal Date.new(2015, 4, 6), @calculator.start_of_next_tax_year
+      end
+    end
+
     context "valid_filing_date?" do
       should "be valid if filing date is on or after start of next tax year" do
         @calculator.filing_date = @calculator.start_of_next_tax_year


### PR DESCRIPTION
Supersedes #2775


[Trello card](https://trello.com/c/mZHU8O0K/202-add-2015-2016-tax-year-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments)

## Description 

The GOV.UK service for estimating the penalty for late submission of an Self Assessment return or late payment of an  Self Assessment bill needs to be set up to show returns for the 6 April 2015 to 5 April 2016 tax year.


## Factcheck

[Preview link](https://smart-answers-pr-2782.herokuapp.com/estimate-self-assessment-penalties/y)
[GOV.UK](https://www.gov.uk/estimate-self-assessment-penalties/y)

## Expected changes 

* 2015-2016 option will be available for selection


### Before 

![screen shot 2016-10-07 at 11 20 18](https://cloud.githubusercontent.com/assets/84896/19186835/0d83e238-8c80-11e6-836a-730b7b7079ff.png)


### After 

![screen shot 2016-10-07 at 11 19 20](https://cloud.githubusercontent.com/assets/84896/19186810/f5bfb230-8c7f-11e6-9159-134f497060bf.png)

