### PR TITLE
Childcare costs a11y changes

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/new_weekly_costs.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/new_weekly_costs.govspeak.erb
@@ -2,6 +2,6 @@
   What are your new weekly costs?
 <% end %>
 
-<% content_for :body do %>
+<% content_for :hint do %>
   Round the total up to the nearest pound.
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_weekly_amount_1.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_weekly_amount_1.govspeak.erb
@@ -2,9 +2,11 @@
   What was the old average weekly amount you gave the Tax Credit Office?
 <% end %>
 
-<% content_for :body do %>
+<% content_for :post_body do %>
   If you don’t know what your previous childcare costs were, check your award or renewal notice.
-
-  Round the total up to the nearest pound.
-
 <% end %>
+
+<% content_for :hint do %>
+  Round the total up to the nearest pound.
+<% end %>
+

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_weekly_amount_1.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_weekly_amount_1.govspeak.erb
@@ -2,11 +2,10 @@
   What was the old average weekly amount you gave the Tax Credit Office?
 <% end %>
 
-<% content_for :post_body do %>
-  If you don’t know what your previous childcare costs were, check your award or renewal notice.
-<% end %>
-
 <% content_for :hint do %>
   Round the total up to the nearest pound.
 <% end %>
 
+<% content_for :post_body do %>
+  If you don’t know what your previous childcare costs were, check your award or renewal notice.
+<% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_weekly_amount_2.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_weekly_amount_2.govspeak.erb
@@ -2,9 +2,10 @@
   What was the old average weekly amount you gave the Tax Credit Office?
 <% end %>
 
-<% content_for :body do %>
-  If you don’t know what your previous childcare costs were, check your award or renewal notice.
-
+<% content_for :hint do %>
   Round the total up to the nearest pound.
+<% end %>
 
+<% content_for :post_body do %>
+  If you don’t know what your previous childcare costs were, check your award or renewal notice.
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_weekly_amount_3.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_weekly_amount_3.govspeak.erb
@@ -2,9 +2,10 @@
   What was the old average weekly amount you gave the Tax Credit Office?
 <% end %>
 
-<% content_for :body do %>
-  If you don’t know what your previous childcare costs were, check your award or renewal notice.
-
+<% content_for :hint do %>
   Round the total up to the nearest pound.
+<% end %>
 
+<% content_for :post_body do %>
+  If you don’t know what your previous childcare costs were, check your award or renewal notice.
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/pay_same_each_time.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/pay_same_each_time.govspeak.erb
@@ -2,15 +2,11 @@
   Do you pay the same each time?
 <% end %>
 
+<% content_for :hint do %>
+  Answer no if you pay a different amount each week or month, or during school holidays. This is known as 'variable costs'.
+<% end %>
+
 <% options(
   "yes": "Yes",
   "no": "No"
 ) %>
-
-<% content_for :body do %>
-  Sometimes you may pay - or expect to pay - different amounts for childcare (known as ‘variable costs’), for example:
-
-  - you regularly use childcare, but pay more during school holidays than you do at term time
-  - the hours you use childcare change from week to week or month to month
-
-<% end %>


### PR DESCRIPTION
https://trello.com/c/9hO2wjHs/336-smart-answer-accessibility-changes

This is part of a cross-team set of changes to improve accessibility in our smart answers by removing pre-field body text, removing suffix fields.

---
new_weekly_costs.govspeak.erb
---

CHANGED
<% content_for :body do %>

TO
<% content_for :hint do %>

REASON
Body text in a form is not accessible 

---
old_weekly_amount_1.govspeak.erb
---

CHANGED
<% content_for :body do %>
If you don’t know what your previous childcare costs were, check your award or renewal notice.		        

Round the total up to the nearest pound.
<% end %>

TO
<% content_for :hint do %>
Round the total up to the nearest pound.
<% end %>

<% content_for :post_body do %>
If you don’t know what your previous childcare costs were, check your award or renewal notice.		     <% end %>  		  

REASON
- body text in a form is not accessible 
- swapped order so that hint comes before post_body in the code

---
old_weekly_amount_2.govspeak.erb
---

Same changes and reasons as old_weekly_amount_1

---
old_weekly_amount_3.govspeak.erb
---

Same changes and reasons as old_weekly_amount_1

---
pay_same_each_time.govspeak.erb
---

CHANGED
<% content_for :body do %>
Sometimes you may pay - or expect to pay - different amounts for childcare (known as ‘variable costs’), for example:
- you regularly use childcare, but pay more during school holidays than you do at term time
- the hours you use childcare change from week to week or month to month
<% end %>

TO
<% content_for :hint do %>
Answer no if you pay a different amount each week or month, or during school holidays. This is known as 'variable costs'.
<% end %>

REASON
- Body text in a form is not accessible
- Made the hint clearer about what we mean by 'pay the same each time'