### PR TITLE
Use content store for breadcrumbs, sidebar & metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'uglifier'
 gem 'uk_postcode', '~> 1.0.1'
 gem 'unicorn', '4.8.3'
 gem 'rails_stdout_logging'
+gem 'govuk_navigation_helpers', '~> 2.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
+    govuk_navigation_helpers (2.0.0)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -273,6 +274,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
   govuk_frontend_toolkit (= 4.14.0)
+  govuk_navigation_helpers (~> 2.0)
   htmlentities (~> 4)
   json
   logstasher (= 0.4.8)
@@ -300,9 +302,6 @@ DEPENDENCIES
   uk_postcode (~> 1.0.1)
   unicorn (= 4.8.3)
   webmock (= 1.20.4)
-
-RUBY VERSION
-   ruby 2.3.0p0
 
 BUNDLED WITH
    1.13.1

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,5 @@
 @import "shims";
 
 @import "smart_answers";
+
+@import "helpers/govuk-component-helpers";

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,0 +1,7 @@
+// GOV.UK components expect to live in a world with a global reset. This CSS
+// might be pushed up to static at some point.
+.govuk-breadcrumbs ol,
+.govuk-related-items ul {
+  padding: 0;
+  margin: 0;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,5 @@
-require "slimmer/headers"
-
 class ApplicationController < ActionController::Base
-  include Slimmer::Headers
   include Slimmer::Template
-  include Slimmer::SharedTemplates
-  before_action :set_analytics_headers
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from ActionController::UnknownFormat, with: :error_404
@@ -31,9 +26,5 @@ protected
     else
       render status: status_code, text: error_message
     end
-  end
-
-  def set_analytics_headers
-    set_slimmer_headers(format: "smart_answer")
   end
 end

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -1,7 +1,10 @@
 class SmartAnswersController < ApplicationController
+  include Slimmer::SharedTemplates
+
   before_action :find_smart_answer, except: %w(index)
   before_action :redirect_response_to_canonical_url, only: %w{show}
   before_action :set_header_footer_only, only: %w{visualise}
+  before_filter :setup_navigation_helpers_and_content_item, except: %w(index)
 
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
   rescue_from SmartAnswer::InvalidNode, with: :error_404
@@ -11,7 +14,6 @@ class SmartAnswersController < ApplicationController
   end
 
   def show
-    set_slimmer_artefact(@presenter.artefact)
     respond_to do |format|
       format.html { render }
       format.json {
@@ -95,13 +97,29 @@ private
   end
 
   def set_expiry(duration = 30.minutes)
-    # if the artefact returned from the Content API is blank, or if
-    # the request to the Content API fails, set a very short cache so
-    # we don't cache an incomplete page for a while
-    duration = 5.seconds if @presenter.present? && @presenter.artefact.blank?
-
     if Rails.configuration.set_http_cache_control_expiry_time
       expires_in(duration, public: true)
     end
+  end
+
+  def setup_navigation_helpers_and_content_item
+    @content_item = Services.content_store.content_item!("/" + params[:id]).to_hash
+
+    # The GOV.UK analytics component[1] automatically sets `govuk:analytics:organisations`
+    # if there's a `organisations` key in the links. This will be sent to Google
+    # Analytics At the moment we want to avoid setting this because it will flood
+    # the analytics reports with (unexpected) data. We are currently working on
+    # a solution to this conundrum[2].
+    #
+    # [1] http://govuk-component-guide.herokuapp.com/components/analytics_meta_tags
+    # [2] https://trello.com/c/DkR63grd
+    if @content_item["links"]
+      @content_item["links"].delete("organisations")
+    end
+
+    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+    @navigation_helpers = nil
+    @content_item = nil
   end
 end

--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -13,7 +13,7 @@ class FlowContentItem
           external_related_links: external_related_links
       },
       schema_name: 'placeholder_smart_answer',
-      document_type: 'smartanswer_document',
+      document_type: 'smart_answer',
       publishing_app: 'smartanswers',
       rendering_app: 'smartanswers',
       locale: 'en',

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -15,12 +15,6 @@ class FlowPresenter
     @node_presenters = {}
   end
 
-  def artefact
-    @artefact ||= Services.content_api.artefact(@flow.name.to_s)
-  rescue GdsApi::HTTPErrorResponse
-    {}
-  end
-
   def title
     start_node.title
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,8 +5,13 @@
     <%= stylesheet_link_tag "print.css", media: "print" %>
     <title><%= yield :title %> - GOV.UK</title>
     <%= yield :head %>
+
+    <% if @content_item %>
+      <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+    <% end %>
   </head>
 <body class="mainstream">
+  <div class="header-context"><!-- Deliberately empty. This will prevent Slimmer from adding the artefact-breadcrumb. --></div>
 
   <%= yield :before_wrapper %>
 

--- a/app/views/smart_answers/show.html.erb
+++ b/app/views/smart_answers/show.html.erb
@@ -7,6 +7,10 @@
   <%= javascript_include_tag "application", defer: true %>
 <% end %>
 
+<% if @navigation_helpers %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+<% end %>
+
 <div class="grid-row">
   <main id="content" role="main">
     <div id="js-replaceable" <% if @presenter.started? %> class="smart-answer-questions group"<% end %>>
@@ -19,6 +23,10 @@
     </div>
   </main>
   <% unless @presenter.started? %>
-    <div id="related-items"></div>
+    <div class="related-container">
+      <% if @navigation_helpers %>
+        <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,4 +17,8 @@ SmartAnswers::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  if ENV['GOVUK_ASSET_ROOT'].present?
+    config.asset_host = ENV['GOVUK_ASSET_ROOT']
+  end
 end

--- a/doc/developing-using-vm.md
+++ b/doc/developing-using-vm.md
@@ -14,7 +14,7 @@ Clone the following repositories:
 
 * [imminence](https://github.com/alphagov/imminence)
 * [asset-manager](https://github.com/alphagov/asset-manager)
-* [govuk_content_api](https://github.com/alphagov/govuk_content_api)
+* [content-store](https://github.com/alphagov/content-store)
 
 If you want to run the Whitehall app locally (to provide the server side of the Worldwide API), then you also need to clone its repository:
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ function inst_prompt() {
     echo -e -n '\n\n'
 }
 
-smart_dependencies=("static" "imminence" "asset-manager" "govuk_content_api" "smart-answers")
+smart_dependencies=("static" "imminence" "asset-manager" "content-store" "smart-answers")
 for i in  "${smart_dependencies[@]}"
 do
     inst_prompt "Changing to \033[1;35m$i"

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,7 +1,7 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/content_store'
 require 'gds_api/imminence'
 require 'gds_api/worldwide'
-require 'gds_api/content_api'
 require 'gds_api/rummager'
 
 module Services
@@ -20,11 +20,13 @@ module Services
     @worldwide_api ||= GdsApi::Worldwide.new(Plek.new.find('whitehall-admin'))
   end
 
-  def self.content_api
-    @content_api ||= GdsApi::ContentApi.new(Plek.new.find("contentapi"))
-  end
-
   def self.rummager
     @rummager ||= GdsApi::Rummager.new(Plek.find("rummager"))
+  end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(
+      Plek.new.find('content-store')
+    )
   end
 end

--- a/test/functional/smart_answers_controller_date_question_test.rb
+++ b/test/functional/smart_answers_controller_date_question_test.rb
@@ -2,17 +2,14 @@ require_relative '../test_helper'
 require_relative '../helpers/fixture_flows_helper'
 require_relative '../fixtures/smart_answer_flows/smart-answers-controller-sample-with-date-question'
 require_relative 'smart_answers_controller_test_helper'
-require 'gds_api/test_helpers/content_api'
 
 class SmartAnswersControllerDateQuestionTest < ActionController::TestCase
   tests SmartAnswersController
 
   include FixtureFlowsHelper
   include SmartAnswersControllerTestHelper
-  include GdsApi::TestHelpers::ContentApi
 
   def setup
-    stub_content_api_default_artefact
     setup_fixture_flows
   end
 

--- a/test/functional/smart_answers_controller_debug_template_path_test.rb
+++ b/test/functional/smart_answers_controller_debug_template_path_test.rb
@@ -1,16 +1,13 @@
 require_relative '../test_helper'
 require_relative '../helpers/fixture_flows_helper'
 require_relative '../fixtures/smart_answer_flows/smart-answers-controller-sample'
-require 'gds_api/test_helpers/content_api'
 
 class SmartAnswersControllerDebugTemplatePathTest < ActionController::TestCase
   tests SmartAnswersController
 
   include FixtureFlowsHelper
-  include GdsApi::TestHelpers::ContentApi
 
   def setup
-    stub_content_api_default_artefact
     setup_fixture_flows
     registry = SmartAnswer::FlowRegistry.instance
     flow_name = 'smart-answers-controller-sample'

--- a/test/functional/smart_answers_controller_money_question_test.rb
+++ b/test/functional/smart_answers_controller_money_question_test.rb
@@ -2,17 +2,14 @@ require_relative '../test_helper'
 require_relative '../helpers/fixture_flows_helper'
 require_relative '../fixtures/smart_answer_flows/smart-answers-controller-sample-with-money-question'
 require_relative 'smart_answers_controller_test_helper'
-require 'gds_api/test_helpers/content_api'
 
 class SmartAnswersControllerMoneyQuestionTest < ActionController::TestCase
   tests SmartAnswersController
 
   include FixtureFlowsHelper
   include SmartAnswersControllerTestHelper
-  include GdsApi::TestHelpers::ContentApi
 
   def setup
-    stub_content_api_default_artefact
     setup_fixture_flows
   end
 

--- a/test/functional/smart_answers_controller_multiple_choice_test.rb
+++ b/test/functional/smart_answers_controller_multiple_choice_test.rb
@@ -2,17 +2,14 @@ require_relative '../test_helper'
 require_relative '../helpers/fixture_flows_helper'
 require_relative '../fixtures/smart_answer_flows/smart-answers-controller-sample-with-multiple-choice-question'
 require_relative 'smart_answers_controller_test_helper'
-require 'gds_api/test_helpers/content_api'
 
 class SmartAnswersControllerMultipleChoiceQuestionTest < ActionController::TestCase
   tests SmartAnswersController
 
   include FixtureFlowsHelper
   include SmartAnswersControllerTestHelper
-  include GdsApi::TestHelpers::ContentApi
 
   def setup
-    stub_content_api_default_artefact
     setup_fixture_flows
   end
 

--- a/test/functional/smart_answers_controller_salary_question_test.rb
+++ b/test/functional/smart_answers_controller_salary_question_test.rb
@@ -2,17 +2,14 @@ require_relative '../test_helper'
 require_relative '../helpers/fixture_flows_helper'
 require_relative '../fixtures/smart_answer_flows/smart-answers-controller-sample-with-salary-question'
 require_relative 'smart_answers_controller_test_helper'
-require 'gds_api/test_helpers/content_api'
 
 class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
   tests SmartAnswersController
 
   include FixtureFlowsHelper
   include SmartAnswersControllerTestHelper
-  include GdsApi::TestHelpers::ContentApi
 
   def setup
-    stub_content_api_default_artefact
     setup_fixture_flows
   end
 

--- a/test/functional/smart_answers_controller_value_question_test.rb
+++ b/test/functional/smart_answers_controller_value_question_test.rb
@@ -2,17 +2,14 @@ require_relative '../test_helper'
 require_relative '../helpers/fixture_flows_helper'
 require_relative '../fixtures/smart_answer_flows/smart-answers-controller-sample-with-value-question'
 require_relative 'smart_answers_controller_test_helper'
-require 'gds_api/test_helpers/content_api'
 
 class SmartAnswersControllerValueQuestionTest < ActionController::TestCase
   tests SmartAnswersController
 
   include FixtureFlowsHelper
   include SmartAnswersControllerTestHelper
-  include GdsApi::TestHelpers::ContentApi
 
   def setup
-    stub_content_api_default_artefact
     setup_fixture_flows
   end
 

--- a/test/helpers/fixture_flows_helper.rb
+++ b/test/helpers/fixture_flows_helper.rb
@@ -1,5 +1,8 @@
 module FixtureFlowsHelper
   def setup_fixture_flows
+    stub_request(:get, %r{#{Plek.new.find("content-store")}/content/(.*)})
+      .to_return(status: 404, body: {}.to_json)
+
     fixture_flows_path = Rails.root.join(*%w{test fixtures smart_answer_flows})
     @preload_flows = FLOW_REGISTRY_OPTIONS[:preload_flows]
     FLOW_REGISTRY_OPTIONS[:preload_flows] = false

--- a/test/integration/engine/engine_test_helper.rb
+++ b/test/integration/engine/engine_test_helper.rb
@@ -1,14 +1,11 @@
 require_relative '../../integration_test_helper'
 require_relative '../../helpers/fixture_flows_helper'
-require 'gds_api/test_helpers/content_api'
 
 class EngineIntegrationTest < ActionDispatch::IntegrationTest
-  include GdsApi::TestHelpers::ContentApi
   include FixtureFlowsHelper
 
   setup do
     setup_fixture_flows
-    stub_content_api_default_artefact
   end
 
   teardown do

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -8,7 +8,6 @@ class ErrorHandlingTest < ActionDispatch::IntegrationTest
     end
 
     def test
-      set_slimmer_headers(skip: true)
       if self.class.exception_to_raise_before_render
         raise self.class.exception_to_raise_before_render
       end
@@ -40,11 +39,6 @@ class ErrorHandlingTest < ActionDispatch::IntegrationTest
       get '/test'
       assert_response 503
     end
-
-    should 'render error message as response body' do
-      get '/test'
-      assert_equal '503 error', response.body
-    end
   end
 
   context 'when ActionController::UnknownFormat raised before render' do
@@ -55,11 +49,6 @@ class ErrorHandlingTest < ActionDispatch::IntegrationTest
     should 'set response status code to 404' do
       get '/test'
       assert_response 404
-    end
-
-    should 'render error message as response body' do
-      get '/test'
-      assert_equal '404 error', response.body
     end
   end
 
@@ -72,11 +61,6 @@ class ErrorHandlingTest < ActionDispatch::IntegrationTest
       get '/test'
       assert_response 503
     end
-
-    should 'replace response body with error message' do
-      get '/test'
-      assert_equal '503 error', response.body
-    end
   end
 
   context 'when ActionController::UnknownFormat raised after render' do
@@ -87,11 +71,6 @@ class ErrorHandlingTest < ActionDispatch::IntegrationTest
     should 'set response status code to 404' do
       get '/test'
       assert_response 404
-    end
-
-    should 'replace response body with error message' do
-      get '/test'
-      assert_equal '404 error', response.body
     end
   end
 end

--- a/test/integration/smart_answers_controller_error_handling_test.rb
+++ b/test/integration/smart_answers_controller_error_handling_test.rb
@@ -1,13 +1,9 @@
 require_relative '../integration_test_helper'
-require 'gds_api/test_helpers/content_api'
 
 class SmartAnswersControllerErrorHandlingTest < ActionDispatch::IntegrationTest
-  include GdsApi::TestHelpers::ContentApi
-
   setup do
     @flow_registry = stub('flow-registry')
     SmartAnswer::FlowRegistry.stubs(:instance).returns(@flow_registry)
-    stub_content_api_default_artefact
   end
 
   context 'when SmartAnswer::InvalidNode raised' do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -6,8 +6,6 @@ Capybara.default_driver = :rack_test
 
 require 'capybara/poltergeist'
 
-require 'gds_api/test_helpers/content_api'
-
 # This additional configuration is a protective measure while
 # we have invalid ssl certs in the test environment, it
 # will ignore ssl errors when requesting scripts from
@@ -21,7 +19,6 @@ Capybara.javascript_driver = :poltergeist
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
-  include GdsApi::TestHelpers::ContentApi
 
   teardown do
     Capybara.use_default_driver

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -11,7 +11,6 @@ WebMock.disable_net_connect!(allow_localhost: true)
 require_relative '../support/fixture_methods'
 require_relative '../support/world_location_stubbing_methods'
 
-require 'gds_api/test_helpers/content_api'
 require 'gds_api/test_helpers/imminence'
 
 require 'mocha/api'
@@ -42,7 +41,6 @@ class SmartAnswersRegressionTest < ActionController::TestCase
     end
   end
 
-  include GdsApi::TestHelpers::ContentApi
   include GdsApi::TestHelpers::Imminence
   include WebMock::API
   include FixtureMethods
@@ -67,7 +65,6 @@ class SmartAnswersRegressionTest < ActionController::TestCase
         Timecop.freeze(smart_answer_helper.current_time)
 
         next if self.class.setup_has_run? && !self.class.teardown_hooks_installed?
-        stub_content_api_default_artefact
         WebMock.stub_request(:get, WorkingDays::BANK_HOLIDAYS_URL).to_return(body: File.open(fixture_file('bank_holidays.json')))
 
         setup_worldwide_locations


### PR DESCRIPTION
This commit changes the way we render breadcrumbs, sidebar and content-store. It is part of similar work in all "mainstream"-like applications on GOV.UK (https://trello.com/c/mOeDK914).

Instead of the content-api, we now use the content-store as the data source for everything. We also use the `govuk_navigation` gem to generate GOV.UK component data.

https://trello.com/c/49441pPb