### PR TITLE
Fix state pension topup tests

### DIFF
--- a/test/integration/smart_answer_flows/state_pension_topup_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_topup_test.rb
@@ -33,6 +33,7 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
 
     context "gender inserted" do
       setup do
+        Timecop.freeze('2016-12-01')
         add_response "male"
       end
       should "ask you topup amount" do
@@ -95,6 +96,7 @@ class CalculateStatePensionTopupTest < ActiveSupport::TestCase
   end
   context "Anyone turns 101 on 2 April 2017 = DOB 2/4/1916 with a top up of £1 a week" do
     setup do
+      Timecop.freeze('2016-12-01')
       add_response Date.parse('1916-04-02')
       add_response "male"
       add_response 1

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -53,6 +53,7 @@ module SmartAnswer::Calculators
     context "lump_sum_and_age" do
       context "when male" do
         setup do
+          Timecop.freeze('2016-12-01')
           @calculator.gender = "male"
         end
 
@@ -101,6 +102,7 @@ module SmartAnswer::Calculators
 
       context "when female" do
         setup do
+          Timecop.freeze('2016-12-01')
           @calculator.gender = "female"
         end
 


### PR DESCRIPTION
The state-pension-topup tests check how much you need to pay in
each calendar year.

As we are in a new year, the number of payments has decreased.

This scheme ends in April this year, and this calculator will be retired.
Rather make radical changes to the tests, I've frozen the date to a time when
they did still pass.

These changes should have been incorporated in https://trello.com/c/ymI446hb