### PR TITLE
PIP Checker: Fix time travel cutoff date

### DIFF
--- a/test/unit/calculators/pip_dates_test.rb
+++ b/test/unit/calculators/pip_dates_test.rb
@@ -26,7 +26,7 @@ module SmartAnswer::Calculators
     context "in_middle_group?" do
       setup do
         @calc = PIPDates.new
-        Timecop.travel('2013-04-07')
+        Timecop.freeze('2013-04-07')
       end
 
       should "be false if born on 1948-04-08" do
@@ -39,10 +39,10 @@ module SmartAnswer::Calculators
         assert @calc.in_middle_group?
       end
 
-      # should "be true if born just before 1997-04-08" do
-      #   @calc.dob = Date.parse('1997-04-07')
-      #   assert @calc.in_middle_group?
-      # end
+      should "be true if born just before 1997-04-08" do
+        @calc.dob = Date.parse('1997-04-07')
+        assert @calc.in_middle_group?
+      end
 
       should "be false if born on 1997-04-08" do
         @calc.dob = Date.parse('1997-04-08')


### PR DESCRIPTION
[Trello card](https://trello.com/c/wPgE2Iuf/409-pipchecker-fix-failing-test-that-depends-on-time)

## Description

This PR freezes the time travel to a cut off date (i.e 2013-04-07).

This statically mocks the current Time.now, as test program executes,
in effect the middle_group? method returns the expected result when
tested against a user's date of birth (eg: 1948-04-08, 1997-04-08 etc).

