### PR TITLE
Register a death: FIX currently in north korea bug

### DIFF
--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -67,8 +67,7 @@ module SmartAnswer::Calculators
     end
 
     def currently_in_north_korea?
-      # TODO: current_country == 'north-korea'
-      nil == 'north-korea'
+      current_country == 'north-korea'
     end
 
     def translator_link_url

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb
@@ -52,7 +52,7 @@
     Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
   <% end %>
 
-  The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+  The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
   <%= render partial: 'fees.govspeak.erb',
              locals: { calculator: calculator } %>

--- a/test/artefacts/register-a-death/overseas/austria/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/algeria.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/algeria.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/brazil.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/china.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/czech-republic.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/estonia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/hong-kong.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/italy.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/libya.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/libya.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/north-korea.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/north-korea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/north-korea.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/north-korea.txt
@@ -1,87 +1,74 @@
 
 
-$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+$!You must register the death according to the regulations in Austria. You will be given a local death certificate.$!
 
-This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+This local death certificate will be accepted in the UK (it may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English).
 
 ##Register the death with the UK authorities
 
-You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+You can also apply to register the death with the British embassy in North Korea.
 
-- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
-- you can order a consular death registration certificate
+You don’t have to do this, but it means:
 
-You will need to:
+- a British-style death certificate will be issued
+- having the death registered at the General Register Office in the UK
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the forms.
-s3. Pay.
-s4. Post your documents and the forms.
+##How to register
 
-###1. Documents
+Download and complete a [registration form](/government/publications/application-to-register-an-overseas-death).
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+##Documents
 
-You must provide:
+You must provide originals and a photocopy of:
 
-- the original local death certificate (not a certificate issued by a doctor)
-
+- a death certificate issued by Pyongyang Friendship Hospital
 - a photocopy of the photo page of the passport of the person who died
 - their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
 - written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
 
-%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+Fill in [form D1, 'Returning the passport of a deceased person'](/government/publications/returning-the-passport-of-a-deceased-person) if you provide their passport.
 
-###2. Forms
+Fill in [form LS01, 'Lost or Stolen Passport Notification'](/government/publications/lost-or-stolen-passport-notification--2) if the passport is lost or unavailable.
 
-Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
-
-###3. Pay
-
-Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
-
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+##Cost
 
 Service | Fee
 -|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the death.
 
