### PR TITLE
Change democratic-republic-of-the-congo slug in overseas-passports

### DIFF
--- a/lib/data/passport_data.yml
+++ b/lib/data/passport_data.yml
@@ -477,7 +477,7 @@ congo:
   applying: 10 weeks
   replacing: 8 weeks
   optimistic_processing_time?: false
-democratic-republic-of-congo:
+democratic-republic-of-the-congo:
   type: ips_application_1
   group: ips_documents_group_3
   app_form: hmpo_1_application_form

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/adult.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/adult.txt
@@ -59,7 +59,7 @@ Which country were you born in?
   * curacao: Curacao
   * cyprus: Cyprus
   * czech-republic: Czech Republic
-  * democratic-republic-of-congo: Democratic Republic Of Congo
+  * democratic-republic-of-the-congo: Democratic Republic Of The Congo
   * denmark: Denmark
   * djibouti: Djibouti
   * dominica: Dominica

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/adult/afghanistan.txt
@@ -1,0 +1,61 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £102.86 |
+| Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- the passport numbers of both parents and their dates and place of birth, and in some cases the same details of grandparents
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/adult/south-africa.txt
@@ -1,0 +1,62 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £102.86 |
+| Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- the passport numbers of both parents and their dates and place of birth, and in some cases the same details of grandparents
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/adult/turks-and-caicos-islands.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/adult/turks-and-caicos-islands.txt
@@ -1,0 +1,61 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £102.86 |
+| Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- the passport numbers of both parents and their dates and place of birth, and in some cases the same details of grandparents
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/child/afghanistan.txt
@@ -1,0 +1,60 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £72.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- the passport numbers of both parents and their dates and place of birth, and in some cases the same details of grandparents
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/child/south-africa.txt
@@ -1,0 +1,61 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £72.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- the passport numbers of both parents and their dates and place of birth, and in some cases the same details of grandparents
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/child/turks-and-caicos-islands.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/applying/child/turks-and-caicos-islands.txt
@@ -1,0 +1,60 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £72.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- the passport numbers of both parents and their dates and place of birth, and in some cases the same details of grandparents
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_new/adult.txt
@@ -1,0 +1,61 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £102.86 |
+| Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- your current passport
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_new/child.txt
@@ -1,0 +1,60 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £72.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- your current passport
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/adult/afghanistan.txt
@@ -1,0 +1,61 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £102.86 |
+| Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- your current passport
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/adult/south-africa.txt
@@ -1,0 +1,62 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £102.86 |
+| Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- your current passport
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/adult/turks-and-caicos-islands.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/adult/turks-and-caicos-islands.txt
@@ -1,0 +1,61 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £102.86 |
+| Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- your current passport
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/child/afghanistan.txt
@@ -1,0 +1,60 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £72.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- your current passport
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/child/south-africa.txt
@@ -1,0 +1,61 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £72.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- your current passport
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/child/turks-and-caicos-islands.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/renewing_old/child/turks-and-caicos-islands.txt
@@ -1,0 +1,60 @@
+
+
+## How long it takes
+
+Your application will take **at least** 10 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £72.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- your current passport
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/replacing/adult.txt
@@ -1,0 +1,62 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your declaration form.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £102.86 |
+| Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/democratic-republic-of-the-congo/replacing/child.txt
+++ b/test/artefacts/overseas-passports/democratic-republic-of-the-congo/replacing/child.txt
@@ -1,0 +1,61 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your declaration form.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- HM Passport Office need to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £19.86.
+
+The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £72.86 |
+
+## How to apply
+
+You must apply and pay for your passport online.
+
+Before you start you need:
+
+- 2 identical new photos of you (or your child, if it’s a child passport application)
+- any other current passports issued by other countries
+- a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+You will need to print, sign and post your declaration form at the end.
+
+[Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Getting your passport
+
+Your passport and supporting documents will be delivered separately by courier.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+
+
+

--- a/test/artefacts/overseas-passports/y.txt
+++ b/test/artefacts/overseas-passports/y.txt
@@ -59,7 +59,7 @@ Which country or territory are you in?
   * curacao: Curacao
   * cyprus: Cyprus
   * czech-republic: Czech Republic
-  * democratic-republic-of-congo: Democratic Republic Of Congo
+  * democratic-republic-of-the-congo: Democratic Republic Of The Congo
   * denmark: Denmark
   * djibouti: Djibouti
   * dominica: Dominica

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/overseas-passports.rb: 6d3c353334c76e2fc60e6bbd2c9e63b5
-test/data/overseas-passports-questions-and-responses.yml: 7a8d988ee334ccbd4c3cfe71cb236f2d
-test/data/overseas-passports-responses-and-expected-results.yml: 1ed6f30cf15d5c5efff81b681063cc38
+test/data/overseas-passports-questions-and-responses.yml: c043e6d865e404d51d3c67d6272f7338
+test/data/overseas-passports-responses-and-expected-results.yml: cf2de5faa89c59248d38d706fbaca8a4
 lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb: 839c3312a6404b18de70eaeb8a100c97
 lib/smart_answer_flows/overseas-passports/outcomes/_getting_your_passport.govspeak.erb: 5b0bb88724dcd306f821543584d1d140
 lib/smart_answer_flows/overseas-passports/outcomes/_how_long.govspeak.erb: 4534bc621bd3d7af0ef7edf2fa50d6a1

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -42,7 +42,7 @@ lib/smart_answer_flows/overseas-passports/questions/which_best_describes_you_adu
 lib/smart_answer_flows/overseas-passports/questions/which_best_describes_you_child.govspeak.erb: 61c9f0f7d1960caacc77fad1544cfa26
 lib/smart_answer_flows/overseas-passports/questions/which_country_are_you_in.govspeak.erb: dc6f1404e792f12c110ce248286c167f
 lib/smart_answer_flows/overseas-passports/questions/which_opt.govspeak.erb: 0f629592f57a5ec972f23bf170d37714
-lib/data/passport_data.yml: 9e325030adbca0102f9fba39eeb1e0ad
+lib/data/passport_data.yml: d71c263c84c8f83c2620de62b1da70cb
 lib/smart_answer/calculators/overseas_passports_calculator.rb: 8e58c37d4698c0384525d4fca14c6000
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer/overseas_passports_helper.rb: 07df4cd921e62464c2dc9534b4d8cdf8

--- a/test/data/overseas-passports-questions-and-responses.yml
+++ b/test/data/overseas-passports-questions-and-responses.yml
@@ -7,6 +7,7 @@
 - burundi # send_application_non_uk_visa_renew_new_colour
 - cambodia # getting_your_passport_with_id
 - cuba # passport_costs_ips_cash
+- democratic-republic-of-the-congo
 - falkland-islands # passport_courier_costs_replacing_ips#{ips_number}
 - france # overseas_passports_embassies (organisation)
 - georgia

--- a/test/data/overseas-passports-responses-and-expected-results.yml
+++ b/test/data/overseas-passports-responses-and-expected-results.yml
@@ -1268,6 +1268,187 @@
   :outcome_node: true
 - :current_node: :which_country_are_you_in?
   :responses:
+  - democratic-republic-of-the-congo
+  :next_node: :renewing_replacing_applying?
+  :outcome_node: false
+- :current_node: :renewing_replacing_applying?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_new
+  :next_node: :child_or_adult_passport?
+  :outcome_node: false
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_new
+  - adult
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_new
+  - child
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :renewing_replacing_applying?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  :next_node: :child_or_adult_passport?
+  :outcome_node: false
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  - adult
+  :next_node: :country_of_birth?
+  :outcome_node: false
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  - adult
+  - afghanistan
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  - adult
+  - south-africa
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  - adult
+  - turks-and-caicos-islands
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  - child
+  :next_node: :country_of_birth?
+  :outcome_node: false
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  - child
+  - afghanistan
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  - child
+  - south-africa
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - renewing_old
+  - child
+  - turks-and-caicos-islands
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :renewing_replacing_applying?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  :next_node: :child_or_adult_passport?
+  :outcome_node: false
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  - adult
+  :next_node: :country_of_birth?
+  :outcome_node: false
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  - adult
+  - afghanistan
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  - adult
+  - south-africa
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  - adult
+  - turks-and-caicos-islands
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  - child
+  :next_node: :country_of_birth?
+  :outcome_node: false
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  - child
+  - afghanistan
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  - child
+  - south-africa
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - democratic-republic-of-the-congo
+  - applying
+  - child
+  - turks-and-caicos-islands
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :renewing_replacing_applying?
+  :responses:
+  - democratic-republic-of-the-congo
+  - replacing
+  :next_node: :child_or_adult_passport?
+  :outcome_node: false
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - democratic-republic-of-the-congo
+  - replacing
+  - adult
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - democratic-republic-of-the-congo
+  - replacing
+  - child
+  :next_node: :ips_application_result_online
+  :outcome_node: true
+- :current_node: :which_country_are_you_in?
+  :responses:
   - falkland-islands
   :next_node: :renewing_replacing_applying?
   :outcome_node: false

--- a/test/integration/smart_answer_flows/overseas_passports_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_test.rb
@@ -7,7 +7,7 @@ class OverseasPassportsTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan laos malta nepal nigeria pakistan pitcairn-island saint-barthelemy saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha st-maarten st-martin tajikistan tanzania timor-leste turkey turkmenistan ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
+    @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo democratic-republic-of-the-congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan laos malta nepal nigeria pakistan pitcairn-island saint-barthelemy saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha st-maarten st-martin tajikistan tanzania timor-leste turkey turkmenistan ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
     stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::OverseasPassportsFlow
   end
@@ -367,6 +367,16 @@ class OverseasPassportsTest < ActiveSupport::TestCase
       add_response 'adult'
       add_response 'united-kingdom'
       assert_current_node :ips_application_result
+    end
+  end # Congo
+
+  context "answer Democratic Republic of the Congo, replacement, adult passport" do
+    should "give the result with custom phrases" do
+      add_response 'democratic-republic-of-the-congo'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result_online
     end
   end # Congo
 

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -460,6 +460,5 @@ class RegisterADeathTest < ActiveSupport::TestCase
         assert_equal '/government/publications/democratic-republic-of-congo-list-of-lawyers', current_state.calculator.translator_link_url
       end
     end
-
   end # Overseas
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/i1GJOLKF

## Motivation

A next-node not found error was raised in errbit for overseas-passports: https://errbit.publishing.service.gov.uk/apps/533c35ae0da1159384044f5f/problems/5807ef5765786313be491e00

overseas-passports matches the country that the user has selected to the country slugs passport_data.yml.  The list of countries and their slugs (first question) is populated from Whitehall admin. Recently the slug for Democratic Republic of the Congo changed from democratic-republic-of-congo to democratic-republic-of-the-congo, but we had not updated our own country list in passport_data.yml.

We need to change every occurrence of democratic-republic-of-congo in overseas-passports to democratic-republic-of-the-congo.

## Factcheck
Not required - This is a live bug.
[overseas-passports](https://smart-answers-pr-2787.herokuapp.com/overseas-passports/y/portugal/applying/adult/democratic-republic-of-the-congo)

## Expected Changes
[URL on GOV.UK](https://www.gov.uk/overseas-passports/y/portugal/applying/adult/democratic-republic-of-the-congo)

### Before
![screen shot 2016-10-20 at 10 28 04](https://cloud.githubusercontent.com/assets/5793815/19554311/e6b912e2-96af-11e6-90a8-96fce78b866b.png)

### After
![screen shot 2016-10-20 at 10 28 54](https://cloud.githubusercontent.com/assets/5793815/19554336/094a07da-96b0-11e6-8f02-22d2c6ca7c23.png)
