### PR TITLE
Changes to PIP Checker Middle Group

### DIFF
--- a/lib/smart_answer/calculators/pip_dates.rb
+++ b/lib/smart_answer/calculators/pip_dates.rb
@@ -12,7 +12,7 @@ module SmartAnswer::Calculators
     end
 
     def in_middle_group?
-      self.dob > GROUP_65_CUTOFF && self.dob < MIDDLE_GROUP_CUTOFF
+      self.dob > GROUP_65_CUTOFF && self.dob <= 16.years.ago
     end
 
     def turning_16_before_oct_2013?

--- a/test/artefacts/pip-checker/no/2000-04-05.txt
+++ b/test/artefacts/pip-checker/no/2000-04-05.txt
@@ -1,8 +1,8 @@
 
 
-$!You can’t claim Personal Independence Payment (PIP) because you’re under 16.$!
+$!You can claim [Personal Independence Payment (PIP)](/pip).$!
 
-You can claim [Disability Living Allowance (DLA)](/disability-living-allowance-children) instead, until you turn 16.
+PIP is replacing Disability Living Allowance (DLA) for people aged 16 to 64.
 
 *[PIP]: Personal Independence Payment
 *[DLA]: Disability Living Allowance

--- a/test/artefacts/pip-checker/yes/2000-04-05.txt
+++ b/test/artefacts/pip-checker/yes/2000-04-05.txt
@@ -1,21 +1,29 @@
 
 
-$! You can’t currently claim Personal Independence Payment (PIP) because you’re under 16.$!
 
-If you’re still getting [Disability Living Allowance (DLA)](/disability-living-allowance-children) at 16 you’ll be sent a letter inviting you to apply for PIP:
+When you’ll be invited to claim Personal Independence Payment (PIP) depends on when your [Disability Living Allowance (DLA)](/dla-disability-living-allowance-benefit) ends. You’ll also be invited to claim PIP if your needs change before your DLA ends.
 
-* shortly after your 16th birthday
+## Your DLA ends before September 2017
 
-* when you leave hospital, if you were in hospital on your 16th birthday
+You’ll be told 20 weeks before your DLA ends and invited to claim PIP.
 
-* about 20 weeks before your DLA award ends, if you were awarded DLA under the rules for people who are terminally ill
+Contact the [Disability Benefits helpline](/disability-benefits-helpline) if your DLA payment is due to end in the next 4 weeks and you haven’t received a letter about making a new claim.
 
-You must claim PIP within 28 days of the date on the letter.
+^Your payment may stop if you don’t contact the helpline.^
 
-You’ll continue to receive DLA until your PIP claim has been assessed.
+##Your DLA ends after September 2017 or your DLA award has no end date
+
+You can be contacted any time to claim PIP. This includes if you have a long-term award of DLA or an indefinite award with no end date.
+
+Not everyone will be contacted to claim PIP right away. You’ll continue to get DLA until Department for Work and Pensions (DWP) writes to you about when it will end.
+
+##If your needs change
+
+You must let DWP know if your [care or mobility needs change](/dla-disability-living-allowance-benefit/eligibility). You’ll be invited to claim PIP.
 
 *[DLA]: Disability Living Allowance
 *[PIP]: Personal Independence Payment
+*[DWP]: Department for Work and Pensions
 
 
 

--- a/test/data/configurations.yml
+++ b/test/data/configurations.yml
@@ -17,3 +17,5 @@
     :current_time: 2016-10-01
   "minimum-wage-calculator-employers":
     :current_time: 2016-10-01
+  "pip-checker":
+    :current_time: 2016-04-05

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -12,4 +12,4 @@ lib/smart_answer_flows/pip-checker/outcomes/under_16.govspeak.erb: 39378651df7f8
 lib/smart_answer_flows/pip-checker/pip_checker.govspeak.erb: 05500842dad33cd660d3387925a3d5e9
 lib/smart_answer_flows/pip-checker/questions/are_you_getting_dla.govspeak.erb: 0668b501c4ad913dbbf0e8ffc8af59bb
 lib/smart_answer_flows/pip-checker/questions/what_is_your_dob.govspeak.erb: 8a7f608d4b124caed3c17cdbbd6fa58b