-<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+You can also get copies from the [General Register Office](http://www.gro.gov.uk/) from September the year after you register - they will cost less.
 
-###4. Send your registration
+##Go to the British embassy
 
-Once you've paid you will be given a reference number to use on your death registration form.
+You can book an appointment at the British embassy and bring along the registration form, supporting documents and the fee.
 
-Post your registration form and documents by secure post to:
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the death will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
-
-Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 
 

--- a/test/artefacts/register-a-death/overseas/austria/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/papua-new-guinea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the death has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/philippines.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/philippines.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/somalia.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/somalia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/somalia.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/somalia.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/austria/another_country/taiwan.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/austria/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/austria/in_the_uk.txt
@@ -1,0 +1,83 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/austria/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/austria/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/austria/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/austria/same_country.txt
@@ -1,0 +1,85 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/austria-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to you by secure courier after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/algeria.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/libya.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/north-korea.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/north-korea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/north-korea.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/north-korea.txt
@@ -1,87 +1,74 @@
 
 
-$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+$!You must register the death according to the regulations in the Democratic Republic Of The Congo. You will be given a local death certificate.$!
 
-This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+This local death certificate will be accepted in the UK (it may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English).
 
 ##Register the death with the UK authorities
 
-You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+You can also apply to register the death with the British embassy in North Korea.
 
-- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
-- you can order a consular death registration certificate
+You don’t have to do this, but it means:
 
-You will need to:
+- a British-style death certificate will be issued
+- having the death registered at the General Register Office in the UK
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the forms.
-s3. Pay.
-s4. Post your documents and the forms.
+##How to register
 
-###1. Documents
+Download and complete a [registration form](/government/publications/application-to-register-an-overseas-death).
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/democratic-republic-of-congo-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+##Documents
 
-You must provide:
+You must provide originals and a photocopy of:
 
-- the original local death certificate (not a certificate issued by a doctor)
-
+- a death certificate issued by Pyongyang Friendship Hospital
 - a photocopy of the photo page of the passport of the person who died
 - their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
 - written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
 
-%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+Fill in [form D1, 'Returning the passport of a deceased person'](/government/publications/returning-the-passport-of-a-deceased-person) if you provide their passport.
 
-###2. Forms
+Fill in [form LS01, 'Lost or Stolen Passport Notification'](/government/publications/lost-or-stolen-passport-notification--2) if the passport is lost or unavailable.
 
-Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
-
-###3. Pay
-
-Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
-
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+##Cost
 
 Service | Fee
 -|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the death.
 
-<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+You can also get copies from the [General Register Office](http://www.gro.gov.uk/) from September the year after you register - they will cost less.
 
-###4. Send your registration
+##Go to the British embassy
 
-Once you've paid you will be given a reference number to use on your death registration form.
+You can book an appointment at the British embassy and bring along the registration form, supporting documents and the fee.
 
-Post your registration form and documents by secure post to:
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the death will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
-
-Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 
 

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/philippines.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/somalia.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/somalia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/democratic-republic-of-the-congo/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/algeria.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/libya.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/north-korea.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/north-korea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the original local death certificate (not a certificate issued by a doctor)
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/north-korea.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/north-korea.txt
@@ -1,87 +1,74 @@
 
 
-$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+$!You must register the death according to the regulations in North Korea. You will be given a local death certificate.$!
 
-This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+This local death certificate will be accepted in the UK (it may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English).
 
 ##Register the death with the UK authorities
 
-You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+You can also apply to register the death with the British embassy in North Korea.
 
-- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
-- you can order a consular death registration certificate
+You don’t have to do this, but it means:
 
-You will need to:
+- a British-style death certificate will be issued
+- having the death registered at the General Register Office in the UK
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the forms.
-s3. Pay.
-s4. Post your documents and the forms.
+##How to register
 
-###1. Documents
+Download and complete a [registration form](/government/publications/application-to-register-an-overseas-death).
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+##Documents
 
-You must provide:
+You must provide originals and a photocopy of:
 
-- the original local death certificate (not a certificate issued by a doctor)
-
+- a death certificate issued by Pyongyang Friendship Hospital
 - a photocopy of the photo page of the passport of the person who died
 - their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
 - written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
 
-%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+Fill in [form D1, 'Returning the passport of a deceased person'](/government/publications/returning-the-passport-of-a-deceased-person) if you provide their passport.
 
-###2. Forms
+Fill in [form LS01, 'Lost or Stolen Passport Notification'](/government/publications/lost-or-stolen-passport-notification--2) if the passport is lost or unavailable.
 
-Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
-
-###3. Pay
-
-Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
-
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+##Cost
 
 Service | Fee
 -|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the death.
 
-<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+You can also get copies from the [General Register Office](http://www.gro.gov.uk/) from September the year after you register - they will cost less.
 
-###4. Send your registration
+##Go to the British embassy
 
-Once you've paid you will be given a reference number to use on your death registration form.
+You can book an appointment at the British embassy and bring along the registration form, supporting documents and the fee.
 
-Post your registration form and documents by secure post to:
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the death will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
-
-Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 
 

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/philippines.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/somalia.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/somalia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/north-korea/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/algeria.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay by credit or debit card - fill in the [credit card authorisation slip](/government/publications/credit-card-authorisation-form-algeria) and post it with your registration form.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/brazil.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/china.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/czech-republic.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/estonia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/hong-kong.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/italy.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/libya.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/north-korea.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/north-korea.txt
@@ -1,0 +1,87 @@
+
+
+$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+
+This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+
+##Register the death with the UK authorities
+
+You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+
+- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
+- you can order a consular death registration certificate
+
+You will need to:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the forms.
+s3. Pay.
+s4. Post your documents and the forms.
+
+###1. Documents
+
+^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+
+You must provide:
+
+- the hospital medical death record
+
+- a photocopy of the photo page of the passport of the person who died
+- their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
+- written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+
+###2. Forms
+
+Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
+
+###3. Pay
+
+Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
+
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+
+Service | Fee
+-|-
+Register a death | £105
+Copy of a death registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+###4. Send your registration
+
+Once you've paid you will be given a reference number to use on your death registration form.
+
+Post your registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
+
+Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/north-korea.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/north-korea.txt
@@ -1,87 +1,74 @@
 
 
-$!You must register the death according to the regulations in the country where the person died. You will be given a local death certificate.$!
+$!You must register the death according to the regulations in Papua New Guinea. You will be given a local death certificate.$!
 
-This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
+This local death certificate will be accepted in the UK (it may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English).
 
 ##Register the death with the UK authorities
 
-You can also apply to register the death with the UK authorities. You don’t have to do this, but it means:
+You can also apply to register the death with the British embassy in North Korea.
 
-- the death will be recorded with the General Register Offices (for England, Wales and Northern Ireland) and the National Records Office of Scotland
-- you can order a consular death registration certificate
+You don’t have to do this, but it means:
 
-You will need to:
+- a British-style death certificate will be issued
+- having the death registered at the General Register Office in the UK
 
-s1. Check that you have the right documents.
-s2. Print out and fill in the forms.
-s3. Pay.
-s4. Post your documents and the forms.
+##How to register
 
-###1. Documents
+Download and complete a [registration form](/government/publications/application-to-register-an-overseas-death).
 
-^Send English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don't send laminated documents.^
+##Documents
 
-You must provide:
+You must provide originals and a photocopy of:
 
-- the hospital medical death record
-
+- a death certificate issued by Pyongyang Friendship Hospital
 - a photocopy of the photo page of the passport of the person who died
 - their original full UK birth, naturalisation or registration certificate (if you can’t provide their passport)
 - written permission from the person’s next of kin or the executor of their estate (if you’re not next of kin or the executor)
 
-%Your application will be rejected if the documents aren’t authentic, don’t confirm the person’s identity or don’t prove that they were a British national when they died. The registration fee won’t be refunded.%
+Fill in [form D1, 'Returning the passport of a deceased person'](/government/publications/returning-the-passport-of-a-deceased-person) if you provide their passport.
 
-###2. Forms
+Fill in [form LS01, 'Lost or Stolen Passport Notification'](/government/publications/lost-or-stolen-passport-notification--2) if the passport is lost or unavailable.
 
-Print out and fill in the [death registration form](/government/publications/application-to-register-an-overseas-death).
-
-###3. Pay
-
-Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
-
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+##Cost
 
 Service | Fee
 -|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
-You must also pay for your documents to be returned to you.
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 
-Postage destination | Fee
--|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+You can order copies of the registration certificate from the British embassy when you register the death.
 
-<a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>
+You can also get copies from the [General Register Office](http://www.gro.gov.uk/) from September the year after you register - they will cost less.
 
-###4. Send your registration
+##Go to the British embassy
 
-Once you've paid you will be given a reference number to use on your death registration form.
+You can book an appointment at the British embassy and bring along the registration form, supporting documents and the fee.
 
-Post your registration form and documents by secure post to:
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the death will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
 $A
-Overseas Registration Unit
-Foreign & Commonwealth Office
-Hanslope Park
-Hanslope
-Milton Keynes
-MK19 7BH
-United Kingdom
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
 $A
 
-##Return of your documents
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
 
-It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.
+Email: <Pyongyang.enquiries@fco.gov.uk>
 
-They’ll contact you within the 3 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the death to be registered.
-
-Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
-
-You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
 
 
 

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/papua-new-guinea.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/philippines.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/somalia.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/somalia.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/taiwan.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/in_the_uk.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/same_country.txt
@@ -40,7 +40,7 @@ Print out and fill in the [death registration form](/government/publications/app
 
 Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> if you are unable to pay online.
 
-The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
+The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
 
 Service | Fee
 -|-

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/register-a-death.rb: 1f7655d6cb1d3ae6df56f1c8e051f0cc
-test/data/register-a-death-questions-and-responses.yml: d0676f39f79e2db6365db0789f759f4d
-test/data/register-a-death-responses-and-expected-results.yml: 391bf589a4c47df16938517f9a2d6c65
+test/data/register-a-death-questions-and-responses.yml: 17df5ebe5ca83bc959a679e64c1fc0a8
+test/data/register-a-death-responses-and-expected-results.yml: 2085dbf31af22a39ce3ee5cbd178f10d
 lib/smart_answer_flows/register-a-death/outcomes/_fees.govspeak.erb: 295a443bf733cdeb0fcd70282af042cc
 lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb: 5a3909331b2a97a9dac6a13d02e860a9
 lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.erb: a04c0907f44a14d715689ce9182959de

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -7,7 +7,7 @@ lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak
 lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.erb: a04c0907f44a14d715689ce9182959de
 lib/smart_answer_flows/register-a-death/outcomes/no_embassy_result.govspeak.erb: 5a7be7180708c2cc38fb612cee1c8a41
 lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb: a6b37c903518230e682a1b852a60d103
-lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb: c0fe9e576c22269ebc678aef577faaca
+lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb: 2ae8478485be4647a794d2b921360ce7
 lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb: aed4dc1d27dc52b74bdf182e62df8705
 lib/smart_answer_flows/register-a-death/questions/did_the_person_die_at_home_hospital.govspeak.erb: 3405db8cb8b24782fc49981c2fce12e7
 lib/smart_answer_flows/register-a-death/questions/was_death_expected.govspeak.erb: 132d4a52801b619af05519a69f2767dd

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -16,7 +16,7 @@ lib/smart_answer_flows/register-a-death/questions/where_did_the_death_happen.gov
 lib/smart_answer_flows/register-a-death/questions/which_country.govspeak.erb: e816742682e96117df80d67faff13fc8
 lib/smart_answer_flows/register-a-death/questions/which_country_are_you_in_now.govspeak.erb: 9c9399d1588c7d5e01ebf1bf5efa31a1
 lib/smart_answer_flows/register-a-death/register_a_death.govspeak.erb: 1820ba3a5f3ed47816c7f151217be439
-lib/smart_answer/calculators/register_a_death_calculator.rb: 003375345f9c8e37280c6e4700383795
+lib/smart_answer/calculators/register_a_death_calculator.rb: f237018e5d873c81e0fd1e0de3af108e
 lib/data/rates/register_a_death.yml: f24583d68edd4b06242b5a92e08e25c3
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/register-a-death.rb: 1f7655d6cb1d3ae6df56f1c8e051f0cc
-test/data/register-a-death-questions-and-responses.yml: 9a58cc8b0302b696096eebacee83cd9e
-test/data/register-a-death-responses-and-expected-results.yml: 0c4bd48208463a6cbfa0a3e37545b0e3
+test/data/register-a-death-questions-and-responses.yml: d0676f39f79e2db6365db0789f759f4d
+test/data/register-a-death-responses-and-expected-results.yml: 391bf589a4c47df16938517f9a2d6c65
 lib/smart_answer_flows/register-a-death/outcomes/_fees.govspeak.erb: 295a443bf733cdeb0fcd70282af042cc
 lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb: 5a3909331b2a97a9dac6a13d02e860a9
 lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.erb: a04c0907f44a14d715689ce9182959de

--- a/test/data/register-a-death-questions-and-responses.yml
+++ b/test/data/register-a-death-questions-and-responses.yml
@@ -32,6 +32,7 @@
 - hong-kong # :booking_text_embassy_hong_kong
 - italy # :postal_delivery_form
 - libya # :consular_service_fees_libya
+- north-korea
 - papua-new-guinea # :embassy_high_commission_or_consulate "British high commission"
 - philippines # :post_only_#{philippines}
 - somalia

--- a/test/data/register-a-death-questions-and-responses.yml
+++ b/test/data/register-a-death-questions-and-responses.yml
@@ -13,6 +13,7 @@
 :which_country?:
 - democratic-republic-of-the-congo
 - australia # :commonwealth_result
+- austria
 - iran # country_has_no_embassy
 - libya # :approved_translator_link
 - north-korea # :documents_list_embassy_north-korea, :footnote_exceptions

--- a/test/data/register-a-death-responses-and-expected-results.yml
+++ b/test/data/register-a-death-responses-and-expected-results.yml
@@ -279,6 +279,137 @@
 - :current_node: :which_country?
   :responses:
   - overseas
+  - austria
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - overseas
+  - austria
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  :next_node: :which_country_are_you_in_now?
+  :outcome_node: false
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - algeria
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - somalia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - south-georgia-and-south-sandwich-islands
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - overseas
+  - austria
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - overseas
   - iran
   :next_node: :no_embassy_result
   :outcome_node: true

--- a/test/data/register-a-death-responses-and-expected-results.yml
+++ b/test/data/register-a-death-responses-and-expected-results.yml
@@ -228,6 +228,14 @@
   - overseas
   - democratic-republic-of-the-congo
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - democratic-republic-of-the-congo
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -358,6 +366,14 @@
   - austria
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - austria
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country_are_you_in_now?
@@ -508,6 +524,14 @@
   - overseas
   - north-korea
   - another_country
+  - north-korea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - north-korea
+  - another_country
   - papua-new-guinea
   :next_node: :oru_result
   :outcome_node: true
@@ -632,6 +656,14 @@
   - papua-new-guinea
   - another_country
   - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country_are_you_in_now?
+  :responses:
+  - overseas
+  - papua-new-guinea
+  - another_country
+  - north-korea
   :next_node: :oru_result
   :outcome_node: true
 - :current_node: :which_country_are_you_in_now?

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -334,8 +334,8 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'another_country'
         add_response 'north-korea'
       end
-      should "give the oru result and be done" do
-        assert_current_node :oru_result
+      should "give the north korean result and be done" do
+        assert_current_node :north_korea_result
       end
     end # Answer Brazil
     context "Death in Poland, currently in Cameroon" do
@@ -415,7 +415,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         add_response 'north-korea'
       end
       should "take you to the embassy outcome with specific phrasing" do
-        assert_current_node :oru_result
+        assert_current_node :north_korea_result
       end
     end
 


### PR DESCRIPTION
Related to #2806 

[Trello card](https://trello.com/c/EU4LTmBN/249-register-a-birth-north-korea)


## Description

This PR focuses on resolving a long standing content mis-match issue, where a death happened in a country (eg: Austria) and the user lives in North Korea.

This appears to be connected to this [commit](https://github.com/alphagov/smart-answers/commit/e3d5220a0f643b9bf7ba7190378360b8c43f26b6).

Changes have been requsted by the content team via this [document](https://docs.google.com/document/d/1-Sya_n3OVodHQAjcFowS2rMppcC8qK9Lfpndt8YLeKM/edit)


## Factcheck

[Preview link](https://smart-answers-pr-2807.herokuapp.com/register-a-death/y/overseas/austria/another_country/north-korea)
[GOV.UK](https://www.gov.uk/register-a-death/y/overseas/austria/another_country/north-korea)

### Expected changes

- Show relevant content where a death happened in a country (eg: Austria) and the user lives in North Korea.

### Before

![screen shot 2016-11-03 at 15 20 57](https://cloud.githubusercontent.com/assets/84896/19972169/27c1d1be-a1d9-11e6-905a-0a6e2dad3f8c.png)

### After

![screen shot 2016-11-03 at 15 20 42](https://cloud.githubusercontent.com/assets/84896/19972200/2c1ddf5a-a1d9-11e6-98c0-6452e78aac06.png)

