### PR TITLE
Update self assessment penalties interest rate

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -106,11 +106,14 @@ module SmartAnswer::Calculators
     end
 
     def interest
-      if overdue_payment_days <= 0
-        0
-      else
-        SmartAnswer::Money.new(calculate_interest(estimated_bill.value, overdue_payment_days).round(2))
+      return 0 if overdue_payment_days <= 0
+
+      days_with_penalty_interest = payment_deadline..(payment_date - 2)
+      interest_charges_per_day = days_with_penalty_interest.map do |date|
+        calculate_interest_for_date(date)
       end
+
+      SmartAnswer::Money.new(interest_charges_per_day.sum.round(2))
     end
 
     def total_owed
@@ -155,9 +158,18 @@ module SmartAnswer::Calculators
       DEADLINES[:payment_deadline][tax_year.to_sym]
     end
 
-    #interest is 3% per annum
-    def calculate_interest(amount, number_of_days)
-      (amount * (0.03 / 365) * (number_of_days - 1)).round(10)
+    def calculate_interest_for_date(date)
+      estimated_bill.value * daily_rate(date)
+    end
+
+    def daily_rate(date)
+      # Rate drops from 3% to 2.75% on 23 August 2016
+      rate_change_date = Date.new(2016, 8, 23)
+      if date < rate_change_date
+        0.03 / 365.0
+      else
+        0.0275 / 365.0
+      end
     end
   end
 end

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -10,4 +10,4 @@ lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_submitte
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb: fd629bd5e95648f5a22246a423cfd026
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb: 590022eac4fbf8db1976da66d777f776
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: 3431fda0cc0bf6c0c7670c04ef38458c
-lib/smart_answer/calculators/self_assessment_penalties.rb: 7e48160fc1ae2862c5f08f23f19597ce
+lib/smart_answer/calculators/self_assessment_penalties.rb: 2f0cb535afa82d3911d6dfc87adc4c2f

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -155,52 +155,57 @@ module SmartAnswer::Calculators
           assert_equal 1500, @calculator.late_filing_penalty
         end
 
-        should "calculate interest and late payment penalty" do
-          @calculator.estimated_bill = SmartAnswer::Money.new(10000)
-          @calculator.payment_date = Date.parse("2014-01-01")
-          assert_equal 0, @calculator.interest
-          # 1 day after the deadling
-          @calculator.payment_date = Date.parse("2014-02-01")
-          assert_equal 0, @calculator.interest
-          # 31 days after the deadline
-          @calculator.payment_date = Date.parse("2014-03-03")
-          assert_equal 24.66, @calculator.interest
-          assert_equal 500, @calculator.late_payment_penalty
-          # should calculate PenaltyInterest1
-          @calculator.payment_date = Date.parse("2014-04-02")
-          assert_equal 49.32, @calculator.interest #50.14 + 0.04 penalty interest
-          # one day before late payment penalty 2
-          @calculator.payment_date = Date.parse("2014-08-01")
-          assert_equal 1000, @calculator.late_payment_penalty
-          assert_equal 148.77, @calculator.interest
-          # should calculate PenaltyInterest2
-          @calculator.payment_date = Date.parse("2014-09-02")
-          assert_equal 1000, @calculator.late_payment_penalty
-          assert_equal 175.07, @calculator.interest
-          # one day before late payment penalty 3
-          @calculator.payment_date = Date.parse("2015-02-01")
-          assert_equal 1500, @calculator.late_payment_penalty
-          assert_equal 300, @calculator.interest
-          # should apply late payment penalty 3
-          @calculator.payment_date = Date.parse("2015-02-02")
-          assert_equal 1500, @calculator.late_payment_penalty
-          assert_equal 300.82, @calculator.interest
-          # should calculate PenaltyInterest3
-          @calculator.payment_date = Date.parse("2015-03-05")
-          assert_equal 1500, @calculator.late_payment_penalty
-          assert_equal 326.3, @calculator.interest
+        context "pay penalty before rate change on 23 Aug 2016" do
+          should "calculate interest and late payment penalty" do
+            @calculator.estimated_bill = SmartAnswer::Money.new(10000)
+            @calculator.payment_date = Date.parse("2014-01-01")
+            assert_equal 0, @calculator.interest
+            # 1 day after the deadline
+            @calculator.payment_date = Date.parse("2014-02-01")
+            assert_equal 0, @calculator.interest
+            # 31 days after the deadline
+            @calculator.payment_date = Date.parse("2014-03-03")
+            assert_equal 24.66, @calculator.interest
+            assert_equal 500, @calculator.late_payment_penalty
+            # should calculate PenaltyInterest1
+            @calculator.payment_date = Date.parse("2014-04-02")
+            assert_equal 49.32, @calculator.interest #50.14 + 0.04 penalty interest
+            # one day before late payment penalty 2
+            @calculator.payment_date = Date.parse("2014-08-01")
+            assert_equal 1000, @calculator.late_payment_penalty
+            assert_equal 148.77, @calculator.interest
+            # should calculate PenaltyInterest2
+            @calculator.payment_date = Date.parse("2014-09-02")
+            assert_equal 1000, @calculator.late_payment_penalty
+            assert_equal 175.07, @calculator.interest
+            # one day before late payment penalty 3
+            @calculator.payment_date = Date.parse("2015-02-01")
+            assert_equal 1500, @calculator.late_payment_penalty
+            assert_equal 300, @calculator.interest
+            # should apply late payment penalty 3
+            @calculator.payment_date = Date.parse("2015-02-02")
+            assert_equal 1500, @calculator.late_payment_penalty
+            assert_equal 300.82, @calculator.interest
+            # should calculate PenaltyInterest3
+            @calculator.payment_date = Date.parse("2015-03-05")
+            assert_equal 1500, @calculator.late_payment_penalty
+            assert_equal 326.3, @calculator.interest
+          end
+
+          should "calculate total owed (excludes filing penalty)" do
+            @calculator.payment_date = Date.parse("2014-02-02")
+            assert_equal 5000, @calculator.total_owed
+            @calculator.payment_date = Date.parse("2014-02-04")
+            assert_equal 5001, @calculator.total_owed
+            @calculator.payment_date = Date.parse("2014-08-01")
+            assert_equal 5574, @calculator.total_owed
+            @calculator.payment_date = Date.parse("2015-02-02")
+            assert_equal 750, @calculator.late_payment_penalty
+            assert_equal 5900, @calculator.total_owed
+          end
         end
 