-lib/smart_answer/calculators/pip_dates.rb: 932656471b713a272fcaeae8451b4aab
+lib/smart_answer/calculators/pip_dates.rb: 083c4d5f3679c0060edcb35ac18e3150

--- a/test/integration/smart_answer_flows/pip_checker_test.rb
+++ b/test/integration/smart_answer_flows/pip_checker_test.rb
@@ -55,29 +55,29 @@ class PIPCheckerTest < ActiveSupport::TestCase
   context "getting DLA" do
     setup do
       add_response 'yes'
-      Timecop.travel('2014-02-03')
+      Timecop.travel('2013-02-03')
     end
 
-    should "ask for your date of birth (03/03/14)" do
+    should "ask for your date of birth (03/03/13)" do
       assert_current_node :what_is_your_dob?
     end
 
-    should "be over 65 by 2013, if born on or before 08-04-1948 (03/03/14)" do
+    should "be over 65 by 2013, if born on or before 08-04-1948 (03/03/13)" do
       add_response "1948-04-08"
       assert_current_node :over_65_in_2013
     end
 
-    should "qualify for pip, if born between 08-06-1997 and 06-10-1997 (03/03/14)" do
+    should "qualify for pip, if born between 08-06-1997 and 06-10-1997 (03/03/13)" do
       add_response '1997-06-08'
       assert_current_node :qualifies_for_pip
     end
 
-    should "qualify for pip at 16, if born on or after 07-10-1997 (03/03/14)" do
+    should "qualify for pip at 16, if born on or after 07-10-1997 (03/03/13)" do
       add_response '1997-10-07'
       assert_current_node :qualifies_for_pip_at_16
     end
 
-    should "qualify for pip, if born between 09-04-1948 and 07-04-1997 (03/03/14)" do
+    should "qualify for pip, if born between 09-04-1948 and 07-04-1997 (03/03/13)" do
       add_response "1996-05-24"
       assert_current_node :qualifies_for_pip
     end

--- a/test/unit/calculators/pip_dates_test.rb
+++ b/test/unit/calculators/pip_dates_test.rb
@@ -19,18 +19,19 @@ module SmartAnswer::Calculators
 
       should "be false if born after 1948-04-08" do
         @calc.dob = Date.parse('1948-04-09')
-        assert ! @calc.in_group_65?
+        refute @calc.in_group_65?
       end
     end
 
     context "in_middle_group?" do
       setup do
         @calc = PIPDates.new
+        Timecop.travel('2013-04-07')
       end
 
       should "be false if born on 1948-04-08" do
         @calc.dob = Date.parse('1948-04-08')
-        assert ! @calc.in_middle_group?
+        refute @calc.in_middle_group?
       end
 
       should "be true if born just after 1948-04-08" do
@@ -45,7 +46,7 @@ module SmartAnswer::Calculators
 
       should "be false if born on 1997-04-08" do
         @calc.dob = Date.parse('1997-04-08')
-        assert ! @calc.in_middle_group?
+        refute @calc.in_middle_group?
       end
     end
 
@@ -71,7 +72,7 @@ module SmartAnswer::Calculators
 
       should "be false if under 16 on 7th Oct 2013" do
         @calc.dob = Date.parse('1997-10-08')
-        assert ! @calc.turning_16_before_oct_2013?
+        refute @calc.turning_16_before_oct_2013?
       end
     end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/a20W0vWM/375-pip-checker-fixing-logic-for-17-and-18-year-old-outcomes)

## Description 

The aim of this PR is to make amends to the middle group in the pip-checker smart answer to cater for users who recently turned 16.

## Factcheck

[Preview link](//smart-answers-pr-2790.herokuapp.com//pip-checker/y/yes/1998-07-06)
[GOVUK](https://www.gov.uk/pip-checker/y/yes/1998-07-06)


### Expected changes
* User who recently turned 16 now get the expected outcomes


### Before
![screen shot 2016-10-20 at 12 50 46](https://cloud.githubusercontent.com/assets/84896/19558732/037d4df8-96c4-11e6-82d7-c4d25bfaf1b7.png)


### After

![screen shot 2016-10-20 at 12 51 34](https://cloud.githubusercontent.com/assets/84896/19558738/08fbd4e8-96c4-11e6-8640-fbc065270610.png)
