### PR TITLE
Register a birth were you married

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -1,6 +1,15 @@
 <% content_for :body do %>
   $!You must register the birth in the country where the child was born. You'll be given a local birth certificate.$!
 
+In most cases, you’ll be able to register the birth with the UK authorities. 
+
+##When you can’t register a birth in the UK
+
+You won’t be able to register a birth if with the UK authorities if any the following apply:
+
+- the child has no mother registered on the birth certificate 
+- the child’s mother is married to a man who is not a UK citizen, even if the child’s father is a UK citizen
+
   <% if calculator.registration_country == 'indonesia' and calculator.british_national_father? and calculator.paternity_declaration? %>
     %You’ll need to get a court order to have the father named on the birth certificate before registering if you’re unmarried and only the father has British nationality.%
   <% end %>

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -5,10 +5,10 @@ In most cases, you’ll be able to register the birth with the UK authorities.
 
 ##When you can’t register a birth in the UK
 
-You won’t be able to register a birth if with the UK authorities if any the following apply:
+You won’t be able to register a birth with the UK authorities if any the following apply:
 
 - the child has no mother registered on the birth certificate 
-- the child’s mother is married to a man who is not a UK citizen, even if the child’s father is a UK citizen
+- at the time of the child’s birth the child’s non-British mother was married to a man who is not a UK citizen, even if the child’s biological father is a UK citizen
 
   <% if calculator.registration_country == 'indonesia' and calculator.british_national_father? and calculator.paternity_declaration? %>
     %You’ll need to get a court order to have the father named on the birth certificate before registering if you’re unmarried and only the father has British nationality.%
@@ -16,7 +16,6 @@ You won’t be able to register a birth if with the UK authorities if any the fo
 
   <% if calculator.higher_risk_country? %>
     <% if calculator.registration_country == 'libya' %>
-      You can also register the birth with the UK authorities.
 
       ^It’s usually quicker to register the birth with the UK authorities if you [get a British passport](/overseas-passports) for the child first. You can’t apply for a passport in Libya but you can apply in a neighbouring country.^
 

--- a/lib/smart_answer_flows/register-a-birth/questions/married_couple_or_civil_partnership.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/questions/married_couple_or_civil_partnership.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Were you married to the other parent when your child was born?
+  Were you married or in a civil partnership with the other parent when your child was born?
 <% end %>
 
 <% options(


### PR DESCRIPTION
@pmanrubia , the Trello card is: https://trello.com/c/W4E0Xui7/523-register-a-birth-abroad-tool 👍 

CHANGED
+Q.3 Were you married to the other parent when your child was born?

TO
Were you married [or in a civil partnership] with the other parent when your child was born?

REASON
2 parents in a civil partnership may be able to register a birth abroad

ADDED
In most cases, you’ll be able to register the birth with the UK authorities. 

##When you can’t register a birth in the UK
You won’t be able to register a birth if with the UK authorities if any the following apply:
the child has no mother registered on the birth certificate 
the child’s mother is married to a man who is not a UK citizen, even if the child’s father is a UK citizen

TO 
+ Outcome oru_result.govspeak.erb

REASON
2 parents in a civil partnership might not always be able register a birth in the UK