### PR TITLE
Calculate statutory sick pay extend last day of sickness

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -263,6 +263,15 @@ module SmartAnswer
         payments
       end
 
+      def self.year_of_sickness
+        current_day = DateHelper.current_day
+        if current_day.month >= 6
+          current_day.next_year.end_of_year
+        else
+          current_day.end_of_year
+        end
+      end
+
     private
 
       def weekly_rate_on(date)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -65,7 +65,7 @@ module SmartAnswer
       # Question 4
       date_question :first_sick_day? do
         from { Date.new(2011, 1, 1) }
-        to { Date.today.end_of_year }
+        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
 
         on_response do |response|
           calculator.sick_start_date = response
@@ -81,7 +81,7 @@ module SmartAnswer
       # Question 5
       date_question :last_sick_day? do
         from { Date.new(2011, 1, 1) }
-        to { Date.today.end_of_year }
+        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
 
         on_response do |response|
           calculator.sick_end_date = response
@@ -128,7 +128,7 @@ module SmartAnswer
       # Question 6.1
       date_question :linked_sickness_start_date? do
         from { Date.new(2010, 1, 1) }
-        to { Date.today.end_of_year }
+        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
 
         on_response do |response|
           calculator.linked_sickness_start_date = response
@@ -148,7 +148,7 @@ module SmartAnswer
       # Question 6.2
       date_question :linked_sickness_end_date? do
         from { Date.new(2010, 1, 1) }
-        to { Date.today.end_of_year }
+        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
 
         on_response do |response|
           calculator.linked_sickness_end_date = response
@@ -222,7 +222,7 @@ module SmartAnswer
       # Question 8
       date_question :last_payday_before_sickness? do
         from { Date.new(2010, 1, 1) }
-        to { Date.today.end_of_year }
+        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
         validate_in_range
 
         precalculate :sick_start_date_for_awe do
@@ -245,7 +245,7 @@ module SmartAnswer
       # Question 8.1
       date_question :last_payday_before_offset? do
         from { Date.new(2010, 1, 1) }
-        to { Date.today.end_of_year }
+        to { Calculators::StatutorySickPayCalculator.year_of_sickness }
         validate_in_range
 
         precalculate :pay_day_offset do

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-statutory-sick-pay.rb: b01febd3a3febdcbba3c908ffbe5a348
+lib/smart_answer_flows/calculate-statutory-sick-pay.rb: ea777ffd72dbbb32034ecfb1639d9f4d
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: dfd8baf65a8c26430cf17958e8908202
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: b42519fbb030e7eaf0912d1de0b8ff47
 lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600
@@ -28,5 +28,5 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/pay_amount_if_not_
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.govspeak.erb: 46ce81328d55d2bef88bb1047cf047cd
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 48289bfc2406d317c688d9e0206c31dd
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: d76164963c614bca260340320f8fe622
 lib/data/rates/statutory_sick_pay.yml: b275311f2ec89fc707e6b9cfefec1179

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -929,6 +929,18 @@ module SmartAnswer
           assert_equal 14.45, calc.ssp_payment
         end
       end
+
+      context "possible year of sickness" do
+        should "returns 31 Dec 2017 when month is between January and May" do
+          Timecop.freeze("1 May 2017")
+          assert_equal StatutorySickPayCalculator.year_of_sickness, Date.parse("31 Dec 2017")
+        end
+
+        should "returns 31 Dec 2018 when month is between June and December" do
+          Timecop.freeze("1 June 2017")
+          assert_equal StatutorySickPayCalculator.year_of_sickness, Date.parse("31 Dec 2018")
+        end
+      end
     end # SSP calculator
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/K8ddsnVU/476-5-calculate-your-employee-s-statutory-sick-pay-2017-content-change-request)

## Motivation

Based on feedex comments from employers using the Statutory Sick Pay
calculator. They are not able to enter future date as the last day
of sickness.

DWP have requested that we automatically render the next year from the
1st of June of the previous year.

Here, we have added a method that caters for the aforementioned.

This ensures that from the 1st of June every year the next year’s
last day is returned.

For factcheck purposes DateHelper.current_day has been used, this allow
configuration of ENV['RATES_QUERY_DATE'] which enables validation of
future content. This is normally set in heroku during factcheck.

**NB:**
Used environment variable from this PR #2412, setting RATES_QUERY_DATE to 2017-06-01

## Factcheck

[Preview link](https://smart-answers-pr-2878.herokuapp.com/calculate-statutory-sick-pay/y/statutory_adoption_pay,statutory_paternity_pay/yes/no)

## Expected changes

  [GOV.UK](https://gov.uk/calculate-statutory-sick-pay/y/statutory_adoption_pay,statutory_paternity_pay/yes/no)
- From 1st of June 2017 the dropdown should include 2018


### Before
*Screenshot taken on 2017-01-15 at 05 58 00*
![screen shot 2017-01-15 at 06 07 10](https://cloud.githubusercontent.com/assets/84896/21960608/e2eb455e-dae8-11e6-8d35-925782180f77.png)



### After
![screen shot 2017-01-15 at 06 20 06](https://cloud.githubusercontent.com/assets/84896/21960671/b2a62754-daea-11e6-82ae-11ddbc01593a.png)


