### PR TITLE
Reinstate use of has_outcome_per_path function

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -111,7 +111,7 @@ module SmartAnswer
         end
 
         next_node do
-          if %w(italy sweden mozambique).include?(calculator.ceremony_country)
+          if calculator.has_outcome_per_path?
             outcome :outcome_marriage_abroad_in_country
           elsif calculator.ceremony_country == 'brazil' && calculator.resident_of_ceremony_country?
             outcome :outcome_marriage_in_brazil_when_residing_in_brazil

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 2e0c44eb24c2615df4d03fbe7e47b0b0
+lib/smart_answer_flows/marriage-abroad.rb: 0167cd381cef0b973e6a51e6cb392286
 test/data/marriage-abroad-questions-and-responses.yml: 1da0ed44bd64ec0febb647b8b6158785
 test/data/marriage-abroad-responses-and-expected-results.yml: a2c265aedad7bc4de78536759288e603
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027


### PR DESCRIPTION
This function was created in an earlier pull request to manage the list of
countries that use an outcome template per path through the flow.

The use of the function must have been lost during a rebase, so I'm
reinstating it here.

No test artefacts were affected by this change.