### PR TITLE
Remove user’s previous birthday from outcome.

### DIFF
--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -30,13 +30,21 @@ module SmartAnswer::Calculators
       return [] if too_young?
       rows = []
       dob = leap_year_birthday?(date_of_birth) ? date_of_birth + 1.day : date_of_birth
-      age = age_at_date(dob, TOPUP_START_DATE)
-      (TOPUP_START_DATE.year..TOPUP_END_DATE.year).each do |_|
+      age = age_at_date(dob, Date.today)
+      (topup_start_year..TOPUP_END_DATE.year).each do |_|
         break if birthday_after_topup_end?(dob, age)
         rows << { amount: lump_sum_amount(age, weekly_amount), age: age } if age >= retirement_age(gender)
         age += 1
       end
       rows
+    end
+
+    def topup_start_year
+      if Date.today.year > TOPUP_START_DATE.year
+        Date.today.year
+      else
+        TOPUP_START_DATE.year
+      end
     end
 
     def too_young?

--- a/lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb
@@ -4,11 +4,15 @@
 <% end %>
 
 <% content_for :body do %>
+<% if calculator.lump_sum_and_age.size == 1 %>
+  To top up your pension by <%= format_money(calculator.weekly_amount) %> per week, you’ll need to make a lump sum payment of <%= number_to_currency(calculator.lump_sum_and_age.first[:amount], precision: 0) %>.
+<% else %>
   To top up your pension by <%= format_money(calculator.weekly_amount) %> per week, you’ll need to make a lump sum payment of either:
 
   <% calculator.lump_sum_and_age.each do |amount_and_age| %>
     - <%= number_to_currency(amount_and_age[:amount], precision: 0) %> when you're <%= amount_and_age[:age] %>
   <% end %>
+<% end %>
 
 
   You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.

--- a/test/artefacts/state-pension-topup/1912-10-12/female/20.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/female/20.txt
@@ -1,8 +1,6 @@
 Results
 
-To top up your pension by £20 per week, you’ll need to make a lump sum payment of either:
-
-- £2,540 when you're 104
+To top up your pension by £20 per week, you’ll need to make a lump sum payment of £2,540.
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.
 

--- a/test/artefacts/state-pension-topup/1912-10-12/female/20.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/female/20.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £20 per week, you’ll need to make a lump sum payment of either:
 
-- £2,540 when you're 103
 - £2,540 when you're 104
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.

--- a/test/artefacts/state-pension-topup/1912-10-12/female/7.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/female/7.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £7 per week, you’ll need to make a lump sum payment of either:
 
-- £889 when you're 103
 - £889 when you're 104
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.

--- a/test/artefacts/state-pension-topup/1912-10-12/female/7.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/female/7.txt
@@ -1,8 +1,6 @@
 Results
 
-To top up your pension by £7 per week, you’ll need to make a lump sum payment of either:
-
-- £889 when you're 104
+To top up your pension by £7 per week, you’ll need to make a lump sum payment of £889.
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.
 

--- a/test/artefacts/state-pension-topup/1912-10-12/male/20.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/male/20.txt
@@ -1,8 +1,6 @@
 Results
 
-To top up your pension by £20 per week, you’ll need to make a lump sum payment of either:
-
-- £2,540 when you're 104
+To top up your pension by £20 per week, you’ll need to make a lump sum payment of £2,540.
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.
 

--- a/test/artefacts/state-pension-topup/1912-10-12/male/20.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/male/20.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £20 per week, you’ll need to make a lump sum payment of either:
 
-- £2,540 when you're 103
 - £2,540 when you're 104
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.

--- a/test/artefacts/state-pension-topup/1912-10-12/male/7.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/male/7.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £7 per week, you’ll need to make a lump sum payment of either:
 
-- £889 when you're 103
 - £889 when you're 104
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.

--- a/test/artefacts/state-pension-topup/1912-10-12/male/7.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/male/7.txt
@@ -1,8 +1,6 @@
 Results
 
-To top up your pension by £7 per week, you’ll need to make a lump sum payment of either:
-
-- £889 when you're 104
+To top up your pension by £7 per week, you’ll need to make a lump sum payment of £889.
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.
 

--- a/test/artefacts/state-pension-topup/1951-04-05/female/20.txt
+++ b/test/artefacts/state-pension-topup/1951-04-05/female/20.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £20 per week, you’ll need to make a lump sum payment of either:
 
