### PR TITLE
Change democratic-republic-of-the-congo slug in help-if-you-are-arrested-abroad

### DIFF
--- a/lib/data/prisoner_packs.yml
+++ b/lib/data/prisoner_packs.yml
@@ -119,7 +119,7 @@
   lawyer: /government/publications/colombia-list-of-lawyers
 - slug: comoros
 - slug: congo
-- slug: democratic-republic-of-congo
+- slug: democratic-republic-of-the-congo
   pdf: /government/publications/democratic-republic-of-congo-prisoner-pack
   lawyer: /government/publications/democratic-republic-of-congo-list-of-lawyers
 - slug: costa-rica

--- a/test/artefacts/help-if-you-are-arrested-abroad/democratic-republic-of-the-congo.txt
+++ b/test/artefacts/help-if-you-are-arrested-abroad/democratic-republic-of-the-congo.txt
@@ -1,0 +1,76 @@
+Help for British nationals arrested abroad
+
+$!
+The Foreign & Commonwealth Office (FCO) or the nearest British embassy, high commission or consulate can give advice on local laws and procedures, contact friends and family and help find a lawyer.
+$!
+
+%
+The person arrested or detained should contact the nearest British embassy, high commission or consulate as soon as possible - the police might also do this on their behalf.
+%
+
+The British embassy, high commission or consulate will contact the arrested person within 24 hours of being told about the arrest and try to visit them as soon as possible.
+
+The British consulate will also arrange for friends and family to be told:
+
+- the person’s been arrested
+- details of the arrest
+- contact details for the arrested person
+
+^The FCO can only give out this information if the arrested person has given their permission.^
+
+##Help available
+
+The FCO and British consulate can offer help to arrested persons or prisoners. This includes:
+
+- providing general information about the country, prison conditions and the local legal system (including if legal aid is available)
+- providing a list of local lawyers and interpreters
+- telling the police or prison doctor about any medical or dental problems with the arrested person’s permission
+- helping with complaints about the police or prison (eg, ill treatment, personal safety, discrimination) with the arrested person or prisoner’s permission
+- sending money to the arrested person from their family
+- sending messages between the arrested person and their family
+- putting the prisoners in touch with the charity [Prisoners Abroad](http://www.prisonersabroad.org.uk "Prisoners Abroad"){:rel="external"}
+- helping British prisoners apply for a transfer to UK where possible
+- visiting prisoners when needed
+
+##Download prisoner packs and other helpful information
+
+The FCO has produced guides explaining the legal and prison system in different countries for British nationals arrested abroad.
+
+- [Prisoner pack for Democratic Republic Of The Congo](/government/publications/democratic-republic-of-congo-prisoner-pack)
+
+- [English speaking lawyers and translators/interpreters in Democratic Republic Of The Congo](/government/publications/democratic-republic-of-congo-list-of-lawyers)
+
+Read more about how the FCO can help someone arrested abroad.
+
+- [Support for British nationals](/government/publications/support-for-british-nationals-abroad-a-guide)
+- [In prison abroad](/government/publications/arrest-or-detention)
+
+- [Transfers back to the UK](/government/publications/arrest-or-detention)
+
+##What the FCO and British consulate can’t do
+
+The FCO and British consulate won’t be able to:
+
+- get someone out of prison or detention
+- help someone get special treatment
+- offer legal advice, start legal proceedings or investigate a crime
+- pay for any costs as a result of being arrested
+- forward packages sent by friends or family to an arrested person or prisoner
+- prevent authorities from deporting a British national after release
+
+##Dual nationals
+
+The FCO and British consulate can help a dual British national (with a valid British passport) as long as they’re arrested in a country other than the one they hold dual nationality with.
+
+They won’t get involved if someone’s arrested in a country for which they hold a valid passport, unless there’s a special humanitarian reason to do so.
+
+##Other organisations that can help
+
+Further help and advice is available from:
+
+- [Fair Trials International](http://www.fairtrials.net/ "Fair Trials International"){:rel="external"}
+- [Prisoners Abroad](http://www.prisonersabroad.org.uk "Prisoners Abroad"){:rel="external"}
+- [Reprieve](http://www.reprieve.org.uk/ "Reprieve"){:rel="external"}
+
+
+

--- a/test/artefacts/help-if-you-are-arrested-abroad/y.txt
+++ b/test/artefacts/help-if-you-are-arrested-abroad/y.txt
@@ -59,7 +59,7 @@ Which country?
   * curacao: Curacao
   * cyprus: Cyprus
   * czech-republic: Czech Republic
-  * democratic-republic-of-congo: Democratic Republic Of Congo
+  * democratic-republic-of-the-congo: Democratic Republic Of The Congo
   * denmark: Denmark
   * djibouti: Djibouti
   * dominica: Dominica

--- a/test/data/help-if-you-are-arrested-abroad-files.yml
+++ b/test/data/help-if-you-are-arrested-abroad-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: 063a7cc0a031aee1c28787a649809972
-test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml: fa03d5879fb2a45ae5b1be91c0d54673
-test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml: 8c62a6c6ff1e6923f260271378c84ef6
+test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml: f1eebfa389bdbc6d66072366c44f3e02
+test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml: f7a49e2e4be4396b994b461b6d66f62a
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/help_if_you_are_arrested_abroad.govspeak.erb: cb923645274b287ba93af8c7118d7f88
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/_common_downloads.govspeak.erb: a1e2ddafdf6dafb6607a9859d2a63e31
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/_further_links.govspeak.erb: c9d3520db7b56be01240c9dd96bf979d

--- a/test/data/help-if-you-are-arrested-abroad-files.yml
+++ b/test/data/help-if-you-are-arrested-abroad-files.yml
@@ -9,4 +9,4 @@ lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_one_gener
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_three_syria.govspeak.erb: 0b22adb7456839f2445b2f7c36936d84
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/questions/which_country.govspeak.erb: 913b5637a2814cbd529affffc55b1f72
 lib/smart_answer/calculators/arrested_abroad.rb: 6b127f4dbdfd258cc9be5957c0f43352
-lib/data/prisoner_packs.yml: 821fb0e9f893354f647d5b97453ce322
+lib/data/prisoner_packs.yml: f010409518f8ba5d347da01a80602bfa

--- a/test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml
+++ b/test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml
@@ -4,6 +4,7 @@
 - andorra # no additional download links
 - austria # additional download links: pdf, lawyer, benefits, prison, consul
 - cyprus  # has region links
+- democratic-republic-of-the-congo
 - greece  # additional download links: police
 - spain   # additional download links: pdf, lawyer, benefits, judicial
 - syria   # outcome: answer_three_syria

--- a/test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml
+++ b/test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml
@@ -21,6 +21,11 @@
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
+  - democratic-republic-of-the-congo
+  :next_node: :answer_one_generic
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
   - greece
   :next_node: :answer_one_generic
   :outcome_node: true

--- a/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
+++ b/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
@@ -7,7 +7,7 @@ class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    @location_slugs = %w(aruba belgium greece iran syria)
+    @location_slugs = %w(aruba belgium greece iran syria democratic-republic-of-the-congo)
     stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::HelpIfYouAreArrestedAbroadFlow
   end
@@ -39,9 +39,9 @@ class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
     end # context: country without specific info
 
     context "Answering with a country that has specific downloads / information" do
-      context "Answering Belgium" do
+      context "Answering Democratic Republic of the Congo" do
         setup do
-          add_response :belgium
+          add_response :"democratic-republic-of-the-congo"
         end
 
         should "take the user to the generic answer" do


### PR DESCRIPTION
Trello card: https://trello.com/c/dw8qEhV3

## Motivation

The slug for Democratic Republic of the Congo changed from democratic-republic-of-congo to democratic-republic-of-the-congo has changed in whitehall admin.

We need to change every occurrence of democratic-republic-of-congo in help-if-you-are-arrested-abroad to democratic-republic-of-the-congo so that the links to the prisoner-packs are displayed.

## Factcheck
Not required - This is a live bug.
[help-if-you-are-arrested-abroad](https://smart-answers-pr-2786.herokuapp.com/help-if-you-are-arrested-abroad/y/democratic-republic-of-the-congo)

## Expected Changes
[URL on GOV.UK](https://www.gov.uk/help-if-you-are-arrested-abroad/y/democratic-republic-of-the-congo)

### Before

![screen shot 2016-10-19 at 16 09 50](https://cloud.githubusercontent.com/assets/5793815/19524693/7d50fbb0-9616-11e6-9002-7774a3c38cae.png)

### After
![screen shot 2016-10-19 at 16 14 48](https://cloud.githubusercontent.com/assets/5793815/19524909/30a9e60e-9617-11e6-8710-1932f960aa9f.png)
