### PR TITLE
Generate test artefacts for Portugal

### DIFF
--- a/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/father/no/2015-02-02/another_country/north-korea.txt
@@ -40,7 +40,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 You can order copies of the registration certificate from the British embassy when you register the birth.
 
-Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until November the year after you register.
 
 ##Go to the British embassy
 

--- a/test/artefacts/register-a-birth/portugal/father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/father/yes/another_country/north-korea.txt
@@ -40,7 +40,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 You can order copies of the registration certificate from the British embassy when you register the birth.
 
-Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until November the year after you register.
 
 ##Go to the British embassy
 

--- a/test/artefacts/register-a-birth/portugal/mother/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/no/another_country/north-korea.txt
@@ -40,7 +40,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 You can order copies of the registration certificate from the British embassy when you register the birth.
 
-Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until November the year after you register.
 
 ##Go to the British embassy
 

--- a/test/artefacts/register-a-birth/portugal/mother/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother/yes/another_country/north-korea.txt
@@ -40,7 +40,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 You can order copies of the registration certificate from the British embassy when you register the birth.
 
-Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until November the year after you register.
 
 ##Go to the British embassy
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/no/another_country/north-korea.txt
@@ -40,7 +40,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 You can order copies of the registration certificate from the British embassy when you register the birth.
 
-Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until November the year after you register.
 
 ##Go to the British embassy
 

--- a/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/north-korea.txt
+++ b/test/artefacts/register-a-birth/portugal/mother_and_father/yes/another_country/north-korea.txt
@@ -40,7 +40,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 You can order copies of the registration certificate from the British embassy when you register the birth.
 
-Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until September the year after you register.
+Cheaper copies will be available from the [General Register Office](http://www.gro.gov.uk) in the UK, but not until November the year after you register.
 
 ##Go to the British embassy
 


### PR DESCRIPTION
Generate test artefacts for Portugal in register-a-birth

The regression tests were failing for Portugal in register-a-birth.
See: https://ci.dev.publishing.service.gov.uk/job/govuk_smart_answers_regressions/6112/console

I think that when PR #2822 was rebased over PR #2820 the shared change
to the GRO text for North Korea needed to be regenerated.