-- £18,260 when you're 64
 - £17,800 when you're 65
 - £17,420 when you're 66
 

--- a/test/artefacts/state-pension-topup/1951-04-05/female/7.txt
+++ b/test/artefacts/state-pension-topup/1951-04-05/female/7.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £7 per week, you’ll need to make a lump sum payment of either:
 
-- £6,391 when you're 64
 - £6,230 when you're 65
 - £6,097 when you're 66
 

--- a/test/artefacts/state-pension-topup/1951-04-06/female/20.txt
+++ b/test/artefacts/state-pension-topup/1951-04-06/female/20.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £20 per week, you’ll need to make a lump sum payment of either:
 
-- £18,260 when you're 64
 - £17,800 when you're 65
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.

--- a/test/artefacts/state-pension-topup/1951-04-06/female/20.txt
+++ b/test/artefacts/state-pension-topup/1951-04-06/female/20.txt
@@ -1,8 +1,6 @@
 Results
 
-To top up your pension by £20 per week, you’ll need to make a lump sum payment of either:
-
-- £17,800 when you're 65
+To top up your pension by £20 per week, you’ll need to make a lump sum payment of £17,800.
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.
 

--- a/test/artefacts/state-pension-topup/1951-04-06/female/7.txt
+++ b/test/artefacts/state-pension-topup/1951-04-06/female/7.txt
@@ -1,8 +1,6 @@
 Results
 
-To top up your pension by £7 per week, you’ll need to make a lump sum payment of either:
-
-- £6,230 when you're 65
+To top up your pension by £7 per week, you’ll need to make a lump sum payment of £6,230.
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.
 

--- a/test/artefacts/state-pension-topup/1951-04-06/female/7.txt
+++ b/test/artefacts/state-pension-topup/1951-04-06/female/7.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £7 per week, you’ll need to make a lump sum payment of either:
 
-- £6,391 when you're 64
 - £6,230 when you're 65
 
 You should get [financial advice](/plan-retirement-income/get-financial-advice) when planning your retirement income.

--- a/test/artefacts/state-pension-topup/1953-04-05/female/20.txt
+++ b/test/artefacts/state-pension-topup/1953-04-05/female/20.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £20 per week, you’ll need to make a lump sum payment of either:
 
-- £19,120 when you're 62
 - £18,680 when you're 63
 - £18,260 when you're 64
 

--- a/test/artefacts/state-pension-topup/1953-04-05/female/7.txt
+++ b/test/artefacts/state-pension-topup/1953-04-05/female/7.txt
@@ -2,7 +2,6 @@ Results
 
 To top up your pension by £7 per week, you’ll need to make a lump sum payment of either:
 
-- £6,692 when you're 62
 - £6,538 when you're 63
 - £6,391 when you're 64
 

--- a/test/data/configurations.yml
+++ b/test/data/configurations.yml
@@ -19,3 +19,5 @@
     :current_time: 2016-10-01
   "pip-checker":
     :current_time: 2016-04-05
+  "state-pension-topup":
+    :current_time: 2016-11-01

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -9,6 +9,6 @@ lib/smart_answer_flows/state-pension-topup/questions/dob_age.govspeak.erb: a98e1
 lib/smart_answer_flows/state-pension-topup/questions/gender.govspeak.erb: f388163b3d7abb9c78bfe8265b2f2856
 lib/smart_answer_flows/state-pension-topup/questions/how_much_extra_per_week.govspeak.erb: 76492f1bf67bbfae095c80e7a8cbe465
 lib/smart_answer_flows/state-pension-topup/state_pension_topup.govspeak.erb: 4abd6d43b9288c4da91ace7460d09132
-lib/smart_answer/calculators/state_pension_topup_calculator.rb: fe836ff394a90f6a5a52d6d207b2d198
+lib/smart_answer/calculators/state_pension_topup_calculator.rb: b97c3b655a1df98969e05803850e8064
 lib/smart_answer/calculators/state_pension_topup_data_query.rb: 62717af09ad451e49dbb9e1a4d5422bc
 lib/data/pension_top_up_data.yml: 8fb3111dcf367687e4035e1dcc8d003b

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/state-pension-topup.rb: 55503f016500699b4e8308b0bd5de50f
 test/data/state-pension-topup-questions-and-responses.yml: f4f609a6e989f166616a05435c6993aa
 test/data/state-pension-topup-responses-and-expected-results.yml: 1207c6118839a3b13810038c57a20d4a
 lib/smart_answer_flows/state-pension-topup/outcomes/outcome_pension_age_not_reached.govspeak.erb: 558d49584fe1ece4d36427740d381273
-lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb: 41a93064bc7d73e3d8380d8ecfa76a5b
+lib/smart_answer_flows/state-pension-topup/outcomes/outcome_topup_calculations.govspeak.erb: 49d0a042b736712573192be995d4ee5d
 lib/smart_answer_flows/state-pension-topup/questions/date_of_lump_sum_payment.govspeak.erb: bc785eb5fa3ee27edfaf9f223694942b
 lib/smart_answer_flows/state-pension-topup/questions/dob_age.govspeak.erb: a98e10bf8b60c21f65d307a56046f4d3
 lib/smart_answer_flows/state-pension-topup/questions/gender.govspeak.erb: f388163b3d7abb9c78bfe8265b2f2856

--- a/test/integration/smart_answer_flows/state_pension_topup_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_topup_test.rb
@@ -47,7 +47,6 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
           assert_equal 10.0, current_state.calculator.weekly_amount
           assert_equal Date.parse("1950-02-02"), current_state.calculator.date_of_birth
           assert_equal [
-            { amount: SmartAnswer::Money.new(8900), age: 65 },
             { amount: SmartAnswer::Money.new(8710), age: 66 },
             { amount: SmartAnswer::Money.new(8470), age: 67 }
           ], current_state.calculator.lump_sum_and_age
@@ -94,16 +93,15 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
       assert_current_node :outcome_pension_age_not_reached
     end
   end
-  context "Anyone turns 101 on 2 April 2017 = DOB 2/4/1916" do
+  context "Anyone turns 101 on 2 April 2017 = DOB 2/4/1916 with a top up of £1 a week" do
     setup do
       add_response Date.parse('1916-04-02')
       add_response "male"
       add_response 1
     end
-    should "show three rates, two of them being the max age rate (100 => 127)" do
+    should "show two rates, both of them being for the max age rate (100 years old) and a lump sum of £127)" do
       assert_current_node :outcome_topup_calculations
       assert_equal [
-        { amount: SmartAnswer::Money.new(137), age: 99 },
         { amount: SmartAnswer::Money.new(127), age: 100 },
         { amount: SmartAnswer::Money.new(127), age: 101 }
       ], current_state.calculator.lump_sum_and_age
@@ -118,17 +116,15 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
       assert_current_node :outcome_pension_age_not_reached
     end
   end
-  context "Male born 13/10/1940 needs 3 rates" do
+  context "Male born 13/10/1940 needs one rate" do
     setup do
       add_response Date.parse('1940-10-14')
       add_response "male"
       add_response 1
     end
-    should "go to calculations outcome and show 3 rates" do
+    should "go to calculations outcome and show one rate" do
       assert_current_node :outcome_topup_calculations
       assert_equal [
-        { amount: SmartAnswer::Money.new(694), age: 74 },
-        { amount: SmartAnswer::Money.new(674), age: 75 },
         { amount: SmartAnswer::Money.new(646), age: 76 }
       ], current_state.calculator.lump_sum_and_age
     end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -31,17 +31,35 @@ module SmartAnswer::Calculators
       end
     end
 
+    context "top-up start date" do
+      context "Should show current year" do
+        should "be 2015" do
+          Timecop.freeze("2015-10-31")
+          assert_equal 2015, @calculator.topup_start_year
+        end
+
+        should "be 2016" do
+          Timecop.freeze("2016-10-31")
+          assert_equal 2016, @calculator.topup_start_year
+        end
+
+        should "be 2015 if year is before scheme start date" do
+          Timecop.freeze("2014-10-31")
+          assert_equal 2015, @calculator.topup_start_year
+        end
+      end
+    end
+
     context "lump_sum_and_age" do
       context "when male" do
         setup do
           @calculator.gender = "male"
         end
 
