### PR TITLE
Allow Mozambique same sex - BN marrying Mozambican

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/uk/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/uk/partner_local/_same_sex.govspeak.erb
@@ -1,1 +1,64 @@
-It’s not possible to get legal recognition for your same-sex relationship in Mozambique.
+You may be able to get married at the British High Commission in Maputo.
+ 
+[Make an appointment at the high commission in Maputo](https://www.consular-appointments.service.gov.uk/fco/).
+ 
+##What documents you’ll need
+ 
+ You’ll need to have been living in Mozambique for 7 full days before you can apply to marry at the British High Commission. You’ll also need to wait a further 14 full days while your notice of marriage is posted at the High Commission. 
+ 
+^You must stay in Mozambique for 14 days from the date of your appointment, if you're not normally resident in Mozambique.^
+ 
+ 
+ You and your partner will need to sign a declaration and provide proof of residence, for example, an employer’s letter, bank statement or plane ticket.
+ 
+ 
+ You’ll both need your original passports. If either of you have been divorced, widowed or in a civil partnership before, you’ll also need either:
+
+
+- [a decree absolute or final order](https://www.gov.uk/copy-decree-absolute-final-order)
+ - a civil partnership dissolution or annulment certificate
+ the [death certificate](https://www.gov.uk/order-copy-birth-death-marriage-certificate/)
+ 
+ 
+##What you need to do
+ 
+ 
+ At your appointment the embassy or consulate will give you:
+ 
+ - a notice of registration
+ - a declaration that you and your partner will need to swear, stating that you’re legally entitled to marry
+ 
+ 
+ Once you’ve completed these and paid the registration fee, the embassy or consulate will display your notice of marriage publicly for 14 days.
+ 
+ 
+ As long as nobody registers an objection you can get married up to 3 months after you gave notice.
+ 
+ 
+ You’ll need to bring two witnesses to your ceremony - they’ll need to show their photo ID (eg passport or driver’s licence).
+ 
+ 
+ You’ll need to pay a fee to register your marriage and a fee for your marriage certificate.
+ 
+ 
+ All same-sex marriages must take place under English and Welsh or Scottish law even if you live in or are from Northern Ireland. Tell the embassy or consulate which law you want to get married under at your appointment.
+ 
+ 
+##Naturalisation of your partner if they move to the UK
+ 
+ 
+ Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+ 
+ 
+## Fees
+ 
+ Service | Fee
+ -|-
+ Receiving a notice of registration | <%= format_money calculator.consular_fee(:receiving_notice_of_registration) %>
+ Registering a marriage |  <%= format_money calculator.consular_fee(:registering_marriage) %>
+ Issuing a marriage certificate | <%= format_money calculator.consular_fee(:issuing_marriage_certificate) %>
+ 
+ You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Mozambique](https://www.gov.uk/government/publications/mozambique-consular-fees).
+ 
+ 
+ You can pay by cash or credit card, but not by personal cheque.


### PR DESCRIPTION
Replaced the existing content, ie this one-liner:

It’s not possible to get legal recognition for your same-sex relationship in Mozambique.

with brand new content.

Reason: this type of marriage is allowed now.

https://trello.com/c/OdIFK1Qk/330-mozambique-marriage-tool-same-sex-marriages-content-change-request
https://govuk.zendesk.com/agent/tickets/1383469