### PR TITLE
Register a birth: FIX currently in north korea bug

### DIFF
--- a/lib/smart_answer/calculators/register_a_birth_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_birth_calculator.rb
@@ -62,8 +62,7 @@ module SmartAnswer::Calculators
     end
 
     def currently_in_north_korea?
-      # TODO: current_country == 'north-korea'
-      nil == 'north-korea'
+      current_country == 'north-korea'
     end
 
     def british_national_father?

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -202,7 +202,7 @@
     You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
   <% end %>
 
-  The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+  The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
   Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/afghanistan-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 6 months if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/afghanistan-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 6 months if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/afghanistan-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 6 months if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/afghanistan-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 6 months if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/afghanistan-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 6 months if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/afghanistan-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 6 months if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/algeria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,66 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/in_the_uk.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/same_country.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/no/2015-02-02/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/democratic-republic-of-the-congo/mother_and_father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/brazil.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/china.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/czech-republic.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/estonia.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/hong-kong.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/italy.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/libya.txt
@@ -47,7 +47,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,25 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^
-
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -28,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/philippines.txt
@@ -47,7 +47,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/sudan.txt
@@ -49,7 +49,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/taiwan.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/in_the_uk.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/same_country.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/brazil.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/china.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/czech-republic.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/estonia.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/hong-kong.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/italy.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/libya.txt
@@ -47,7 +47,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/north-korea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/north-korea.txt
@@ -1,25 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^
-
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -28,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/philippines.txt
@@ -47,7 +47,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/sudan.txt
@@ -49,7 +49,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/taiwan.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/in_the_uk.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/same_country.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/brazil.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/china.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/czech-republic.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/estonia.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/hong-kong.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/italy.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/libya.txt
@@ -47,7 +47,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/north-korea.txt
@@ -1,25 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-^Only the mother will be named on the local birth certificate if you aren’t married. To add the father’s name you must swear a paternity declaration in a Moroccan court and you may be ordered to get married.^
-
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -28,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/philippines.txt
@@ -47,7 +47,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/sudan.txt
@@ -49,7 +49,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/taiwan.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/in_the_uk.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/same_country.txt
@@ -43,7 +43,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/morocco-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- a [name confirmation form](https://www.gov.uk/government/publications/birth-registration-name-confirmation-form) that says how you would like the child's full name to be registered, if the name differs from the name on the local birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2006-06-30.txt
@@ -1,0 +1,17 @@
+
+
+$!You must register the birth according to the regulations in the Netherlands.$!
+
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t automatically pass on British nationality to a child born before 1 July 2006.
+
+You may still be able to apply for [British citizenship](https://www.gov.uk/register-british-citizen/born-before-2006-british-father) for the child.
+
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on the father's [legal country of domicile](/government/publications/legitimation-and-domicile) at the time of the birth)
+- the country where the father was [legally domiciled](/government/publications/legitimation-and-domicile) at the time of the birth did not distinguish between married and unmarried parents
+
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/sudan.txt
@@ -1,0 +1,91 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/no/2015-02-02/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/sudan.txt
@@ -1,0 +1,91 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/father/yes/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/sudan.txt
@@ -1,0 +1,91 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/no/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/sudan.txt
@@ -1,0 +1,91 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother/yes/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/sudan.txt
@@ -1,0 +1,91 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/no/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/libya.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/philippines.txt
@@ -1,0 +1,89 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/sudan.txt
@@ -1,0 +1,91 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/netherlands/mother_and_father/yes/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/netherlands-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the Dutch version of the child’s full birth certificate (‘akte van geboorte’) and a translation of the certificate into English
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/netherlands/neither.txt
+++ b/test/artefacts/register-a-birth/netherlands/neither.txt
@@ -1,0 +1,6 @@
+
+
+You can’t register your child’s birth with the UK authorities. Your child must have an automatic claim to British nationality at birth to be eligible.
+
+
+

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/brazil.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/china.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/czech-republic.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/estonia.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/hong-kong.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/italy.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/libya.txt
@@ -59,7 +59,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,105 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- a Certificate of No Marriage ("Cenomar") issued by the National Statistics Office (NSO) or Philippine Statistics Authority (PSA) - if the Filipino mother is single
+- an Advisory on Marriage certificate issued by the NSO or PSA - if the Filipino mother is married
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
+- photos of the child growing up in the Philippines with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 16 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,81 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- a Certificate of No Marriage ("Cenomar") issued by the National Statistics Office (NSO) or Philippine Statistics Authority (PSA) - if the Filipino mother is single
-- an Advisory on Marriage certificate issued by the NSO or PSA - if the Filipino mother is married
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
-- photos of the child growing up in the Philippines with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 16 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/philippines.txt
@@ -59,7 +59,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/sudan.txt
@@ -61,7 +61,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/taiwan.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/in_the_uk.txt
@@ -59,7 +59,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/same_country.txt
@@ -59,7 +59,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/brazil.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/china.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/czech-republic.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/estonia.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/hong-kong.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/italy.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/libya.txt
@@ -59,7 +59,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/north-korea.txt
@@ -1,0 +1,105 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- a Certificate of No Marriage ("Cenomar") issued by the National Statistics Office (NSO) or Philippine Statistics Authority (PSA) - if the Filipino mother is single
+- an Advisory on Marriage certificate issued by the NSO or PSA - if the Filipino mother is married
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
+- photos of the child growing up in the Philippines with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 16 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,81 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- a Certificate of No Marriage ("Cenomar") issued by the National Statistics Office (NSO) or Philippine Statistics Authority (PSA) - if the Filipino mother is single
-- an Advisory on Marriage certificate issued by the NSO or PSA - if the Filipino mother is married
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
-- photos of the child growing up in the Philippines with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 16 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/papua-new-guinea.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/philippines.txt
@@ -59,7 +59,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/sudan.txt
@@ -61,7 +61,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/taiwan.txt
@@ -55,7 +55,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/in_the_uk.txt
@@ -59,7 +59,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/same_country.txt
@@ -59,7 +59,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/brazil.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/china.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/czech-republic.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/estonia.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/hong-kong.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/italy.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/libya.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/north-korea.txt
@@ -1,0 +1,102 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
+- photos of the child growing up in the Philippines with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 16 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,78 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
-- photos of the child growing up in the Philippines with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 16 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/papua-new-guinea.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/philippines.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/sudan.txt
@@ -58,7 +58,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/taiwan.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/in_the_uk.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/same_country.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/brazil.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/china.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/czech-republic.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/estonia.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/hong-kong.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/italy.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/libya.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,78 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
-- photos of the child growing up in the Philippines with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 16 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,102 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
+- photos of the child growing up in the Philippines with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 16 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/papua-new-guinea.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/philippines.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/sudan.txt
@@ -58,7 +58,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/taiwan.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/in_the_uk.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/same_country.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/brazil.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/china.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/czech-republic.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/estonia.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/hong-kong.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/italy.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/libya.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,102 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
+- photos of the child growing up in the Philippines with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 16 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,78 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
-- photos of the child growing up in the Philippines with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 16 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/philippines.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/sudan.txt
@@ -58,7 +58,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/taiwan.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/in_the_uk.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/same_country.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/brazil.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/china.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/czech-republic.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/estonia.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/hong-kong.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/italy.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/libya.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,78 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
-- photos of the child growing up in the Philippines with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 16 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,102 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in the Philippines
+- photos of the child growing up in the Philippines with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 16 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/philippines.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/sudan.txt
@@ -58,7 +58,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/taiwan.txt
@@ -52,7 +52,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/in_the_uk.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/same_country.txt
@@ -56,7 +56,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/brazil.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/china.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/czech-republic.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/estonia.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/hong-kong.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/italy.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/libya.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- the hospital live birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,78 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
-- photos of the child growing up in Sierra Leone with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,103 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- the hospital live birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
+- photos of the child growing up in Sierra Leone with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/philippines.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/sudan.txt
@@ -59,7 +59,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/taiwan.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/in_the_uk.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/same_country.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/brazil.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/china.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/czech-republic.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/estonia.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/hong-kong.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/italy.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/libya.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- the hospital live birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,78 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
-- photos of the child growing up in Sierra Leone with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/north-korea.txt
@@ -1,0 +1,103 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- the hospital live birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
+- photos of the child growing up in Sierra Leone with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/papua-new-guinea.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/philippines.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/sudan.txt
@@ -59,7 +59,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/taiwan.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/in_the_uk.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/same_country.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/brazil.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/china.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/czech-republic.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/estonia.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/hong-kong.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/italy.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/libya.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- the hospital live birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,78 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
-- photos of the child growing up in Sierra Leone with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/north-korea.txt
@@ -1,0 +1,103 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- the hospital live birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
+- photos of the child growing up in Sierra Leone with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/papua-new-guinea.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/philippines.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/sudan.txt
@@ -59,7 +59,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/taiwan.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/in_the_uk.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/same_country.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/brazil.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/china.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/czech-republic.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/estonia.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/hong-kong.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/italy.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/libya.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- the hospital live birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,78 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
-- photos of the child growing up in Sierra Leone with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,103 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- the hospital live birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
+- photos of the child growing up in Sierra Leone with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/papua-new-guinea.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/philippines.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/sudan.txt
@@ -59,7 +59,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/taiwan.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/in_the_uk.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/same_country.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/brazil.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/china.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/czech-republic.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/estonia.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/hong-kong.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/italy.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/libya.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- the hospital live birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,78 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
-- photos of the child growing up in Sierra Leone with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,103 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- the hospital live birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
+- photos of the child growing up in Sierra Leone with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/philippines.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/sudan.txt
@@ -59,7 +59,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/taiwan.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/in_the_uk.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/same_country.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/brazil.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/china.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/czech-republic.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/estonia.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/hong-kong.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/italy.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/libya.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- the hospital live birth certificate
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,78 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
-
-If the child doesn't have a British passport you must also send the original copies of:
-
-- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
-- health cards from the hospital, doctor or clinic
-- immunisation and vaccination cards
-- a letter from the hospital confirming the birth
-- receipts from the hospital for the birth and any medical treatment (if any)
-- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
-- photos of the child growing up in Sierra Leone with its parents and any siblings
-- the parents' wedding photos (if the parents have been married)
-- photos of the mother during pregnancy (if the mother is a British citizen)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,103 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- the hospital live birth certificate
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+If the child doesn't have a British passport you must also send the original copies of:
+
+- the mother’s antenatal, postnatal and delivery notes from the hospital (eg blood test results, ultrasound scans and doctors' notes) or copies certified by the hospital if you can't get the originals
+- health cards from the hospital, doctor or clinic
+- immunisation and vaccination cards
+- a letter from the hospital confirming the birth
+- receipts from the hospital for the birth and any medical treatment (if any)
+- photos of the child as a baby, in which the child can clearly be identified with its parents in Sierra Leone
+- photos of the child growing up in Sierra Leone with its parents and any siblings
+- the parents' wedding photos (if the parents have been married)
+- photos of the mother during pregnancy (if the mother is a British citizen)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/philippines.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/sudan.txt
@@ -59,7 +59,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/taiwan.txt
@@ -53,7 +53,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/in_the_uk.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/same_country.txt
@@ -57,7 +57,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/brazil.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/china.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/czech-republic.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/estonia.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/hong-kong.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/italy.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/libya.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,68 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
-
-If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/philippines.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/another_country/taiwan.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/in_the_uk.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/sudan/father/no/2015-02-02/same_country.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/brazil.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/china.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/czech-republic.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/estonia.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/hong-kong.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/italy.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/libya.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,68 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
-
-If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/north-korea.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/papua-new-guinea.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/philippines.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/another_country/taiwan.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/in_the_uk.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sudan/father/yes/same_country.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/brazil.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/china.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/czech-republic.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/estonia.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/hong-kong.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/italy.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/libya.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,68 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
-
-If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/north-korea.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/papua-new-guinea.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/philippines.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/another_country/taiwan.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/in_the_uk.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/no/same_country.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/brazil.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/china.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/czech-republic.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/estonia.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/hong-kong.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/italy.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/libya.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,68 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
-
-If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/papua-new-guinea.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/philippines.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/another_country/taiwan.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/in_the_uk.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sudan/mother/yes/same_country.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/brazil.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/china.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/czech-republic.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/estonia.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/hong-kong.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/italy.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/libya.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,68 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
-
-If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/philippines.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/another_country/taiwan.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/in_the_uk.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/no/same_country.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/brazil.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/china.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/czech-republic.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/estonia.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/hong-kong.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/italy.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/libya.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,68 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
-
-If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-* at least 12 weeks if the child doesn’t have a British passport
-* 5 working days if the child has a British passport
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
-The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+Once the Overseas Registration Unit gets your form and the right documents, registering the birth will usually take:
+
+* at least 12 weeks if the child doesn’t have a British passport
+* 5 working days if the child has a British passport
+
+The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/philippines.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/another_country/taiwan.txt
@@ -42,7 +42,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/in_the_uk.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/sudan/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sudan/mother_and_father/yes/same_country.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/in_the_uk.txt
@@ -42,7 +42,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/same_country.txt
@@ -42,7 +42,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/brazil.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/china.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/czech-republic.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/estonia.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/hong-kong.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/italy.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/libya.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/north-korea.txt
@@ -1,23 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents’ names
-- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -26,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents’ names
+- hospital, medical or insurance records naming the parents as the birth parents (if the birth was registered more than three months after it took place)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/philippines.txt
@@ -45,7 +45,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/sudan.txt
@@ -47,7 +47,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/taiwan.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/in_the_uk.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/same_country.txt
@@ -41,7 +41,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,59 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/libya.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate - it must have both parents' names
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/north-korea.txt
@@ -1,22 +1,16 @@
 
 
-$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+$!You can apply to register the birth with the British embassy in North Korea.$!
 
-You can also register the birth with the UK authorities. You must:
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the birth registration form.
-s3. Pay.
-s4. Post your documents and the form.
+##Documents
 
-##1. Check your documents
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+You must provide the original copies of:
 
-You must send the original versions of:
-
-- the child’s full local birth certificate - it must have both parents' names
-
+- a birth certificate issued by Pyongyang Friendship Hospital
 - the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
 - the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
 - the parents’ marriage or civil partnership certificate (if applicable)
@@ -25,61 +19,57 @@ You must send the original versions of:
 - a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 - written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
 
-You must also send photocopies of:
+You must also provide photocopies of:
 
 - the photo page of the child’s British passport if they have one
-- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
 
 %Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
 
-##2. Fill in the application form
+You’ll need to provide originals and a photocopy of each document.
 
-Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
-
-##3. Pay
-
-You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
-
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
-
-Once you’ve paid you will be given a reference number to use on your birth registration form.
+##Cost
 
 Service | Fee
 -|-
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the birth.
 
-<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
 
-##4. Send your registration
+##Go to the British embassy
 
-Post the registration form and documents by secure post to:
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
 
-Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/philippines.txt
@@ -44,7 +44,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/sudan.txt
@@ -46,7 +46,7 @@ You can [pay for the registration online](https://pay-register-birth-abroad.serv
 
 If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [application form](/government/publications/applicatio
 
 You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
 
-The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
 
 Once you’ve paid you will be given a reference number to use on your birth registration form.
 

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/register-a-birth.rb: ecd4500ead144c94294a25e9bb66b420
-test/data/register-a-birth-questions-and-responses.yml: 7dbec068aec3c78138ff40cbd95965d0
-test/data/register-a-birth-responses-and-expected-results.yml: 5e534e655f7f479b29a089c84b9e1e4f
+test/data/register-a-birth-questions-and-responses.yml: a557e64da8feb7af1b2699780f606354
+test/data/register-a-birth-responses-and-expected-results.yml: d0d0e64fcbbf0cc6e02ef75e35d409f2
 lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb: 8c7e4d35431cb9a708504fec00558b02
 lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb: f259f0c518f6b418a683d6482874a451
 lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb: d3df03e03088e121a8c9608697219f33

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/register-a-birth.rb: ecd4500ead144c94294a25e9bb66b420
-test/data/register-a-birth-questions-and-responses.yml: 140fba32b4b6bcca874747c89ed8c361
-test/data/register-a-birth-responses-and-expected-results.yml: aa9179e9a98d7271df70c2fff5ef66ce
+test/data/register-a-birth-questions-and-responses.yml: 7dbec068aec3c78138ff40cbd95965d0
+test/data/register-a-birth-responses-and-expected-results.yml: 5e534e655f7f479b29a089c84b9e1e4f
 lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb: 8c7e4d35431cb9a708504fec00558b02
 lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb: f259f0c518f6b418a683d6482874a451
 lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb: d3df03e03088e121a8c9608697219f33

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -18,7 +18,7 @@ lib/smart_answer_flows/register-a-birth/questions/where_are_you_now.govspeak.erb
 lib/smart_answer_flows/register-a-birth/questions/which_country.govspeak.erb: 913b5637a2814cbd529affffc55b1f72
 lib/smart_answer_flows/register-a-birth/questions/who_has_british_nationality.govspeak.erb: 9a1a1acec4abc5a3f5199ab2eae0cd1c
 lib/smart_answer_flows/register-a-birth/register_a_birth.govspeak.erb: 05cf2d9426fc91f395fc524fdfdac800
-lib/smart_answer/calculators/register_a_birth_calculator.rb: f08a8ba06eb47818cbaa12806b749f69
+lib/smart_answer/calculators/register_a_birth_calculator.rb: 39a68cfaeaeeabff82bbfdb38875f8aa
 lib/data/rates/register_a_birth.yml: 8d678c61d06f614a67e8faa1933b0ff5
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.gov
 lib/smart_answer_flows/register-a-birth/outcomes/no_embassy_result.govspeak.erb: 23ec4444ac49bec78adc427c46e3e4c0
 lib/smart_answer_flows/register-a-birth/outcomes/no_registration_result.govspeak.erb: 7b60252b078e6aec6f5759e894ce4ffb
 lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb: a161e34a4b4a5dfce17cda20d58f3a88
-lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb: cccbf5b3c72c62e9a8f40223ea5e9613
+lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb: bfe59b25454a9e855497813083149215
 lib/smart_answer_flows/register-a-birth/questions/childs_date_of_birth.govspeak.erb: e911daf1dc69ce85db372dc4ea3bdd50
 lib/smart_answer_flows/register-a-birth/questions/country_of_birth.govspeak.erb: 31c306c928e71eee86c60352f51ccf83
 lib/smart_answer_flows/register-a-birth/questions/have_you_adopted_the_child.govspeak.erb: 3a9d66656446a508c7232b26778dfa23

--- a/test/data/register-a-birth-questions-and-responses.yml
+++ b/test/data/register-a-birth-questions-and-responses.yml
@@ -7,6 +7,7 @@
 - iran # country_has_no_embassy
 - libya # consular_service_fees_libya
 - morocco # swear_in_moroccan_court
+- netherlands
 - north-korea # handled by the embassy if user is currently in the country
 - papua-new-guinea # registration_can_take_3_months
 - philippines # oru_extra_documents_in_philippines_when_mother_not_british

--- a/test/data/register-a-birth-questions-and-responses.yml
+++ b/test/data/register-a-birth-questions-and-responses.yml
@@ -41,6 +41,7 @@
 - hong-kong # :go_to_the_embassy (special case)
 - italy # :postal_form_return
 - libya # :fees_for_consular_services
+- north-korea
 - papua-new-guinea # :embassy_high_commission_or_consulate "British high commission"
 - philippines # :post_only_philippines
 - sudan

--- a/test/data/register-a-birth-responses-and-expected-results.yml
+++ b/test/data/register-a-birth-responses-and-expected-results.yml
@@ -102,6 +102,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - afghanistan
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -261,6 +270,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - afghanistan
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -447,6 +465,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - afghanistan
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -633,6 +660,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - algeria
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -755,6 +791,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - algeria
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -891,6 +936,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - algeria
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -1055,6 +1109,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - algeria
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -1195,6 +1259,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - algeria
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -1317,6 +1390,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - algeria
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -1477,6 +1559,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - democratic-republic-of-the-congo
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -1599,6 +1690,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - democratic-republic-of-the-congo
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -1735,6 +1835,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - democratic-republic-of-the-congo
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -1899,6 +2008,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - democratic-republic-of-the-congo
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -2039,6 +2158,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - democratic-republic-of-the-congo
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -2161,6 +2289,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - democratic-republic-of-the-congo
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -2326,6 +2463,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - morocco
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -2448,6 +2594,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - morocco
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -2584,6 +2739,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - morocco
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -2748,6 +2912,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - morocco
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -2888,6 +3062,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - morocco
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -3010,6 +3193,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - morocco
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -3165,6 +3357,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -3287,6 +3488,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -3423,6 +3633,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -3587,6 +3806,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -3727,6 +3956,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -3849,6 +4087,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -4004,6 +4251,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - north-korea
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -4126,6 +4382,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - north-korea
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -4262,6 +4527,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - north-korea
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -4426,6 +4700,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - north-korea
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -4566,6 +4850,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - north-korea
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -4688,6 +4981,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - north-korea
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -4843,6 +5145,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - papua-new-guinea
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -4965,6 +5276,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - papua-new-guinea
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -5101,6 +5421,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - papua-new-guinea
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -5265,6 +5594,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - papua-new-guinea
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -5405,6 +5744,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - papua-new-guinea
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -5527,6 +5875,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - papua-new-guinea
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -5682,6 +6039,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - philippines
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -5804,6 +6170,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - philippines
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -5940,6 +6315,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - philippines
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -6104,6 +6488,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - philippines
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -6244,6 +6638,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - philippines
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -6366,6 +6769,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - philippines
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -6521,6 +6933,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sierra-leone
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -6643,6 +7064,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sierra-leone
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -6779,6 +7209,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sierra-leone
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -6943,6 +7382,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sierra-leone
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -7083,6 +7532,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sierra-leone
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -7205,6 +7663,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sierra-leone
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -7365,6 +7832,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sudan
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -7487,6 +7963,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sudan
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -7623,6 +8108,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sudan
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -7787,6 +8281,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sudan
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -7927,6 +8431,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sudan
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -8049,6 +8562,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - sudan
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -8204,6 +8726,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - st-martin
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -8326,6 +8857,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - st-martin
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -8462,6 +9002,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - st-martin
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -8626,6 +9175,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - st-martin
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -8766,6 +9325,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - st-martin
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -8888,6 +9456,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - st-martin
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -9043,6 +9620,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - timor-leste
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -9165,6 +9751,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - timor-leste
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -9301,6 +9896,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - timor-leste
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -9465,6 +10069,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - timor-leste
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -9605,6 +10219,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - timor-leste
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -9727,6 +10350,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - timor-leste
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -9882,6 +10514,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - usa
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -10004,6 +10645,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - usa
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -10140,6 +10790,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - usa
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -10304,6 +10963,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - usa
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -10444,6 +11113,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - usa
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -10566,6 +11244,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - usa
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -10721,6 +11408,15 @@
   - mother
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - venezuela
+  - mother
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -10843,6 +11539,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - venezuela
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -10979,6 +11684,15 @@
   - 'yes'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - venezuela
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?
@@ -11143,6 +11857,16 @@
   - 'no'
   - '2015-02-02'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - venezuela
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -11283,6 +12007,15 @@
   - mother_and_father
   - 'yes'
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - venezuela
+  - mother_and_father
+  - 'yes'
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -11405,6 +12138,15 @@
   - 'no'
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - venezuela
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country?

--- a/test/data/register-a-birth-responses-and-expected-results.yml
+++ b/test/data/register-a-birth-responses-and-expected-results.yml
@@ -3064,6 +3064,845 @@
   :outcome_node: true
 - :current_node: :country_of_birth?
   :responses:
+  - netherlands
+  :next_node: :who_has_british_nationality?
+  :outcome_node: false
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - netherlands
+  - mother
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother
+  - 'no'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - netherlands
+  - father
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - father
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  :next_node: :childs_date_of_birth?
+  :outcome_node: false
+- :current_node: :childs_date_of_birth?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2006-06-30'
+  :next_node: :homeoffice_result
+  :outcome_node: true
+- :current_node: :childs_date_of_birth?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - father
+  - 'no'
+  - '2015-02-02'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - netherlands
+  - mother_and_father
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - netherlands
+  - mother_and_father
+  - 'no'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - netherlands
+  - neither
+  :next_node: :no_registration_result
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
   - north-korea
   :next_node: :who_has_british_nationality?
   :outcome_node: false

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -561,7 +561,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
       add_response "another_country"
       add_response "north-korea"
 
-      assert_current_node :oru_result
+      assert_current_node :north_korea_result
     end
 
     should "display 3 months if child born in a lower risk (non phase-5) country and currently in Cambodia" do


### PR DESCRIPTION
Related to #2807 

[Trello card](https://trello.com/c/EU4LTmBN/249-register-a-birth-north-korea)


## Description

This PR focuses on resolving a long standing content mis-match issue, where a user gives birth in a country (eg: Netherland) and lives in North Korea.

This appears to be connected to this [commit](https://github.com/alphagov/smart-answers/commit/8ca42320a4b0e5e7a537da31d831d469ce793727).

Changes have been requsted by the content team via this [document](https://docs.google.com/document/d/1jEKscYILy95tFSkewltcMJvMWwXqr4LT9tTYfio_x4M/edit)


## Factcheck

[Preview link](https://smart-answers-pr-2806.herokuapp.com//register-a-birth/y/netherlands/mother/yes/another_country/north-korea )
[GOV.UK](https://www.gov.uk/register-a-birth/y/netherlands/mother/yes/another_country/north-korea )

### Expected changes

- Show relevant content where user gives birth in a country (eg: Netherland) and lives in North Korea

### Before
![screen shot 2016-11-03 at 14 52 30](https://cloud.githubusercontent.com/assets/84896/19970854/2dfb0b94-a1d5-11e6-8767-9d633d72476d.png)

### After

![screen shot 2016-11-03 at 14 52 16](https://cloud.githubusercontent.com/assets/84896/19970859/33489580-a1d5-11e6-8b23-64dab8fdc30b.png)
