### PR TITLE
Refactor consumption of API response via gds-api-adapter gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :test do
   gem 'capybara', '2.1.0'
   gem 'ci_reporter'
   gem 'minitest', '~> 5.1'
+  gem 'minitest-focus', '~> 1.1', '>= 1.1.2'
   gem 'mocha', '1.1.0', require: false
   gem 'poltergeist', '1.6.0'
   gem 'shoulda', '~> 3.5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~> 4.2.7'
 
 gem 'airbrake', '4.1.0'
 gem 'ast'
-gem 'gds-api-adapters', '~> 36.4.0'
+gem 'gds-api-adapters', '~> 37.2.0'
 gem 'govspeak', '~> 3.3.0'
 gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 gem 'govuk_frontend_toolkit', '4.14.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.1)
+    minitest-focus (1.1.2)
+      minitest (>= 4, < 6)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
@@ -281,6 +283,7 @@ DEPENDENCIES
   lrucache (= 0.1.4)
   method_source
   minitest (~> 5.1)
+  minitest-focus (~> 1.1, >= 1.1.2)
   mocha (= 1.1.0)
   nokogiri
   parser

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (36.4.1)
+    gds-api-adapters (37.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -269,7 +269,7 @@ DEPENDENCIES
   binding_of_caller
   capybara (= 2.1.0)
   ci_reporter
-  gds-api-adapters (~> 36.4.0)
+  gds-api-adapters (~> 37.2.0)
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -22,7 +22,10 @@ class WorldLocation
 
   def self.find(location_slug)
     cache_fetch("find_#{location_slug}") do
-      data = Services.worldwide_api.world_location(location_slug)
+      response = Services.worldwide_api.world_location(location_slug)
+      if response
+        data = OpenStruct.new(response.to_hash)
+      end
       self.new(data) if data
     end
   end
@@ -53,16 +56,21 @@ class WorldLocation
     @data = data
   end
 
+  def slug
+    self.details["slug"]
+  end
+
   def ==(other)
-    other.is_a?(self.class) && other.slug == self.slug
+    other.is_a?(self.class) && other.slug == slug
   end
 
   def_delegators :@data, :title, :details
-  def_delegators :details, :slug
+  # def_delegators :details, :slug
   alias_method :name, :title
 
   def organisations
-    @organisations ||= WorldwideOrganisation.for_location(self.slug)
+    # binding.pry
+    @organisations ||= WorldwideOrganisation.for_location(slug)
   end
 
   def fco_organisation

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -1,7 +1,7 @@
 require 'lrucache'
 
 class WorldLocation
-  extend Forwardable
+  attr_reader :title, :details, :slug
 
   def self.cache
     @cache ||= LRUCache.new(max_size: 250, soft_ttl: 24.hours, ttl: 1.week)
@@ -13,8 +13,11 @@ class WorldLocation
 
   def self.all
     cache_fetch("all") do
-      world_locations = Services.worldwide_api.world_locations.with_subsequent_pages.map do |l|
-        new(l) if l.format == "World location" && l.details && l.details.slug.present?
+      world_locations = Services.worldwide_api.world_locations.with_subsequent_pages.map do |response|
+        location = response.to_hash
+        if valid_world_location_format?(location)
+          self.new(location)
+        end
       end
       world_locations.compact
     end
@@ -22,13 +25,16 @@ class WorldLocation
 
   def self.find(location_slug)
     cache_fetch("find_#{location_slug}") do
-      response = Services.worldwide_api.world_location(location_slug)
-      if response
-        data = OpenStruct.new(response.to_hash)
-      end
-      self.new(data) if data
+      location = Services.worldwide_api.world_location(location_slug)&.to_hash
+      self.new(location) if location
     end
   end
+
+  def self.valid_world_location_format?(location)
+    location.is_a?(Hash) && location["format"] == "World location" &&
+      location["details"].is_a?(Hash) && location["details"]["slug"].present?
+  end
+  private_class_method :valid_world_location_format?
 
   # Fetch a value from the cache.
   #
@@ -52,25 +58,20 @@ class WorldLocation
     end
   end
 
-  def initialize(data)
-    @data = data
+  def initialize(location)
+    @title = location.fetch("title", "")
+    @details = location.fetch("details", {})
+    @slug = @details.fetch("slug", "")
   end
 
-  def slug
-    self.details["slug"]
-  end
-
-  def ==(other)
-    other.is_a?(self.class) && other.slug == slug
-  end
-
-  def_delegators :@data, :title, :details
-  # def_delegators :details, :slug
   alias_method :name, :title
 
+  def ==(other)
+    other.is_a?(self.class) && other.slug == @slug
+  end
+
   def organisations
-    # binding.pry
-    @organisations ||= WorldwideOrganisation.for_location(slug)
+    @organisations ||= WorldwideOrganisation.for_location(@slug)
   end
 
   def fco_organisation

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,1 +1,0 @@
-GdsApi.config.always_raise_for_not_found = false

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -42,12 +42,14 @@ module SmartAnswer::Calculators
     end
 
     def london?(postcode)
-      area(postcode).any? { |result| result[:type] == 'EUR' && result[:name] == "London" }
+      area(postcode).any? do |result|
+        result["type"] == "EUR" && result["name"] == "London"
+      end
     end
 
     def area(postcode)
-      response = Services.imminence_api.areas_for_postcode(postcode)
-      (response&.results || {})
+      response = Services.imminence_api.areas_for_postcode(postcode)&.to_hash
+      OpenStruct.new(response).results || []
     end
 
   private

--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -9,11 +9,11 @@ module SmartAnswer::Calculators
     end
 
     def countries_for_postcode
-      areas_for_postcode.map(&:country_name).uniq
+      areas_for_postcode.map { |results| results["country_name"] }.uniq
     end
 
     def areas_for_postcode
-      Services.imminence_api.areas_for_postcode(postcode).results
+      Services.imminence_api.areas_for_postcode(postcode).to_hash["results"]
     end
   end
 end

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -38,4 +38,4 @@ lib/smart_answer_flows/benefit-cap-calculator/questions/widowed_parent_amount.go
 lib/smart_answer_flows/benefit-cap-calculator/questions/widows_aged_amount.govspeak.erb: fdeaf95afd6103b96e4e05291650277d
 lib/smart_answer_flows/benefit-cap-calculator/questions/working_tax_credit.govspeak.erb: d96c2ff97c1bb068389fbefc25b9ed1a
 lib/data/benefit_cap_data.yml: 8650b5c0937d03a96dc086b7c68d0b96
-lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb: 3eaf4ec2cae400ab374dead3e00be9f4
+lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb: 45fe15f6690f8d7d6698021c331b6786

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -31,4 +31,4 @@ lib/smart_answer_flows/landlord-immigration-check/questions/right_to_abode.govsp
 lib/smart_answer_flows/landlord-immigration-check/questions/tenant_country.govspeak.erb: a28062a1e9cb019d012fb962524130ee
 lib/smart_answer_flows/landlord-immigration-check/questions/tenant_over_18.govspeak.erb: c4a270709e77da5aff8c4e50aa56e905
 lib/smart_answer_flows/landlord-immigration-check/questions/time_limited_to_remain.govspeak.erb: 05c03a6a5cc9e07c3816a446cdc1c6f3
-lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: 8f94f99690138ede5c134b870c983489
+lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: ae7170f4ec47359b982cbe107ef03cbb

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -211,7 +211,7 @@ class WorldLocationTest < ActiveSupport::TestCase
     should "allow accessing required top-level attributes" do
       assert_equal "Rohan", @location.title
       assert_equal "Rohan", @location.name # alias for title
-      assert_equal 'rohan', @location.details.slug
+      assert_equal 'rohan', @location.slug
     end
 
     should "allow accessing required details attributes" do


### PR DESCRIPTION
Related to #2761

[Trello card](https://trello.com/c/Gduv7tZL/355-upgrade-gds-adapters-to-latest-version-in-smart-answers)


## Why? 

The reason for these changes is to reduce the occurrence of error-prone nil response from OpenStruct objects that were previously returned by the gds-api-adapters. OpenStruct returns nil even when an attribute doesn’t exist by default, which is confusing and error-prone (and makes the code more complicated to debug).

## Description

This PR makes changes to the following api calls: 
- worldwide_api
- imminence_api

Changes made within affect:
- mainly how the response is consumed. 
- a few cosmetic changes (mostly renaming for clarity)
- fix of lint errors 
- regression artefacts

**NB:**
Previously a response object was actually returned (pre gds-api-adapter changes 37.x.x ). Following the recent changes, response are returned as hashes (with the help of the new to_hash message).
