### PR TITLE
Self assessment penalty a11y changes

### DIFF
--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_much_tax.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_much_tax.govspeak.erb
@@ -1,13 +1,13 @@
 <% content_for :title do %>
-  Please enter how much your tax bill is (or an estimate if you don’t know)
+  How much was your tax bill?
 <% end %>
 
 <% content_for :hint do %>
-  This calculator is anonymous. None of your details will be passed to HMRC.
+  Enter an estimate if you don't know the exact amount.
 <% end %>
 
-<% content_for :suffix_label do %>
-  for the tax year
+<% content_for :post_body do %>
+  Your details won't be passed to HMRC.
 <% end %>
 
 <% content_for :error_message do %>


### PR DESCRIPTION
https://trello.com/c/9hO2wjHs/336-smart-answer-accessibility-changes (team 2 board)
https://trello.com/c/4glCGIOI/464-accessibility-fixes-for-smart-answers-self-assessment-penalty-childcare-costs (content tools board)

This is part of a cross-team set of changes to improve accessibility in our smart answers by removing pre-field body text, removing suffix fields.

CHANGED
Please enter how much your tax bill is (or an estimate if you don’t know)

TO
How much was your tax bill?

REASON
More concise, and avoids hint in the question.

MOVED AND CHANGED
<% content_for :hint do %>
This calculator is anonymous. None of your details will be passed to HMRC.
<% end %>

TO
<% content_for :post_body do %>
Your details won't be passed to HMRC.
<% end %>

REASON
More concise, and moved to post_body because it's not a hint.

ADDED
<% content_for :hint do %>
Enter an estimate if you don't know the exact amount.
<% end %>

REASON
Moved from title into hint, as it's an instruction to help with completing the field.

REMOVED
<% content_for :suffix_label do %>
for the tax year
<% end %>

REASON
Suffix labels are not accessible