### PR TITLE
New same-sex and opp-sex outcomes for Philippines

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_opposite_sex.govspeak.erb
@@ -28,7 +28,7 @@ You’ll need to bring:
 If you’ve been married or in a civil partnership before, you’ll also need:
 
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email) - if you’re divorced
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_opposite_sex.govspeak.erb
@@ -10,9 +10,9 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 
 An affidavit is a religious document. If you don’t want to swear a religious oath, you can sign an affirmation instead.
 
-s1. Download an [affirmation or affidavit](/government/publications/marriage-in-the-philippines)
-s2. Fill it in on your computer on one side of A4 - the embassy won’t accept it if it’s handwritten
-s3. Print it out but don’t sign it - you’ll need to sign it at the embassy
+s1. Download an [affirmation or affidavit](/government/publications/marriage-in-the-philippines).
+s2. Fill it in on your computer on one side of A4 - the embassy won’t accept it if it’s handwritten.
+s3. Print it out but don’t sign it - you’ll need to sign it at the embassy.
 
 [Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_opposite_sex.govspeak.erb
@@ -1,51 +1,56 @@
+## Before you start
+Contact the [Civil Registrar](https://psa.gov.ph/lcr-directory) where you want to get married to find out about local marriage laws, including what documents you’ll need.
 
-Contact the relevant local authorities in the Philippines to find out about local marriage laws, including what documents you’ll need.
+## Prove you’re free to get married
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %> per person. You can pay in the [local currency](/government/publications/philippines-consular-fees) in cash or by bank-issued cheque.
 
-##What you need to do
+### Swear an affirmation or affidavit
 
-Make an appointment at the British embassy or consulate in the Philippines to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
+An affidavit is a religious document. If you don’t want to swear a religious oath, you can sign an affirmation instead.
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+s1. Download an [affirmation or affidavit](/government/publications/marriage-in-the-philippines)
+s2. Fill it in on your computer on one side of A4 - the embassy won’t accept it if it’s handwritten
+s3. Print it out but don’t sign it - you’ll need to sign it at the embassy
 
-You’ll need to complete an [affirmation for marriage](/government/publications/marriage-in-the-philippines) (non-religious) form or an [affidavit for marriage](/government/publications/marriage-in-the-philippines) (religious) form.
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
 
-You must download and fill in (but not sign) the forms in advance. It must be typed on a computer and printed.
+^Your partner will also need to swear an affirmation or affidavit if they’re British. If they’re not, they might need an equivalent document.^
 
-^Your partner will probably need to get an affirmation or affidavit as well.^
+You’ll need to bring:
 
-You’ll need to provide supporting documents, including:
-
-- your affirmation or affidavit
 - your passport
-
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) - you’ll need to get the document [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English (bring the original and English translation with you)
-- the original marriage certificate, Advisory of Marriage and court documents (if the previous marriage was annulled in the Philippines)
+- your affirmation or affidavit
+- proof of your address, for example a utility bill or driving licence
 - evidence if you’ve changed your name by deed poll
 
-##What happens next
+If you’ve been married or in a civil partnership before, you’ll also need:
 
-You can usually get your affirmation or affidavit on the day of your appointment if you have all your supporting documents.
 
-Once you have your affirmation or affidavit, you can apply for a marriage licence from the local civil registrar.
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
+- the original marriage certificate, Advisory of Marriage and court documents - if the previous marriage was annulled in the Philippines
 
-^Your partner will probably need to get an affirmation or affidavit as well.^
+^If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll need evidence that you or your ex partner lived in or were a national of that country at the time of the divorce.^
 
-## Fees
+If your documents aren’t in English, you’ll need to bring [certified translations](/government/collections/lists-of-translators-and-interpreters) as well as the originals.
 
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-           collection: calculator.services,
-           as: :service,
-           locals: { calculator: calculator } %>
+## Get married
+You should give your affirmation or affidavit to the [local Civil Registrar](https://psa.gov.ph/lcr-directory) when you apply for a marriage licence.
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for the Philippines](/government/publications/philippines-consular-fees).
+You’ll usually get the marriage licence 10 days after you apply. You can book your wedding once you’ve got it.
 
-<%=  render partial: 'how_to_pay.govspeak.erb',
-            locals: {calculator: calculator}%>
+The marriage licence is valid for 120 days and can be used anywhere in the Philippines.
+
+## After you get married
+Your marriage will be recognised in the UK if:
+
+- you follow the correct process according to the law in the Philippines
+- it would be allowed under UK law
+
+You don’t need to register your marriage in the UK.
+
+If your partner isn’t a British citizen, they can apply for [British citizenship](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.govspeak.erb
@@ -1,49 +1,58 @@
-You may be able to register a civil partnership or get married at the British embassy or consulate in the Philippines.
+## Before you start
+You can get married at the British embassy in Manila.
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+If you and your partner don’t live in the Philippines, you need to have been there for at least 21 days before you can get married. You need to stay in the country for the 21 days.
 
-##What documents you’ll need
+## Prove you’re free to get married
 
-You need to have been living in the Philippines for 21 days. You and your partner will need to sign a declaration and provide proof of residence for example, an employer’s letter or a bank statement.
+You and your partner need to give notice of your marriage and sign a declaration that you’re legally allowed to marry.
 
-You’ll both need your original passports. If either of you have been divorced, widowed or in a civil partnership before, you’ll also need either:
+You need to have been in the Philippines for at least 7 full days before you can give notice. This means if you arrived on Monday, you can’t give notice until the following Tuesday.
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- the [death certificate](/order-copy-birth-death-marriage-certificate/)
+### Give notice of your marriage
+[Make an appointment at the British embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage and set a date for your wedding.
 
-##What you need to do
+It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice. You can pay in the [local currency](/government/publications/philippines-consular-fees) in cash or by bank-issued cheque.
 
-At your appointment the embassy or consulate will give you:
+You need to bring:
 
--  a notice of registration
--  a declaration that you and your partner will need to swear, stating that you’re legally entitled to marry or enter into a civil partnership
+- your and your partner’s passports
+- proof that you’ve been in the Philippines for at least 7 full days, for example a utility bill, bank statement, visa or boarding pass
+- proof that your partner is free to get married if they’re not British, for example a certificate of no impediment or a passport showing marital status
 
-Once you’ve completed these and paid the registration fee, the embassy or consulate will display your notice publicly for 14 days.
+If you or your partner have been married or in a civil partnership before, you’ll also need:
 
-As long as nobody registers an objection you can get married or enter into a civil partnership up to 3 months after you gave notice.
+- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a printed PDF and covering email) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
 
-You’ll need to bring two witnesses to your ceremony - they’ll need to show their photo ID (for example passport or driver’s licence).
+^If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll need evidence that you or your ex partner lived in or were a national of that country at the time of the divorce.^
 
-You’ll need to pay a fee to register your marriage or civil partnership and a fee for your marriage or civil partnership certificate.
+The British embassy will display your notice publicly for 14 days. If nobody registers an objection, you can get married up to 3 months after the end of your notice period.
 
-^All same-sex marriages must take place under English and Welsh or Scottish law even if you live in or are from Northern Ireland. Tell the embassy or consulate which law you want to get married under at your appointment.^
+### Sign a declaration
+You and your partner also need to sign a declaration to say that you’re legally allowed to get married. The British embassy will give you the document to sign.
 
-##Naturalisation of your partner if they move to the UK
+You both need to bring proof that you live in the Philippines or you’ve been there for at least the last 21 full days. This could be a utility bill, bank statement, visa or boarding pass.
 
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+## Get married
+Your wedding ceremony will be at the British embassy in Manila on the date you agreed.
 
-## Fees
+You’ll need to bring 2 witnesses to your ceremony. Your witnesses must:
 
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-           collection: calculator.services,
-           as: :service,
-           locals: { calculator: calculator } %>
+- bring photo ID
+- be 16 or over
+- know you or your partner
+- understand English well enough to follow the ceremony and read the marriage register
 
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for the Philippines](/government/publications/philippines-consular-fees).
+You, your partner and your 2 witnesses will sign the marriage register.
 
-<%=  render partial: 'how_to_pay.govspeak.erb',
-            locals: {calculator: calculator}%>
+It costs <%= format_money calculator.consular_fee(:registering_marriage) %> to register your marriage. You can also pay <%= format_money calculator.consular_fee(:issuing_marriage_certificate) %> for a marriage certificate if you want one.
 
-##Convert a civil partnership to a same-sex marriage
+You can pay when you give notice or on your wedding day. You need to pay in the [local currency](/government/publications/philippines-consular-fees) in cash or by bank-issued cheque.
 
-If you’ve already entered into a civil partnership you may be able to convert it to a same-sex marriage - read [‘Convert a civil partnership to a same-sex marriage abroad’](/convert-civil-partnership-abroad).
+## After you get married
+You’ll be married under UK law, so your marriage will be recognised in the UK but not in the Philippines or other countries where same sex marriage isn’t legal.
+
+If your partner isn’t a British citizen, they can apply for [British citizenship](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.govspeak.erb
@@ -22,7 +22,7 @@ You need to bring:
 
 If you or your partner have been married or in a civil partnership before, you’ll also need:
 
-- your [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a printed PDF and covering email) - if you’re divorced
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a printed PDF and covering email from the court) - if you’re divorced
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.govspeak.erb
@@ -17,7 +17,7 @@ It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage)
 You need to bring:
 
 - your and your partner’s passports
-- proof that you’ve been in the Philippines for at least 7 full days, for example a utility bill, bank statement, visa or boarding pass
+- proof that you’ve been in the Philippines for at least 7 full days, for example a utility bill, bank statement, passport stamp or boarding pass
 - proof that your partner is free to get married if they’re not British, for example a certificate of no impediment or a passport showing marital status
 
 If you or your partner have been married or in a civil partnership before, you’ll also need:
@@ -34,7 +34,7 @@ The British embassy will display your notice publicly for 14 days. If nobody reg
 ### Sign a declaration
 You and your partner also need to sign a declaration to say that you’re legally allowed to get married. The British embassy will give you the document to sign.
 
-You both need to bring proof that you live in the Philippines or you’ve been there for at least the last 21 full days. This could be a utility bill, bank statement, visa or boarding pass.
+You both need to bring proof that you live in the Philippines or you’ve been there for at least the last 21 full days. This could be a utility bill, bank statement, passport stamp or boarding pass.
 
 ## Get married
 Your wedding ceremony will be at the British embassy in Manila on the date you agreed.


### PR DESCRIPTION
Have added new outcomes for Philippines. There were previously 18, this has been reduced to 2: one for same-sex and one for opposite-sex. 

These are the changes that were worked on in the improvement sprints. 