-        should "show two rates for ages 85 and 86" do
+        should "show one rate for age 86" do
           @calculator.date_of_birth = Date.parse('1930-04-06')
           @calculator.weekly_amount = 10
           expectation = [
-            { amount: 3940.0, age: 85 },
             { amount: 3660.0, age: 86 }
           ]
           assert_equal expectation, @calculator.lump_sum_and_age
@@ -61,6 +79,24 @@ module SmartAnswer::Calculators
           @calculator.date_of_birth = Date.parse('1953-04-06')
           assert_equal [], @calculator.lump_sum_and_age
         end
+
+        should "show one rate when born on 1944-05-01 and with top-up of £1 a week" do
+          @calculator.date_of_birth = Date.parse('1944-05-01')
+          @calculator.weekly_amount = 1
+          expectation = [
+            { amount: 738.0, age: 72 },
+          ]
+          assert_equal expectation, @calculator.lump_sum_and_age
+        end
+
+        should "show one rate when born on 1949-10-14 and with top-up of £1 a week" do
+          @calculator.date_of_birth = Date.parse('1949-10-14')
+          @calculator.weekly_amount = 1
+          expectation = [
+            { amount: 847.0, age: 67 },
+          ]
+          assert_equal expectation, @calculator.lump_sum_and_age
+        end
       end
 
       context "when female" do
@@ -72,19 +108,16 @@ module SmartAnswer::Calculators
           @calculator.date_of_birth = Date.parse('1953-04-05')
           @calculator.weekly_amount = 1
           expectation = [
-            { amount: 956.0, age: 62 },
             { amount: 934.0, age: 63 },
             { amount: 913.0, age: 64 },
           ]
           assert_equal expectation, @calculator.lump_sum_and_age
         end
 
-        should "show three rates when born on 1952-10-13 and with top-up of £1 a week" do
+        should "show one rate when born on 1952-10-13 and with top-up of £1 a week" do
           @calculator.date_of_birth = Date.parse('1952-10-13')
           @calculator.weekly_amount = 1
           expectation = [
-            { amount: 956.0, age: 62 },
-            { amount: 934.0, age: 63 },
             { amount: 913.0, age: 64 },
           ]
           assert_equal expectation, @calculator.lump_sum_and_age
@@ -93,6 +126,16 @@ module SmartAnswer::Calculators
         should "show no rates when born on 1953-04-06 or after (too young to qualify)" do
           @calculator.date_of_birth = Date.parse('1953-04-06')
           assert_equal [], @calculator.lump_sum_and_age
+        end
+
+        should "show two rates when born on 1951-04-05 and with top-up of £20 per week" do
+          @calculator.date_of_birth = Date.parse('1951-04-05')
+          @calculator.weekly_amount = 20
+          expectation = [
+            { amount: 17800.0, age: 65 },
+            { amount: 17420.0, age: 66 },
+          ]
+          assert_equal expectation, @calculator.lump_sum_and_age
         end
       end
     end


### PR DESCRIPTION
Trello card: https://trello.com/c/ymI446hb

## Motivation

The calculator tells you how much you pay to top up your State Pension based on:

* the age you were on the birthday before last
* the age you were at your last birthday (ie your current age)
* the age you'll be on your next birthday - this only displays if you reach your next birthday by 5 April 2017, when the top-up scheme
ends.

The first point is causing users some confusion. As, even though the information is correct, they can’t act on it as that year (the birthday before last) is in the past.

Change the calculator so that, instead, it only shows how much you pay to top up your State Pension based on:

* your current age
* the age you'll be on your next birthday if your birthday is before
5 April 2017

## Factcheck
[state-pension-topup](https://smart-answers-pr-2819.herokuapp.com/state-pension-topup/y/1949-10-14/male/1.0)

## Expected changes
[URL on GOV.UK](https://www.gov.uk/state-pension-topup/y/1949-10-14/male/1.0)

* Change the calculator so that it only shows how much you pay to top up your State Pension based on:
  * your current age
  * the age you'll be on your next birthday if your birthday is before 5 April 2017

### Before
![screen shot 2016-11-15 at 11 33 05](https://cloud.githubusercontent.com/assets/5793815/20304294/4d0a156a-ab27-11e6-9b3d-81dea3c42286.png)

### After
![screen shot 2016-12-01 at 10 39 28](https://cloud.githubusercontent.com/assets/5793815/20790917/7a0cba1c-b7b2-11e6-9544-2d1cc4b2a0e3.png)