-        should "calculate total owed (excludes filing penalty)" do
-          @calculator.payment_date = Date.parse("2014-02-02")
-          assert_equal 5000, @calculator.total_owed
-          @calculator.payment_date = Date.parse("2014-02-04")
-          assert_equal 5001, @calculator.total_owed
-          @calculator.payment_date = Date.parse("2014-08-01")
-          assert_equal 5574, @calculator.total_owed
-          @calculator.payment_date = Date.parse("2015-02-02")
-          assert_equal 750, @calculator.late_payment_penalty
-          assert_equal 5900, @calculator.total_owed
+        context "pay penalty after rate change on 23 Aug 2016" do
         end
       end # filed or paid late
     end # online submission

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -7,18 +7,20 @@ module SmartAnswer::Calculators
         online_filing_deadline: {
           "2012-13": Date.new(2014, 1, 31),
           "2013-14": Date.new(2015, 1, 31),
-          "2014-15": Date.new(2015, 1, 31),
-          "2015-16": Date.new(2017, 1, 31)
+          "2014-15": Date.new(2016, 1, 31),
+          "2015-16": Date.new(2017, 1, 31),
         },
         offline_filing_deadline: {
           "2012-13": Date.new(2013, 10, 31),
           "2013-14": Date.new(2014, 10, 31),
-          "2015-16": Date.new(2016, 10, 31)
+          "2014-15": Date.new(2015, 10, 31),
+          "2015-16": Date.new(2016, 10, 31),
         },
         payment_deadline: {
           "2012-13": Date.new(2014, 1, 31),
           "2013-14": Date.new(2015, 1, 31),
-          "2015-16": Date.new(2017, 1, 31)
+          "2014-15": Date.new(2016, 1, 31),
+          "2015-16": Date.new(2017, 1, 31),
         },
       }
 


### PR DESCRIPTION
## Trello card
https://trello.com/c/lm5VUxFp

## Motivation
HMRC’s interest rate for late penalties changed from 3% to 2.75% on 23 August.

Interest is charged at:

* 3% up to 22 August 2016
* 2.75% from 23 August 2016

## Expected change

Interest before the 22 August 2016 point should stay the same. Interest after that should be slightly less than currently live.

### Before
* [GOV.UK](https://www.gov.uk/estimate-self-assessment-penalties/y/2015-16/paper/2017-01-01/2017-03-01/1000.0)

![screenshot-www gov uk-2016-12-14-15-31-00](https://cloud.githubusercontent.com/assets/424772/21188216/8bbe06de-c212-11e6-8553-b7d08871efc3.png)

### After
* [Fact check](https://smart-answers-pr-2840.herokuapp.com/estimate-self-assessment-penalties/y/2015-16/paper/2017-01-01/2017-03-01/1000.0)

![screenshot-smartanswers dev gov uk-2016-12-21-14-11-46](https://cloud.githubusercontent.com/assets/424772/21392393/8022b8e0-c787-11e6-8a2d-9356f87dbef5.png)


