### PR TITLE
Register Document Type with Rummager

### DIFF
--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -24,7 +24,8 @@ class SearchPayloadPresenter
       title: title,
       description: description,
       indexable_content: indexable_content,
-      link: "/#{slug}"
+      link: "/#{slug}",
+      content_store_document_type: 'smart_answer',
     }
   end
 end

--- a/test/unit/services/search_indexer_test.rb
+++ b/test/unit/services/search_indexer_test.rb
@@ -20,6 +20,7 @@ class SearchIndexerTest < ActiveSupport::TestCase
       description: flow_presenter.description,
       indexable_content: flow_presenter.indexable_content,
       link: "/#{flow_presenter.slug}",
+      content_store_document_type: 'smart_answer',
     )
 
     SearchIndexer.call(flow_presenter)


### PR DESCRIPTION
We need to be able to filter Rummager on document_type for Guidance content, so this change updates Searchable to present the document type for all "Editions".

This has been tested locally by running the `rummager:index` Rake task and checking that the `content_store_document_type` was present on a given document.

Trello: https://trello.com/c/M1cXENeB/341-add-content-store-document-type-to-all-guidance-content-in-rummager