### PR TITLE
Put body text into hint for benefits cap calculator postcode question

### DIFF
--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/enter_postcode.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/enter_postcode.govspeak.erb
@@ -3,7 +3,7 @@
 
 <% end %>
 
-<% content_for :body do %>
+<% content_for :hint do %>
   eg SW1A 2AA
 <% end %>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/none/50.0/single.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/none/50.0/single.txt
@@ -1,9 +1,8 @@
 Enter your postcode
 
+
+
 eg SW1A 2AA
-
-
-
 
 
 

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -19,7 +19,7 @@ lib/smart_answer_flows/benefit-cap-calculator/questions/bereavement_amount.govsp
 lib/smart_answer_flows/benefit-cap-calculator/questions/carers_amount.govspeak.erb: b572736670c6373307927774f23b7f6b
 lib/smart_answer_flows/benefit-cap-calculator/questions/child_benefit_amount.govspeak.erb: 465deb851760f3e8b7ba9d33a4c16bb2
 lib/smart_answer_flows/benefit-cap-calculator/questions/child_tax_amount.govspeak.erb: 766920160ec013b13fecb8c8e19e9595
-lib/smart_answer_flows/benefit-cap-calculator/questions/enter_postcode.govspeak.erb: b174675b5bcf6c01c550118015ee9d2e
+lib/smart_answer_flows/benefit-cap-calculator/questions/enter_postcode.govspeak.erb: d06a6b34cd4dc98b7df1a49d314592fd
 lib/smart_answer_flows/benefit-cap-calculator/questions/esa_amount.govspeak.erb: 204e7be6c65e354817779f0287bbd5c2
 lib/smart_answer_flows/benefit-cap-calculator/questions/guardian_amount.govspeak.erb: 511ad85c4de40c835495c1f564606903
 lib/smart_answer_flows/benefit-cap-calculator/questions/housing_benefit_amount.govspeak.erb: b1bb30f721bd176e247476f4a4dbe3a6


### PR DESCRIPTION
## Trello

Part of card https://trello.com/c/SQwpXvCF/339-sa-questions-page-restructure-quick-tasks and https://trello.com/c/fEeJdpVr/506-smart-answer-accessibility-changes

## Motivation

Make this question consistent with the rest of gov.uk  - the "body" copy is more appropriate in the question hint.

## Expected change

Question content previously in the body section should now be in the hint.

### Before

[gov.uk](https://www.gov.uk/benefit-cap-calculator/y/yes/no/no/child_benefit/90.0/90.0/parent)

<img width="1062" alt="old" src="https://cloud.githubusercontent.com/assets/6338228/21690130/e06e3e10-d36a-11e6-9ab5-d2b0800aa449.png">

### After

<img width="1047" alt="new" src="https://cloud.githubusercontent.com/assets/6338228/21690143/e9bd18c4-d36a-11e6-8dff-35b661009ce2.png">



