### PR TITLE
Move environment variables to test helper

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -19,8 +19,6 @@ git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-sc
 export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
 
 bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment
-export GOVUK_APP_DOMAIN=dev.gov.uk
-export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 
 export DISPLAY=:99
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 
 ENV["RAILS_ENV"] = "test"
+ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
+
 require File.expand_path('../../config/environment', __FILE__)
 
 if ENV["TEST_COVERAGE"]

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -7,8 +7,8 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
   end
 
   test 'sending item to content store' do
-    draft_request = stub_request(:put, "http://publishing-api.dev.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685")
-    publishing_request = stub_request(:post, "http://publishing-api.dev.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685/publish")
+    draft_request = stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685")
+    publishing_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685/publish")
 
     presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: nil))
 

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PanopticonRegistererTest < ActiveSupport::TestCase
   test 'sending item to panopticon' do
-    request = stub_request(:put, %r[http://panopticon.dev.gov.uk/])
+    request = stub_request(:put, %r[https://panopticon.test.gov.uk/])
     flow_presenters = [OpenStruct.new, OpenStruct.new]
 
     silence_logging do
@@ -13,7 +13,7 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
   end
 
   test 'sending correct data to panopticon' do
-    stub_request(:put, "http://panopticon.dev.gov.uk/artefacts/a-smart-answer.json")
+    stub_request(:put, "https://panopticon.test.gov.uk/artefacts/a-smart-answer.json")
 
     registerable = OpenStruct.new(
       slug: 'a-smart-answer',
@@ -27,7 +27,7 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
 
     assert_requested(
       :put,
-      "http://panopticon.dev.gov.uk/artefacts/a-smart-answer.json",
+      "https://panopticon.test.gov.uk/artefacts/a-smart-answer.json",
       body: {
         slug: "a-smart-answer",
         content_id: 'be9adf07-ce73-468e-be81-31716b4492f2',


### PR DESCRIPTION
These two environment variables need to live in the test helper so that they're set every time, regardless wether or not the test is running on CI.

Also, it's better to use `test.gov.uk`, since it won't exist and won't cause inadvertent real requests.