### PR TITLE
PIP Checker: Fix Timecop vs ::ActiveSupport::TimeWithZone issue

### DIFF
--- a/lib/smart_answer/calculators/pip_dates.rb
+++ b/lib/smart_answer/calculators/pip_dates.rb
@@ -12,7 +12,7 @@ module SmartAnswer::Calculators
     end
 
     def in_middle_group?
-      self.dob > GROUP_65_CUTOFF && self.dob <= 16.years.ago
+      self.dob > GROUP_65_CUTOFF && self.dob <= 16.years.ago(Date.today)
     end
 
     def turning_16_before_oct_2013?

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -12,4 +12,4 @@ lib/smart_answer_flows/pip-checker/outcomes/under_16.govspeak.erb: 39378651df7f8
 lib/smart_answer_flows/pip-checker/pip_checker.govspeak.erb: 05500842dad33cd660d3387925a3d5e9
 lib/smart_answer_flows/pip-checker/questions/are_you_getting_dla.govspeak.erb: 0668b501c4ad913dbbf0e8ffc8af59bb
 lib/smart_answer_flows/pip-checker/questions/what_is_your_dob.govspeak.erb: 8a7f608d4b124caed3c17cdbbd6fa58b
-lib/smart_answer/calculators/pip_dates.rb: 083c4d5f3679c0060edcb35ac18e3150
+lib/smart_answer/calculators/pip_dates.rb: c3b6880fa1830db0ca87502ebd9e19c8


### PR DESCRIPTION
Trello cards
- [#409](https://trello.com/c/wPgE2Iuf/409-pipchecker-fix-failing-test-that-depends-on-time)
- [#414](https://trello.com/c/buSLWlnU/414-pip-checker-fix-timecop-vs-activesupport-timewithzone-issue)



## Description


It appears to me the main reason this fails (i.e middle_group?),
This is because the 16.year.ago (which is from ActiveSupport::Duration#ago [1])
uses :Time.current [2], which underneath returns ::Time.zone.now.

::Time.zone.now is an instance of ActiveSupport::TimeWithZone which
Timecop [3] appears to ignore.

According to this comment [3] Time.cop only caters for the following:

- Date.today
- Time.now
- DateTime.now

Years (i.e 16.years) is only a measurement of time .. see its
implementation here [4]

This is the reason why it is now important to include pass Date.today
to ago.

[1] https://github.com/rails/rails/blob/03cd88a07221a1511c9d06fe4173052bb5554d0b/activesupport/lib/active_support/duration.rb#L69
[2] https://github.com/rails/rails/blob/b775987e72260233c66080483b3c964f9549d094/activesupport/lib/active_support/core_ext/time/calculations.rb#L45

[3] https://github.com/travisjeffery/timecop/blob/master/lib/timecop/timecop.rb#L10

[4]  https://github.com/rails/rails/blob/b451de0d6de4df6bc66b274cec73b919f823d5ae/activesupport/lib/active_support/core_ext/integer/time.rb#L35