### PR TITLE
Update plek content store url

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "success_url": "/",
   "env": {
     "GOVUK_APP_DOMAIN": "integration.publishing.service.gov.uk",
-    "PLEK_SERVICE_CONTENT_STORE_URI": "https://www-origin.integration.publishing.service.gov.uk/api" ,
+    "PLEK_SERVICE_CONTENT_STORE_URI": "https://www.gov.uk/api" ,
     "PLEK_SERVICE_STATIC_URI": "https://assets-origin.integration.publishing.service.gov.uk/",
     "RUNNING_ON_HEROKU": "true",
     "EXPOSE_GOVSPEAK": "true",

--- a/doc/developing-without-vm.md
+++ b/doc/developing-without-vm.md
@@ -3,7 +3,7 @@
 The simplest way to get Smart Answers running locally is to run:
 
 ```bash
-$ PLEK_SERVICE_CONTENT_STORE_URI=https://www-origin.integration.publishing.service.gov.uk/api \
+$ PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
 PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk \
 PLEK_SERVICE_STATIC_URI=assets-origin.integration.publishing.service.gov.uk \
 rails s


### PR DESCRIPTION
Following some deployments to heroku by content designers,

This [1] plek content store url returned 403 status. Now switching
to use [2].

[1] https://www-origin.integration.publishing.service.gov.uk/api
[2] https://www.gov.uk/api