### PR TITLE
Automate date ranges for redundancy pay calculators

### DIFF
--- a/lib/smart_answer/calculators/redundancy_calculator.rb
+++ b/lib/smart_answer/calculators/redundancy_calculator.rb
@@ -39,5 +39,27 @@ module SmartAnswer::Calculators
     def self.northern_ireland_redundancy_rates(date)
       RatesQuery.from_file('redundancy_pay_northern_ireland').rates(date)
     end
+
+    def self.first_selectable_date
+      if between_january_and_august?
+        four_years_ago
+      else
+        three_years_ago
+      end
+    end
+
+    def self.between_january_and_august?
+      Date.today.month < 9
+    end
+
+    def self.four_years_ago
+      4.years.ago.beginning_of_year
+    end
+
+    def self.three_years_ago
+      3.years.ago.beginning_of_year
+    end
+
+    private_class_method :between_january_and_august?, :four_years_ago, :three_years_ago
   end
 end

--- a/lib/smart_answer/calculators/redundancy_calculator.rb
+++ b/lib/smart_answer/calculators/redundancy_calculator.rb
@@ -48,6 +48,14 @@ module SmartAnswer::Calculators
       end
     end
 
+    def self.last_selectable_date
+      if between_january_and_august?
+        end_of_current_year
+      else
+        end_of_next_year
+      end
+    end
+
     def self.between_january_and_august?
       Date.today.month < 9
     end
@@ -60,6 +68,14 @@ module SmartAnswer::Calculators
       3.years.ago.beginning_of_year
     end
 
-    private_class_method :between_january_and_august?, :four_years_ago, :three_years_ago
+    def self.end_of_current_year
+      Date.today.end_of_year
+    end
+
+    def self.end_of_next_year
+      Date.today.next_year.end_of_year
+    end
+
+    private_class_method :between_january_and_august?, :four_years_ago, :three_years_ago, :end_of_current_year, :end_of_next_year
   end
 end

--- a/lib/smart_answer_flows/shared/redundancy_pay_flow.rb
+++ b/lib/smart_answer_flows/shared/redundancy_pay_flow.rb
@@ -4,7 +4,7 @@ module SmartAnswer
       def define
         date_question :date_of_redundancy? do
           from { Calculators::RedundancyCalculator.first_selectable_date }
-          to { 1.year.since }
+          to { Calculators::RedundancyCalculator.last_selectable_date }
           validate_in_range
 
           calculate :rates do |response|

--- a/lib/smart_answer_flows/shared/redundancy_pay_flow.rb
+++ b/lib/smart_answer_flows/shared/redundancy_pay_flow.rb
@@ -3,7 +3,7 @@ module SmartAnswer
     class RedundancyPayFlow < Flow
       def define
         date_question :date_of_redundancy? do
-          from { Date.civil(2013, 1, 1) }
+          from { Calculators::RedundancyCalculator.first_selectable_date }
           to { 1.year.since }
           validate_in_range
 

--- a/test/data/calculate-employee-redundancy-pay-files.yml
+++ b/test/data/calculate-employee-redundancy-pay-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/age_of_employ
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/date_of_redundancy.govspeak.erb: e6ba7dfca27ad55335fb2cd7dda62d5f
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/weekly_pay_before_tax.govspeak.erb: 805f2283eecf730779d648b2998db59f
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/years_employed.govspeak.erb: 6840413403d9331d79e3b60f04d244a9
-lib/smart_answer_flows/shared/redundancy_pay_flow.rb: 944b61e48afdcecde98c8f179ec5b90a
-lib/smart_answer/calculators/redundancy_calculator.rb: 102729e2e21790e3f3691cc01d1c1d95
+lib/smart_answer_flows/shared/redundancy_pay_flow.rb: 2e7a40d1ea84a2df615a6405b3fa2bee
+lib/smart_answer/calculators/redundancy_calculator.rb: 1a722b46d399ce719d1a4c41cc1a93fd
 lib/data/rates/redundancy_pay.yml: a214c01e46e92847f26b1de107997c78
 lib/data/rates/redundancy_pay_northern_ireland.yml: 83dcea5aa4048b6fb5d4aa222343e5c5

--- a/test/data/calculate-employee-redundancy-pay-files.yml
+++ b/test/data/calculate-employee-redundancy-pay-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/age_of_employ
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/date_of_redundancy.govspeak.erb: e6ba7dfca27ad55335fb2cd7dda62d5f
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/weekly_pay_before_tax.govspeak.erb: 805f2283eecf730779d648b2998db59f
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/years_employed.govspeak.erb: 6840413403d9331d79e3b60f04d244a9
-lib/smart_answer_flows/shared/redundancy_pay_flow.rb: 2e7a40d1ea84a2df615a6405b3fa2bee
-lib/smart_answer/calculators/redundancy_calculator.rb: 1a722b46d399ce719d1a4c41cc1a93fd
+lib/smart_answer_flows/shared/redundancy_pay_flow.rb: 91e04ab20e95e6a5b92bed8b41928038
+lib/smart_answer/calculators/redundancy_calculator.rb: 9ec0274471599d20b95a7a7dd42b6fe1
 lib/data/rates/redundancy_pay.yml: a214c01e46e92847f26b1de107997c78
 lib/data/rates/redundancy_pay_northern_ireland.yml: 83dcea5aa4048b6fb5d4aa222343e5c5

