### PR TITLE
Change start button text for benchmarking

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,15 @@ module ApplicationHelper
       register-a-death
     ).exclude?(name)
   end
+
+  def start_button
+    case @name.to_s
+    when "overseas-passports"
+      "Continue"
+    when "calculate-your-child-maintenance"
+      "Calculate your child maintenance"
+    else
+      "Start now"
+    end
+  end
 end

--- a/app/views/smart_answers/_landing.html.erb
+++ b/app/views/smart_answers/_landing.html.erb
@@ -18,7 +18,7 @@
       <div class="intro">
         <%= start_node.body %>
         <p class="get-started">
-          <a rel="nofollow" href="<%= smart_answer_path(@name, started: 'y') %>" class="big button">Start now</a>
+          <a rel="nofollow" href="<%= smart_answer_path(@name, started: 'y') %>" class="big button"><%= start_button %></a>
         </p>
       </div>
       <%= start_node.post_body %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/BC8KhGuK/359-change-smart-answer-button-text-for-gov-uk-benchmarking)

## Description

This PR changes the start button text for the benchmarking
exercise, due to start on the 24th.

A helper (start_button) is defined that caters for the change in the
start button text.

The following smarts-answer (and button text) are affect by this PR:

- Overseas passport => "Continue"
- Calculate your child maintenance => "Calculate your child maintenance"

## Factcheck Overseas passport
[Preview link](//smart-answers-pr-2792.herokuapp.com/overseas-passports)
[GOVUK](//gov.uk/overseas-passports)

### Expected changes
* Change in start button text for Overseas passport and Calculate your child maintenance smart answers

### Before
![screen shot 2016-10-20 at 16 02 11](https://cloud.githubusercontent.com/assets/84896/19565404/a03d65e6-96de-11e6-9ade-6aaccffa8625.png)

### After

![screen shot 2016-10-20 at 16 02 05](https://cloud.githubusercontent.com/assets/84896/19565386/96cb7868-96de-11e6-8d6b-71fdd4934354.png)


## Factcheck Calculate your child maintenance

[Preview link](//smart-answers-pr-2792.herokuapp.com/calculate-your-child-maintenance)
[GOVUK](//gov.uk/calculate-your-child-maintenance)

### Expected changes
* Change in start button text for Overseas passport and Calculate your child maintenance smart answers

### Before
![screen shot 2016-10-20 at 16 03 25](https://cloud.githubusercontent.com/assets/84896/19565450/cade9b30-96de-11e6-9c04-5dc37da1a42e.png)


### After

![screen shot 2016-10-20 at 16 03 17](https://cloud.githubusercontent.com/assets/84896/19565459/d04bc2e6-96de-11e6-8fbe-1e5e100b7a0d.png)
