### PR TITLE
Fix bug in visualisation controller

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -1,5 +1,6 @@
 class SmartAnswersController < ApplicationController
   include Slimmer::SharedTemplates
+  include Slimmer::Headers
 
   before_action :find_smart_answer, except: %w(index)
   before_action :redirect_response_to_canonical_url, only: %w{show}

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -193,4 +193,12 @@ class SmartAnswersControllerTest < ActionController::TestCase
       end
     end
   end
+
+  context "GET /<slug>/visualise" do
+    should "display the visualisation" do
+      get :visualise, id: 'smart-answers-controller-sample'
+
+      assert_select "h1", /Smart answers controller sample/
+    end
+  end
 end


### PR DESCRIPTION
In https://github.com/alphagov/smart-answers/pull/2805 the `Slimmer::Headers` module was removed, causing `set_slimmer_headers` to error.

This adds a test and fixes the issue.

https://trello.com/c/49441pPb
