### PR TITLE
Update content store environment variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "success_url": "/",
   "env": {
     "GOVUK_APP_DOMAIN": "integration.publishing.service.gov.uk",
-    "PLEK_SERVICE_CONTENTAPI_URI": "https://www.gov.uk/api",
+    "PLEK_SERVICE_CONTENT_STORE_URI": "https://www-origin.integration.publishing.service.gov.uk/api" ,
     "PLEK_SERVICE_STATIC_URI": "https://assets-origin.integration.publishing.service.gov.uk/",
     "RUNNING_ON_HEROKU": "true",
     "EXPOSE_GOVSPEAK": "true",

--- a/doc/common-errors.md
+++ b/doc/common-errors.md
@@ -29,16 +29,16 @@ You'll see this error if the Smart Answers app can't connect to the Content API.
 
 ```
 SocketError at /marriage-abroad
-Failed to open TCP connection to contentapi.dev.gov.uk:80 (getaddrinfo: nodename nor servname provided, or not known)
+Failed to open TCP connection to content_store.dev.gov.uk:80 (getaddrinfo: nodename nor servname provided, or not known)
 ```
 
 ### Resolution
 
 There are a couple of solutions to this problem:
 
-1. Set the `PLEK_SERVICE_CONTENTAPI_URI` environment variable to a valid host. NOTE. This doesn't need to be hosting the Content API (although you can use "https://www.gov.uk/api" if that's what you want), it simply needs to be a host that responds to HTTP requests.
+1. Set the `PLEK_SERVICE_CONTENT_STORE_URI` environment variable to a valid host. NOTE. This doesn't need to be hosting the Content API (although you can use "https://www.gov.uk/api" if that's what you want), it simply needs to be a host that responds to HTTP requests.
 
-2. Configure a web server (e.g. Apache) on your machine to respond to http://contentapi.dev.gov.uk. This is the default location of the Content API in development so configuring this means that you won't have to set the `PLEK_SERVICE_CONTENTAPI_URI` environment variable.
+2. Configure a web server (e.g. Apache) on your machine to respond to http://content_store.dev.gov.uk. This is the default location of the Content API in development so configuring this means that you won't have to set the `PLEK_SERVICE_CONTENT_STORE_URI` environment variable.
 
 
 ## "SocketError" when viewing a Smart Answer (relating to Worldwide API)

--- a/doc/developing-without-vm.md
+++ b/doc/developing-without-vm.md
@@ -3,7 +3,7 @@
 The simplest way to get Smart Answers running locally is to run:
 
 ```bash
-$ PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api \
+$ PLEK_SERVICE_CONTENT_STORE_URI=https://www-origin.integration.publishing.service.gov.uk/api \
 PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk \
 PLEK_SERVICE_STATIC_URI=assets-origin.integration.publishing.service.gov.uk \
 rails s

--- a/startup_heroku.sh
+++ b/startup_heroku.sh
@@ -20,7 +20,7 @@ echo
 heroku config:set \
 --app $APP_NAME \
 GOVUK_APP_DOMAIN=integration.publishing.service.gov.uk \
-PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api \
+PLEK_SERVICE_CONTENT_STORE_URI=https://www-origin.integration.publishing.service.gov.uk/api \
 PLEK_SERVICE_STATIC_URI=https://assets-origin.integration.publishing.service.gov.uk/ \
 RUNNING_ON_HEROKU=true \
 EXPOSE_GOVSPEAK=true \


### PR DESCRIPTION
In #2805 we changed the way we render breadcrumbs and sidebars.  Instead of using the [content-api][1] we use the [content-store][2] as the data source for all the information. We are also using [govuk_navigation][3] gem to generate GOV.UK component data.

This PR update documents and scripts that still refer to [content-store][2]:

- Heroku app
- common-errors.md
- development-without-vm
- startup_heroku.sh

[1]: https://github.com/alphagov/govuk_content_api
[2]: https://github.com/alphagov/content-store
[3]: https://github.com/alphagov/govuk-content-navigation