### PR TITLE
Changed Portugal link to list of translators

### DIFF
--- a/lib/data/translators.yml
+++ b/lib/data/translators.yml
@@ -54,7 +54,7 @@ nepal: /government/publications/nepal-list-of-lawyers
 netherlands: /government/publications/netherlands-list-of-lawyers
 nicaragua: /government/publications/nicaragua-list-of-lawyers
 paraguay: /government/publications/list-of-english-speaking-lawyers-and-translators-in-paraguay
-portugal: /government/publications/portugal-list-of-lawyers
+portugal: /government/publications/portugal-list-of-translators-and-interpreters
 russia: /government/publications/russia-list-of-lawyers
 san-marino: /government/publications/italy-list-of-lawyers
 serbia: /government/publications/list-of-translators-and-interpreters-in-serbia


### PR DESCRIPTION
https://trello.com/c/aNRpoQck/330-register-a-death-wrong-link
https://govuk.zendesk.com/agent/tickets/1399127

CHANGED
portugal: /government/publications/portugal-list-of-lawyers

TO
portugal: /government/publications/portugal-list-of-translators-and-interpreters

REASON
The link on the Portugal outcome says 'Use an approved translator', but the link was going to a list of lawyers.

NOTE
Many of the other country outcomes also have a link to lawyers instead of translators. In many cases, this is correct because there isn't a dedicated list of translators for that country, because

- users need to go to lawyers that offer a translation service instead
- many embassies haven't created a list of translators

We also need to look into whether the content on the outcome could do a better job of explaining that users can go to lawyers or translators.

So for now, I'm changing this Portugal link only. But I'll create a new ticket to look into the above. (And hook up with team 4 because of a related ticket that's been closed: https://trello.com/c/hcwQFA0x/95-register-a-birth-abroad-lawyer-translator-link-improvement)