### PR TITLE
Sweden marriage abroad (9 outcomes and title change)

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/_title.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/_title.html.erb
@@ -1,5 +1,5 @@
 <% if calculator.partner_is_same_sex? && !calculator.resident_of_ceremony_country? %>
-    Civil partnership in Sweden
+    Marriage in Sweden
 <% else %>
     Marriage in Sweden
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_british/_opposite_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_british/_opposite_sex.html.erb
@@ -59,7 +59,11 @@ Box 27819
 115 93 Stockholm
 $A
 
-^You don't need to stay in the country while your notice is posted.^
+Once you’ve posted your notice and paid the registration fee, the embassy or consulate will display your notice of marriage publicly for 7 days, from the day after they receive your payment.
+
+As long as nobody registers an objection, the embassy you will give you a CNI on the 8th day. You don’t need to stay in the country while your notice is posted.
+
+After you receive your CNI, you need to take it to the [Swedish tax authorities](http://www.skatteverket.se/privat.4.76a43be412206334b89800052864.html) to be registered.
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_british/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_british/_same_sex.html.erb
@@ -1,3 +1,8 @@
+Same-sex relationships in Sweden that are recognised as civil partnerships under British law are known as:
+
+- marriage
+- ’registrerat partnerskap’, or ’registered partnership’
+
 Contact the [Swedish Tax Authorities](http://www.skatteverket.se/servicelankar/otherlanguages/inenglish/contactus.4.4c5def2714bbf25766d2d6f.html) to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
@@ -59,7 +64,11 @@ Box 27819
 115 93 Stockholm
 $A
 
-^You don't need to stay in the country while your notice is posted.^
+Once you’ve posted your notice and paid the registration fee, the embassy or consulate will display your notice of marriage publicly for 7 days. 
+
+As long as nobody registers an objection, the embassy you will give you a CNI on the 8th day. You don’t need to stay in the country while your notice is posted. 
+
+After you receive your CNI, you need to take it to the [Swedish tax authorities](http://www.skatteverket.se/privat.4.76a43be412206334b89800052864.html) to be registered.
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_opposite_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_opposite_sex.html.erb
@@ -59,7 +59,11 @@ Box 27819
 115 93 Stockholm
 $A
 
-^You don't need to stay in the country while your notice is posted.^
+Once you’ve posted your notice and paid the registration fee, the embassy or consulate will display your notice of marriage publicly for 7 days, from the day after they receive your payment.
+
+As long as nobody registers an objection, the embassy you will give you a CNI on the 8th day. You don’t need to stay in the country while your notice is posted.
+
+After you receive your CNI, you need to take it to the [Swedish tax authorities](http://www.skatteverket.se/privat.4.76a43be412206334b89800052864.html) to be registered.
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_same_sex.html.erb
@@ -70,6 +70,10 @@ As long as nobody registers an objection, the embassy you will give you a CNI on
 
 After you receive your CNI, you need to take it to the [Swedish tax authorities](http://www.skatteverket.se/privat.4.76a43be412206334b89800052864.html) to be registered.
 
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
 ## Fees
 
 <%= render partial: 'consular_fees_table_items.govspeak.erb',

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_same_sex.html.erb
@@ -1,3 +1,8 @@
+Same-sex relationships in Sweden that are recognised as civil partnerships under British law are known as:
+
+- marriage
+- ’registrerat partnerskap’, or ’registered partnership’
+
 Contact the [Swedish Tax Authorities](http://www.skatteverket.se/servicelankar/otherlanguages/inenglish/contactus.4.4c5def2714bbf25766d2d6f.html) to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
@@ -59,7 +64,11 @@ Box 27819
 115 93 Stockholm
 $A
 
-^You don't need to stay in the country while your notice is posted.^
+Once you’ve posted your notice and paid the registration fee, the embassy or consulate will display your notice of marriage publicly for 7 days. 
+
+As long as nobody registers an objection, the embassy you will give you a CNI on the 8th day. You don’t need to stay in the country while your notice is posted. 
+
+After you receive your CNI, you need to take it to the [Swedish tax authorities](http://www.skatteverket.se/privat.4.76a43be412206334b89800052864.html) to be registered.
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_other/_opposite_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_other/_opposite_sex.html.erb
@@ -59,7 +59,11 @@ Box 27819
 115 93 Stockholm
 $A
 
-^You don't need to stay in the country while your notice is posted.^
+Once you’ve posted your notice and paid the registration fee, the embassy or consulate will display your notice of marriage publicly for 7 days, from the day after they receive your payment.
+
+As long as nobody registers an objection, the embassy you will give you a CNI on the 8th day. You don’t need to stay in the country while your notice is posted.
+
+After you receive your CNI, you need to take it to the [Swedish tax authorities](http://www.skatteverket.se/privat.4.76a43be412206334b89800052864.html) to be registered.
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_other/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_other/_same_sex.html.erb
@@ -1,3 +1,8 @@
+Same-sex relationships in Sweden that are recognised as civil partnerships under British law are known as:
+
+- marriage
+- ’registrerat partnerskap’, or ’registered partnership’
+
 Contact the [Swedish Tax Authorities](http://www.skatteverket.se/servicelankar/otherlanguages/inenglish/contactus.4.4c5def2714bbf25766d2d6f.html) to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
@@ -59,7 +64,15 @@ Box 27819
 115 93 Stockholm
 $A
 
-^You don't need to stay in the country while your notice is posted.^
+Once you’ve posted your notice and paid the registration fee, the embassy or consulate will display your notice of marriage publicly for 7 days. 
+
+As long as nobody registers an objection, the embassy you will give you a CNI on the 8th day. You don’t need to stay in the country while your notice is posted. 
+
+After you receive your CNI, you need to take it to the [Swedish tax authorities](http://www.skatteverket.se/privat.4.76a43be412206334b89800052864.html) to be registered.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_british/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_british/_same_sex.html.erb
@@ -1,8 +1,3 @@
-Same-sex relationships in Sweden that are recognised as civil partnerships under British law are known as:
-
-- marriage
-- ’registrerat partnerskap’, or ’registered partnership’.
-
 Contact the relevant local authorities in Sweden to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Sweden](/foreign-travel-advice/sweden).
@@ -11,10 +6,12 @@ You should also check the [travel advice for Sweden](/foreign-travel-advice/swed
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Sweden.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+There are 2 ways you can get a CNI:
 
-<%= render partial: 'shared/overseas_passports_embassies.govspeak.erb',
-           locals: { overseas_passports_embassies: calculator.overseas_passports_embassies } %>
+- [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/sweden/uk/partner_local/same_sex)
+- [go to Sweden and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/sweden/ceremony_country/partner_local/same_sex)
+
+%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_british/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_british/_same_sex.html.erb
@@ -11,7 +11,7 @@ There are 2 ways you can get a CNI:
 - [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/sweden/uk/partner_local/same_sex)
 - [go to Sweden and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/sweden/ceremony_country/partner_local/same_sex)
 
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
+%If you choose to post notice in Sweden, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_local/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_local/_same_sex.html.erb
@@ -1,8 +1,3 @@
-Same-sex relationships in Sweden that are recognised as civil partnerships under British law are known as:
-
-- marriage
-- ’registrerat partnerskap’, or ’registered partnership’.
-
 Contact the relevant local authorities in Sweden to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Sweden](/foreign-travel-advice/sweden).
@@ -11,10 +6,12 @@ You should also check the [travel advice for Sweden](/foreign-travel-advice/swed
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Sweden.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+There are 2 ways you can get a CNI:
 
-<%= render partial: 'shared/overseas_passports_embassies.govspeak.erb',
-           locals: { overseas_passports_embassies: calculator.overseas_passports_embassies } %>
+- [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/sweden/uk/partner_local/same_sex)
+- [go to Sweden and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/sweden/ceremony_country/partner_local/same_sex)
+
+%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_local/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_local/_same_sex.html.erb
@@ -11,7 +11,7 @@ There are 2 ways you can get a CNI:
 - [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/sweden/uk/partner_local/same_sex)
 - [go to Sweden and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/sweden/ceremony_country/partner_local/same_sex)
 
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
+%If you choose to post notice in Sweden, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_other/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_other/_same_sex.html.erb
@@ -1,8 +1,3 @@
-Same-sex relationships in Sweden that are recognised as civil partnerships under British law are known as:
-
-- marriage
-- ’registrerat partnerskap’, or ’registered partnership’.
-
 Contact the relevant local authorities in Sweden to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Sweden](/foreign-travel-advice/sweden).
@@ -11,10 +6,12 @@ You should also check the [travel advice for Sweden](/foreign-travel-advice/swed
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to enter into a civil partnership or equivalent in Sweden.
 
-Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+There are 2 ways you can get a CNI:
 
-<%= render partial: 'shared/overseas_passports_embassies.govspeak.erb',
-           locals: { overseas_passports_embassies: calculator.overseas_passports_embassies } %>
+- [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/sweden/uk/partner_local/same_sex)
+- [go to Sweden and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/sweden/ceremony_country/partner_local/same_sex)
+
+%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_other/_same_sex.html.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/third_country/partner_other/_same_sex.html.erb
@@ -11,7 +11,7 @@ There are 2 ways you can get a CNI:
 - [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/sweden/uk/partner_local/same_sex)
 - [go to Sweden and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/sweden/ceremony_country/partner_local/same_sex)
 
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
+%If you choose to post notice in Sweden, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 
 ##Naturalisation of your partner if they move to the UK
 


### PR DESCRIPTION
https://trello.com/c/bb0m6XM1/307-sweden-marriage-tool-update-missing-text-content-change-request

Changes to the following marriage abroad outcomes for Sweden:
A. All opposite sex outcomes where user lives in Sweden
1. Partner British 
2. Partner Swedish
3. Partner other
B. All same sex outcomes where user lives in Sweden
4. Partner British 
5. Partner Swedish
6. Partner other
C. All same sex outcomes where the user lives elsewhere
7. Partner British 
8. Partner Swedish
9. Partner other

I've also changed the page title file.

This doesn't affect the logic.