### PR TITLE
Stop registering routes with panopticon

### DIFF
--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -12,15 +12,13 @@ class FlowContentItem
       details: {
           external_related_links: external_related_links
       },
-      schema_name: 'placeholder_smart_answer',
+      schema_name: 'generic_with_external_related_links',
       document_type: 'smart_answer',
       publishing_app: 'smartanswers',
       rendering_app: 'smartanswers',
       locale: 'en',
       public_updated_at: Time.now.iso8601,
-      routes: [
-        { type: 'exact', path: base_path }
-      ]
+      routes: routes
     }
   end
 
@@ -30,8 +28,19 @@ class FlowContentItem
 
 private
 
+  def routes
+    [
+      { type: 'prefix', path: base_path },
+      { type: 'exact', path: json_path }
+    ]
+  end
+
   def base_path
     '/' + flow_presenter.slug
+  end
+
+  def json_path
+    "#{base_path}.json"
   end
 
   def external_related_links

--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -19,14 +19,6 @@ class FlowRegistrationPresenter
     start_node.title
   end
 
-  def paths
-    ["/#{@flow.name}.json"]
-  end
-
-  def prefixes
-    ["/#{@flow.name}"]
-  end
-
   def description
     start_node.meta_description
   end

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -15,7 +15,7 @@ module SmartAnswer
 
       payload = content_item.payload
 
-      assert_valid_against_schema(payload, 'placeholder')
+      assert_valid_against_schema(payload, 'generic_with_external_related_links')
     end
 
     test '#payload returns a valid content-item with external related links' do
@@ -24,7 +24,7 @@ module SmartAnswer
 
       payload = content_item.payload
 
-      assert_valid_against_schema(payload, 'placeholder')
+      assert_valid_against_schema(payload, 'generic_with_external_related_links')
     end
 
     test '#base_path is the name of the flow' do

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -40,18 +40,6 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
     end
   end
 
-  context "paths" do
-    should "generate and /flow.name.json" do
-      assert_equal ["/flow-sample.json"], @presenter.paths
-    end
-  end
-
-  context "prefixes" do
-    should "generate /flow.name" do
-      assert_equal ["/flow-sample"], @presenter.prefixes
-    end
-  end
-
   context "description" do
     should "use the meta_description from the start node template" do
       assert_equal "FLOW_DESCRIPTION", @presenter.description


### PR DESCRIPTION
- We no longer want Panopticon to register routes for Smart Answers.
Publishing API should to it for us.

- Publishing API ignores registering routes for Placeholder schemas. Here
we are swapping it to use the `generic_with_external_related_links`
schema which Publishing API will act upon.

In order to test this we took a before snapshot of the routes in `router-api` using:

`Route.where(backend_id: 'smartanswers').to_a`

Then we ran the `publishing_api:publish` rake task and took another snapshot of the routes in `router-api` again and compared the two.

Merge after:

- [x] - https://github.com/alphagov/govuk-content-schemas/pull/465
- [x] - The new content schema needs to be deployed

[Trello card](https://trello.com/c/5W6X8HgW/586-register-smart-answers-routes-only-through-publishing-api-3)