### PR TITLE
Change plek service content store uri

### DIFF
--- a/startup_heroku.sh
+++ b/startup_heroku.sh
@@ -20,7 +20,7 @@ echo
 heroku config:set \
 --app $APP_NAME \
 GOVUK_APP_DOMAIN=integration.publishing.service.gov.uk \
-PLEK_SERVICE_CONTENT_STORE_URI=https://www-origin.integration.publishing.service.gov.uk/api \
+PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
 PLEK_SERVICE_STATIC_URI=https://assets-origin.integration.publishing.service.gov.uk/ \
 RUNNING_ON_HEROKU=true \
 EXPOSE_GOVSPEAK=true \


### PR DESCRIPTION
## Description

This PR changes the plek service content store uri from [1] to [2]

This is becuase [1] returns GdsApi::HTTPUnauthorized response when
smartanswers tries to use the content store from heroku, but at the
moment [2] appears to grant access to the content store.

[1]  https://www-origin.integration.publishing.service.gov.uk/api/
[2]  https://www.gov.uk/api/