### PR TITLE
Student finance calculator: Changed 'gross (pre-tax) income' to 'taxable income'

### DIFF
--- a/lib/smart_answer_flows/student-finance-calculator/questions/whats_your_household_income.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/questions/whats_your_household_income.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  This is your parents’ or partner’s gross (pre-tax) income plus your own. It affects how much help you'll get with living costs.
+  This is your parents’ or partner’s taxable income plus your own. It affects how much help you'll get with living costs.
 <% end %>
 
 <% content_for :error_message do %>


### PR DESCRIPTION
TRELLO: https://trello.com/c/3vR2VkD8/389-fw-student-finance-calculator
ZEN: https://govuk.zendesk.com/agent/tickets/1468578
FILE: /student-finance-calculator/questions/whats_your_household_income.govspeak.erb

CHANGED
gross (pre-tax) income

TO
taxable income

REASON
We no longer use the term 'gross income'.