--- a/test/data/calculate-your-redundancy-pay-files.yml
+++ b/test/data/calculate-your-redundancy-pay-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/calculate-your-redundancy-pay/questions/age_of_employee.g
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/date_of_redundancy.govspeak.erb: bdb2975cce5bd91c754ac13fad1af4b8
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/weekly_pay_before_tax.govspeak.erb: 9662fd7b09d3722850ede311bf27b844
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/years_employed.govspeak.erb: 6bf4ef75048732fab207104b21cdc6e6
-lib/smart_answer_flows/shared/redundancy_pay_flow.rb: 2e7a40d1ea84a2df615a6405b3fa2bee
-lib/smart_answer/calculators/redundancy_calculator.rb: 1a722b46d399ce719d1a4c41cc1a93fd
+lib/smart_answer_flows/shared/redundancy_pay_flow.rb: 91e04ab20e95e6a5b92bed8b41928038
+lib/smart_answer/calculators/redundancy_calculator.rb: 9ec0274471599d20b95a7a7dd42b6fe1
 lib/data/rates/redundancy_pay.yml: a214c01e46e92847f26b1de107997c78
 lib/data/rates/redundancy_pay_northern_ireland.yml: 83dcea5aa4048b6fb5d4aa222343e5c5

--- a/test/data/calculate-your-redundancy-pay-files.yml
+++ b/test/data/calculate-your-redundancy-pay-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/calculate-your-redundancy-pay/questions/age_of_employee.g
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/date_of_redundancy.govspeak.erb: bdb2975cce5bd91c754ac13fad1af4b8
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/weekly_pay_before_tax.govspeak.erb: 9662fd7b09d3722850ede311bf27b844
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/years_employed.govspeak.erb: 6bf4ef75048732fab207104b21cdc6e6
-lib/smart_answer_flows/shared/redundancy_pay_flow.rb: 944b61e48afdcecde98c8f179ec5b90a
-lib/smart_answer/calculators/redundancy_calculator.rb: 102729e2e21790e3f3691cc01d1c1d95
+lib/smart_answer_flows/shared/redundancy_pay_flow.rb: 2e7a40d1ea84a2df615a6405b3fa2bee
+lib/smart_answer/calculators/redundancy_calculator.rb: 1a722b46d399ce719d1a4c41cc1a93fd
 lib/data/rates/redundancy_pay.yml: a214c01e46e92847f26b1de107997c78
 lib/data/rates/redundancy_pay_northern_ireland.yml: 83dcea5aa4048b6fb5d4aa222343e5c5

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -121,5 +121,33 @@ module SmartAnswer::Calculators
         assert_equal 17.5, @calculator.number_of_weeks_entitlement
       end
     end
+
+    context "Redundancy date selector" do
+      context "Earliest selectable date" do
+        context "Months January to August" do
+          should "return the start of the year, four years ago if date is January 1st" do
+            Timecop.freeze('2016-01-01')
+            assert_equal Date.parse('2012-01-01'), RedundancyCalculator.first_selectable_date
+          end
+
+          should "return the start of the year, four years ago if date is August 31st" do
+            Timecop.freeze('2016-08-31')
+            assert_equal Date.parse('2012-01-01'), RedundancyCalculator.first_selectable_date
+          end
+        end
+
+        context "Months September to December" do
+          should "return the start of the year, three years ago if date is September 1st" do
+            Timecop.freeze('2016-09-01')
+            assert_equal Date.parse('2013-01-01'), RedundancyCalculator.first_selectable_date
+          end
+
+          should "return the start of the year, three years ago if date is December 31st" do
+            Timecop.freeze('2016-12-31')
+            assert_equal Date.parse('2013-01-01'), RedundancyCalculator.first_selectable_date
+          end
+        end
+      end
+    end
   end
 end

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -148,6 +148,32 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context "Last selectable date" do
+        context "Months January to August" do
+          should "return the end of the current year if the date is January 1st" do
+            Timecop.freeze('2016-01-01')
+            assert_equal Date.parse('2016-12-31'), RedundancyCalculator.last_selectable_date
+          end
+
+          should "return the end of the current year if the date is August 31st" do
+            Timecop.freeze('2016-08-31')
+            assert_equal Date.parse('2016-12-31'), RedundancyCalculator.last_selectable_date
+          end
+        end
+
+        context "Months September to December" do
+          should "return end of the next year if the date is September 1st" do
+            Timecop.freeze('2016-09-01')
+            assert_equal Date.parse('2017-12-31'), RedundancyCalculator.last_selectable_date
+          end
+
+          should "return end of the next year if the date is December 31st" do
+            Timecop.freeze('2016-12-31')
+            assert_equal Date.parse('2017-12-31'), RedundancyCalculator.last_selectable_date
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/9Iq4SmoQ
Follows on from PR #2833 

## Motivation

In PR #2833 we fixed a problem where users were unable to  calculate their statutory redundancy entitlement in advance. They wanted to calculate payments for redundancy dates that start in the new year, but the date selector drop-down limited them to the end of the current year.

The fix in PR #2833 was a quick one that hard coded the dates the users see in the drop-down. The problem with this is that in January, we will have to undo that work so the users can only select until the end of the current year.

This PR automates the changes in the date selector.

If the date is in the first two-thirds of the year (January to August), the date selector starts at 4 years in the past and goes to the end of the current year.

If the date is in the last third of the year (September to December), the date selector starts at 3 years in the past and goes to the end of the next year.

## Expected changes

URLs on GOV.UK:

* [calculate-employee-redundancy-pay](https://www.gov.uk/calculate-employee-redundancy-pay/y)
   * The user should not see any changes.
* [calculate-your-redundancy-pay](https://www.gov.uk/calculate-your-redundancy-pay/y)
   * The user should not see any changes.