### PR TITLE
Change Portugal link to list of translators

### DIFF
--- a/lib/data/translators.yml
+++ b/lib/data/translators.yml
@@ -54,7 +54,7 @@ nepal: /government/publications/nepal-list-of-lawyers
 netherlands: /government/publications/netherlands-list-of-lawyers
 nicaragua: /government/publications/nicaragua-list-of-lawyers
 paraguay: /government/publications/list-of-english-speaking-lawyers-and-translators-in-paraguay
-portugal: /government/publications/portugal-list-of-lawyers
+portugal: /government/publications/portugal-list-of-translators-and-interpreters
 russia: /government/publications/russia-list-of-lawyers
 san-marino: /government/publications/italy-list-of-lawyers
 serbia: /government/publications/list-of-translators-and-interpreters-in-serbia

--- a/test/artefacts/register-a-birth/portugal/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2006-06-30.txt
@@ -1,0 +1,17 @@
+
+
+$!You must register the birth according to the regulations in Portugal.$!
+
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t automatically pass on British nationality to a child born before 1 July 2006.
+
+You may still be able to apply for [British citizenship](https://www.gov.uk/register-british-citizen/born-before-2006-british-father) for the child.
+
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on the father's [legal country of domicile](/government/publications/legitimation-and-domicile) at the time of the birth)
+- the country where the father was [legally domiciled](/government/publications/legitimation-and-domicile) at the time of the birth did not distinguish between married and unmarried parents
+
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/brazil.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/brazil.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/china.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/china.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/czech-republic.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/czech-republic.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/estonia.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/estonia.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/hong-kong.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/hong-kong.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/italy.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/italy.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/libya.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/libya.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/north-korea.txt
@@ -1,0 +1,77 @@
+
+
+$!You can apply to register the birth with the British embassy in North Korea.$!
+
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
+
+##Documents
+
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
+
+You must provide the original copies of:
+
+- a birth certificate issued by Pyongyang Friendship Hospital
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also provide photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+You’ll need to provide originals and a photocopy of each document.
+
+##Cost
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
+
+You can order copies of the registration certificate from the British embassy when you register the birth.
+
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+
+##Go to the British embassy
+
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
+
+$A
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
+$A
+
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/philippines.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/philippines.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/sudan.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/sudan.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/taiwan.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/taiwan.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/in_the_uk.txt
@@ -1,0 +1,84 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/in_the_uk.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/same_country.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/same_country.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/brazil.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/brazil.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/china.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/china.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/czech-republic.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/czech-republic.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/estonia.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/estonia.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/hong-kong.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/hong-kong.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/italy.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/italy.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/libya.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/libya.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/north-korea.txt
@@ -1,0 +1,75 @@
+
+
+$!You can apply to register the birth with the British embassy in North Korea.$!
+
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
+
+##Documents
+
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
+
+You must provide the original copies of:
+
+- a birth certificate issued by Pyongyang Friendship Hospital
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also provide photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+You’ll need to provide originals and a photocopy of each document.
+
+##Cost
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
+
+You can order copies of the registration certificate from the British embassy when you register the birth.
+
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+
+##Go to the British embassy
+
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
+
+$A
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
+$A
+
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/papua-new-guinea.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/philippines.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/philippines.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/sudan.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/sudan.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/taiwan.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/taiwan.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/in_the_uk.txt
@@ -1,0 +1,84 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/in_the_uk.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/same_country.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/same_country.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/brazil.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/brazil.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/china.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/china.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/czech-republic.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/czech-republic.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/estonia.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/estonia.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/hong-kong.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/hong-kong.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/italy.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/italy.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/libya.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/libya.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/north-korea.txt
@@ -1,0 +1,77 @@
+
+
+$!You can apply to register the birth with the British embassy in North Korea.$!
+
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
+
+##Documents
+
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
+
+You must provide the original copies of:
+
+- a birth certificate issued by Pyongyang Friendship Hospital
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also provide photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+You’ll need to provide originals and a photocopy of each document.
+
+##Cost
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
+
+You can order copies of the registration certificate from the British embassy when you register the birth.
+
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+
+##Go to the British embassy
+
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
+
+$A
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
+$A
+
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/papua-new-guinea.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/papua-new-guinea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/philippines.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/philippines.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/sudan.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/sudan.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/taiwan.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/taiwan.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/in_the_uk.txt
@@ -1,0 +1,84 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/in_the_uk.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/same_country.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/same_country.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/brazil.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/brazil.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/china.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/china.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/czech-republic.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/czech-republic.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/estonia.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/estonia.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/hong-kong.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/hong-kong.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/italy.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/italy.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/libya.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/libya.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/north-korea.txt
@@ -1,0 +1,75 @@
+
+
+$!You can apply to register the birth with the British embassy in North Korea.$!
+
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
+
+##Documents
+
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
+
+You must provide the original copies of:
+
+- a birth certificate issued by Pyongyang Friendship Hospital
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also provide photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+You’ll need to provide originals and a photocopy of each document.
+
+##Cost
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
+
+You can order copies of the registration certificate from the British embassy when you register the birth.
+
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+
+##Go to the British embassy
+
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
+
+$A
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
+$A
+
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/papua-new-guinea.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/philippines.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/philippines.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/sudan.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/sudan.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/taiwan.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/taiwan.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/in_the_uk.txt
@@ -1,0 +1,84 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/in_the_uk.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/same_country.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/same_country.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/brazil.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/brazil.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/china.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/china.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/czech-republic.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/czech-republic.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/estonia.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/estonia.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/hong-kong.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/hong-kong.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/italy.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/italy.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/libya.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/libya.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/north-korea.txt
@@ -1,0 +1,77 @@
+
+
+$!You can apply to register the birth with the British embassy in North Korea.$!
+
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
+
+##Documents
+
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
+
+You must provide the original copies of:
+
+- a birth certificate issued by Pyongyang Friendship Hospital
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also provide photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+You’ll need to provide originals and a photocopy of each document.
+
+##Cost
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
+
+You can order copies of the registration certificate from the British embassy when you register the birth.
+
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+
+##Go to the British embassy
+
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+The mother must register the birth. If you want the father’s name on the consular birth certificate, both parents will need to swear a paternity declaration in person at the nearest consulate.
+
+Paternity declarations are free. Contact the consulate for more details.
+
+$A
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
+$A
+
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/philippines.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/philippines.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/sudan.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/sudan.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/taiwan.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/taiwan.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/in_the_uk.txt
@@ -1,0 +1,84 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/in_the_uk.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/same_country.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/same_country.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/brazil.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/brazil.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/china.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/china.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/czech-republic.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/czech-republic.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/estonia.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/estonia.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/hong-kong.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/hong-kong.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/italy.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/italy.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/libya.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/libya.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/north-korea.txt
@@ -1,0 +1,75 @@
+
+
+$!You can apply to register the birth with the British embassy in North Korea.$!
+
+Download and complete the [birth registration form](/government/publications/application-to-register-an-overseas-birth).
+
+##Documents
+
+^Provide English translations of all foreign documents. Use a professional translator and include their name and address with your application. Don’t provide laminated documents.^
+
+You must provide the original copies of:
+
+- a birth certificate issued by Pyongyang Friendship Hospital
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also provide photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo page of the parent’s current passport (for British parents)
+- the birth certificate or the photo page of the parent’s current passport (for parents who aren’t British)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+You’ll need to provide originals and a photocopy of each document.
+
+##Cost
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
+
+You can order copies of the registration certificate from the British embassy when you register the birth.
+
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+
+##Go to the British embassy
+
+Book an appointment at the British embassy and bring the registration form, supporting documents and the fee.
+
+Either parent can register the birth.
+
+$A
+British Embassy Pyongyang
+Munsu-Dong Compound,, 
+Pyongyang,
+Democratic People&#39;s Republic of Korea
+Pyongyang
+North Korea
+$A
+
+$C
+Telephone: 00 (850) 2 381 7982
+Telephone (out-of-hours emergency): 00 (850) 191 250 7980 (from outside DPRK)
+Fax: (+850) 2 381 7985
+
+Email: <Pyongyang.enquiries@fco.gov.uk>
+
+[ British Embassy Pyongyang - opening hours](https://www.gov.uk/government/world/organisations/british-embassy-pyonyang/office/british-embassy-pyongyang)
+$C
+
+^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
+
+Your documents will be returned to the British Embassy in Pyongyang after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -1,0 +1,88 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
+
+You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/philippines.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/philippines.txt
@@ -1,0 +1,90 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/sudan.txt
@@ -1,0 +1,92 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities.
+
+^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first.^
+
+To register the birth with the UK authorities you must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You can [pay for the registration online](https://pay-register-birth-abroad.service.gov.uk/start).
+
+If you’re unable to pay for the registration online, you can also pay in person at the Consular section of the [British Embassy, Khartoum](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact).
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/sudan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/sudan.txt
@@ -15,7 +15,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/taiwan.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/taiwan.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/in_the_uk.txt
@@ -1,0 +1,84 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign and Commonwealth Office
+PO Box 6255
+Milton Keynes
+MK10 1XX
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/in_the_uk.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/same_country.txt
@@ -1,0 +1,86 @@
+
+
+$!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
+
+You can also register the birth with the UK authorities. You must:
+
+s1. Check that you have the right documents.
+s2. Print out and fill in the birth registration form.
+s3. Pay.
+s4. Post your documents and the form.
+
+##1. Check your documents
+
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+
+You must send the original versions of:
+
+- the child’s full local birth certificate (‘assento de nascimento’) - it must have both parents’ names
+- the hospital declaration of live birth (if the hospital’s name is not on your child’s birth certificate)
+
+- the long version of the parent’s birth certificate showing the child’s grandparents’ details (for parents who were born in the UK)
+- the parent’s naturalisation or registration certificate (for parents who weren’t born in the UK)
+- the parents’ marriage or civil partnership certificate (if applicable)
+- evidence that the parents’ previous marriages or civil partnerships have ended (eg divorce or death certificates)
+- change of name documents (if either parent has ever changed their name)
+- a letter from the parent’s employer if they’re working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+- written evidence if the parent was born overseas while one of their own parents was working abroad as a UK civil servant, EU civil servant, diplomat or member of HM Forces (for British parents)
+
+You must also send photocopies of:
+
+- the photo page of the child’s British passport if they have one
+- the photo pages of both parents’ current passports regardless of nationality (if you don't have a passport, send a copy of another identity document that has a photo)
+
+%Your application will be rejected if the documents aren’t authentic, don’t confirm the child’s identity or don’t prove that the child has a claim to British nationality. The registration fee won’t be refunded.%
+
+##2. Fill in the application form
+
+Print out and fill in the [application form](/government/publications/application-to-register-an-overseas-birth).
+
+##3. Pay
+
+You should pay online for the registration. Email <birthregistrationenquiries@fco.gov.uk> if you’re unable to pay online.
+
+The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from November the year after you register.
+
+Once you’ve paid you will be given a reference number to use on your birth registration form.
+
+Service | Fee
+-|-
+Register a birth | £105
+Copy of a birth registration certificate | £65
+
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
+Rest of world | £22
+
+<a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>
+
+##4. Send your registration
+
+Post the registration form and documents by secure post to:
+
+$A
+Overseas Registration Unit
+Foreign & Commonwealth Office
+Hanslope Park
+Hanslope
+Milton Keynes
+MK19 7BH
+United Kingdom
+$A
+
+##Return of your documents
+
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
+
+Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
+
+
+

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/same_country.txt
@@ -11,7 +11,7 @@ s4. Post your documents and the form.
 
 ##1. Check your documents
 
-^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-lawyers) and include their name and address with your application. Don't send laminated documents.^
+^Send English translations of all foreign documents. Use an [approved translator](/government/publications/portugal-list-of-translators-and-interpreters) and include their name and address with your application. Don't send laminated documents.^
 
 You must send the original versions of:
 

--- a/test/artefacts/register-a-birth/portugal/neither.txt
+++ b/test/artefacts/register-a-birth/portugal/neither.txt
@@ -1,0 +1,6 @@
+
+
+You can’t register your child’s birth with the UK authorities. Your child must have an automatic claim to British nationality at birth to be eligible.
+
+
+

--- a/test/artefacts/register-a-death/portugal.txt
+++ b/test/artefacts/register-a-death/portugal.txt
@@ -1,0 +1,16 @@
+Where did the death happen?
+
+
+
+
+
+  * england_wales: England or Wales
+  * scotland: Scotland
+  * northern_ireland: Northern Ireland
+  * overseas: Abroad
+
+
+
+
+
+

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -23,7 +23,7 @@ lib/data/rates/register_a_birth.yml: 8d678c61d06f614a67e8faa1933b0ff5
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 0bc67c4469fe692a4fa53c9b461821bf
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
-lib/data/translators.yml: d8aae004accbb90983664f63fb76e813
+lib/data/translators.yml: 79abd2e0c2570130f7d832e4242c153a
 lib/data/registrations.yml: ffb11e760ce3aa07cf342caaedb3e6f5
 lib/smart_answer/calculators/country_name_formatter.rb: 583df7103672f581bf5510732c1b2be1
 lib/smart_answer/calculators/registrations_data_query.rb: 3afcd514ecedadd19b0db67f54ac5ea6

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/register-a-birth.rb: ecd4500ead144c94294a25e9bb66b420
-test/data/register-a-birth-questions-and-responses.yml: a557e64da8feb7af1b2699780f606354
-test/data/register-a-birth-responses-and-expected-results.yml: d0d0e64fcbbf0cc6e02ef75e35d409f2
+test/data/register-a-birth-questions-and-responses.yml: b4dd33367f71386f8fca61bc9ec36300
+test/data/register-a-birth-responses-and-expected-results.yml: 76a52a8d6650219a67785b56506ed9fb
 lib/smart_answer_flows/register-a-birth/outcomes/_fees.govspeak.erb: 8c7e4d35431cb9a708504fec00558b02
 lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb: f259f0c518f6b418a683d6482874a451
 lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb: d3df03e03088e121a8c9608697219f33

--- a/test/data/register-a-birth-questions-and-responses.yml
+++ b/test/data/register-a-birth-questions-and-responses.yml
@@ -10,6 +10,7 @@
 - netherlands
 - north-korea # handled by the embassy if user is currently in the country
 - papua-new-guinea # registration_can_take_3_months
+- portugal
 - philippines # oru_extra_documents_in_philippines_when_mother_not_british
 - sierra-leone # oru_extra_documents_variant_intro
 - somalia

--- a/test/data/register-a-birth-responses-and-expected-results.yml
+++ b/test/data/register-a-birth-responses-and-expected-results.yml
@@ -103,7 +103,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -279,7 +279,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -474,7 +474,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -661,7 +661,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -800,7 +800,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -945,7 +945,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -1110,7 +1110,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -1260,7 +1260,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -1399,7 +1399,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -1560,7 +1560,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -1699,7 +1699,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -1844,7 +1844,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -2009,7 +2009,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -2159,7 +2159,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -2298,7 +2298,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -2464,7 +2464,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -2603,7 +2603,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -2748,7 +2748,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -2913,7 +2913,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -3063,7 +3063,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -3202,7 +3202,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -3358,7 +3358,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -3497,7 +3497,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -3642,7 +3642,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -3807,7 +3807,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -3957,7 +3957,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -4096,7 +4096,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -4252,7 +4252,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -4391,7 +4391,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -4536,7 +4536,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -4701,7 +4701,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -4851,7 +4851,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -4990,7 +4990,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -5146,7 +5146,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -5285,7 +5285,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -5430,7 +5430,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -5595,7 +5595,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -5745,7 +5745,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -5884,7 +5884,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -5933,6 +5933,900 @@
 - :current_node: :who_has_british_nationality?
   :responses:
   - papua-new-guinea
+  - neither
+  :next_node: :no_registration_result
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - portugal
+  :next_node: :who_has_british_nationality?
+  :outcome_node: false
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - portugal
+  - mother
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - north-korea
+  :next_node: :north_korea_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - north-korea
+  :next_node: :north_korea_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother
+  - 'no'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - portugal
+  - father
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - north-korea
+  :next_node: :north_korea_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - father
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  :next_node: :childs_date_of_birth?
+  :outcome_node: false
+- :current_node: :childs_date_of_birth?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2006-06-30'
+  :next_node: :homeoffice_result
+  :outcome_node: true
+- :current_node: :childs_date_of_birth?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - north-korea
+  :next_node: :north_korea_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - father
+  - 'no'
+  - '2015-02-02'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - portugal
+  - mother_and_father
+  :next_node: :married_couple_or_civil_partnership?
+  :outcome_node: false
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - north-korea
+  :next_node: :north_korea_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'yes'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :married_couple_or_civil_partnership?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  :next_node: :where_are_you_now?
+  :outcome_node: false
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - same_country
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  :next_node: :which_country?
+  :outcome_node: false
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - brazil
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - china
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - czech-republic
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - estonia
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - hong-kong
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - italy
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - libya
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - north-korea
+  :next_node: :north_korea_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - papua-new-guinea
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - philippines
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - sudan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :which_country?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - another_country
+  - taiwan
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :where_are_you_now?
+  :responses:
+  - portugal
+  - mother_and_father
+  - 'no'
+  - in_the_uk
+  :next_node: :oru_result
+  :outcome_node: true
+- :current_node: :who_has_british_nationality?
+  :responses:
+  - portugal
   - neither
   :next_node: :no_registration_result
   :outcome_node: true
@@ -6040,7 +6934,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -6179,7 +7073,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -6324,7 +7218,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -6489,7 +7383,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -6639,7 +7533,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -6778,7 +7672,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -6934,7 +7828,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -7073,7 +7967,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -7218,7 +8112,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -7383,7 +8277,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -7533,7 +8427,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -7672,7 +8566,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -7833,7 +8727,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -7972,7 +8866,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -8117,7 +9011,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -8282,7 +9176,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -8432,7 +9326,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -8571,7 +9465,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -8727,7 +9621,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -8866,7 +9760,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -9011,7 +9905,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -9176,7 +10070,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -9326,7 +10220,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -9465,7 +10359,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -9621,7 +10515,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -9760,7 +10654,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -9905,7 +10799,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -10070,7 +10964,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -10220,7 +11114,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -10359,7 +11253,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -10515,7 +11409,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -10654,7 +11548,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -10799,7 +11693,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -10964,7 +11858,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -11114,7 +12008,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -11253,7 +12147,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -11409,7 +12303,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -11548,7 +12442,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -11693,7 +12587,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -11858,7 +12752,7 @@
   - '2015-02-02'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -12008,7 +12902,7 @@
   - 'yes'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:
@@ -12147,7 +13041,7 @@
   - 'no'
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country?
   :responses:

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/register-a-death.rb: 1f7655d6cb1d3ae6df56f1c8e051f0cc
-test/data/register-a-death-questions-and-responses.yml: 17df5ebe5ca83bc959a679e64c1fc0a8
-test/data/register-a-death-responses-and-expected-results.yml: 2085dbf31af22a39ce3ee5cbd178f10d
+test/data/register-a-death-questions-and-responses.yml: a422d90c6e5ee9ebbbf2da30f039d846
+test/data/register-a-death-responses-and-expected-results.yml: 6f3be8b4dd12987fe0288c22d212204e
 lib/smart_answer_flows/register-a-death/outcomes/_fees.govspeak.erb: 295a443bf733cdeb0fcd70282af042cc
 lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb: 5a3909331b2a97a9dac6a13d02e860a9
 lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.erb: a04c0907f44a14d715689ce9182959de

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -21,7 +21,7 @@ lib/data/rates/register_a_death.yml: f24583d68edd4b06242b5a92e08e25c3
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 0bc67c4469fe692a4fa53c9b461821bf
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
-lib/data/translators.yml: d8aae004accbb90983664f63fb76e813
+lib/data/translators.yml: 79abd2e0c2570130f7d832e4242c153a
 lib/smart_answer/calculators/registrations_data_query.rb: 3afcd514ecedadd19b0db67f54ac5ea6
 lib/smart_answer/calculators/country_name_formatter.rb: 583df7103672f581bf5510732c1b2be1
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127

--- a/test/data/register-a-death-questions-and-responses.yml
+++ b/test/data/register-a-death-questions-and-responses.yml
@@ -1,6 +1,7 @@
 ---
 :where_did_the_death_happen?:
 - england_wales
+- portugal
 - scotland
 - northern_ireland
 - overseas

--- a/test/data/register-a-death-responses-and-expected-results.yml
+++ b/test/data/register-a-death-responses-and-expected-results.yml
@@ -46,6 +46,11 @@
   :outcome_node: true
 - :current_node: :where_did_the_death_happen?
   :responses:
+  - portugal
+  :next_node: :where_did_the_death_happen?
+  :outcome_node: false
+- :current_node: :where_did_the_death_happen?
+  :responses:
   - scotland
   :next_node: :did_the_person_die_at_home_hospital?
   :outcome_node: false
@@ -229,7 +234,7 @@
   - democratic-republic-of-the-congo
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country_are_you_in_now?
   :responses:
@@ -374,7 +379,7 @@
   - austria
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country_are_you_in_now?
   :responses:
@@ -525,7 +530,7 @@
   - north-korea
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country_are_you_in_now?
   :responses:
@@ -664,7 +669,7 @@
   - papua-new-guinea
   - another_country
   - north-korea
-  :next_node: :oru_result
+  :next_node: :north_korea_result
   :outcome_node: true
 - :current_node: :which_country_are_you_in_now?
   :responses:


### PR DESCRIPTION
### Trello card 
[Register a death: Fix Portugal translators link](https://trello.com/c/6zuLYkMl/405-register-a-death-fix-portugal-translators-link)

## Description
Fix link on Register A Death that points to list of lawyers when it should be pointing to a list of translators.

## Factcheck
[Factcheck version](https://smart-answers-pr-2822.herokuapp.com/register-a-death/y/overseas/portugal/in_the_uk)

## Expected changes
[URL on GOV.UK](https://www.gov.uk/register-a-death/y/overseas/portugal/in_the_uk)

#### Before

https://www.gov.uk/register-a-death/y/overseas/portugal/in_the_uk

![image](https://cloud.githubusercontent.com/assets/424772/20481206/ea1baeb2-afdd-11e6-8fa9-18dc8c9f0df7.png)


#### After
https://smart-answers-pr-2822.herokuapp.com/register-a-death/y/overseas/portugal/in_the_uk

![image](https://cloud.githubusercontent.com/assets/424772/20481122/7e9814aa-afdd-11e6-884a-2b9219c2f9ec.png)

