### PR TITLE
Pay leave for parents

### DIFF
--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb
@@ -2,8 +2,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-<%= render partial: 'statutory_maternity_pay_warning.govspeak.erb' %>
-
  | Dates
 - | -
 Earliest leave can start | <%= format_date(calculator.earliest_start_mat_leave) %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_statutory_maternity_pay_warning.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_statutory_maternity_pay_warning.govspeak.erb
@@ -1,1 +1,1 @@
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2014-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/employee/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2015-04-05/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2011

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 10 November 2013

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/self-employed/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/self-employed/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/self-employed/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2014-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 16 November 2014

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/self-employed/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/self-employed/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/self-employed/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 18 January 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/self-employed/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/self-employed/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/self-employed/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 15 November 2015

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother can claim maternity allowance as soon as she’s been pregnant for 26
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -4,8 +4,6 @@
 
 The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
-
 | Dates
 - | -
 Earliest leave can start | 13 November 2016

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/no/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/no/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/yes/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 | Dates and amounts
 - | -

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -4,7 +4,7 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
-^You're not eligible for maternity allowance if you get Statutory Maternity Pay from another job.^
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
 
 ###Dates and amounts
 

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -10,7 +10,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_extra_help.govspeak.erb: 120e37ea86f9fd5fb138144d085549a7
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: b7c6fae7fa98a36781bd1b197150c5f8
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.govspeak.erb: e1555fd4de46d55dfb5d36e04f6bc42d
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 4c5a2ec95e5a9af0631455853229281e
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 11e728f05f4e684db9a204c1f0cd62b3
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: ee77d0073e0fa5fe2d402cfd56f4e045
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_leave.govspeak.erb: 11930d6727f1a95f6aba571c6c0148b6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: 8d551b6951cda592031be89058fd69f6

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -19,7 +19,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb: 30d
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_leave.govspeak.erb: 8a866beb5a6fb6fd3301185dfa7c9098
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb: dd8475f0eabbd08efdf625db5dc4cede
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_single_birth_nothing.govspeak.erb: a62e26a33835b11b26320bcb09b193d6
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_statutory_maternity_pay_warning.govspeak.erb: 5d910eb8dc1462f4f2ce6b8959956438
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_statutory_maternity_pay_warning.govspeak.erb: 6bf9329c9514981523707aa72105e430
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/outcome_birth_nothing.govspeak.erb: 15ae49e3011c3aa0bfcde091a48b8a56
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/outcome_mat_allowance.govspeak.erb: 519706c731e3099f6498082f75067a6f
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/outcome_mat_allowance_14_weeks.govspeak.erb: fa2103f1e4afb2c0607fdd630680f598


### PR DESCRIPTION
## Trello
https://trello.com/c/6Eyy6ZNY/498-1-pay-leave-for-parents-remove-statutory-maternity-pay-callout-from-maternity-leave-outcome

## Heroku

[PR deploy](https://smart-answers-pr-2908.herokuapp.com/pay-leave-for-parents/)

## Description
The maternity pay warning callout should only appear on maternity allowance outcomes. In addition to this the content of this callout has also changed.

Affects a lot of artefacts as this smart answer has many outcome routes.

## Expected changes

Pay leave for parents:

*Callout content change*

[On gov.uk](https://www.gov.uk/pay-leave-for-parents/y/no/2012-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year)

Before:
<img width="1027" alt="before_message_content" src="https://cloud.githubusercontent.com/assets/6338228/23031330/87098892-f468-11e6-9f94-f57b2e59ee7f.png">


After:
<img width="1017" alt="after_message_content" src="https://cloud.githubusercontent.com/assets/6338228/23031349/93a9fb2c-f468-11e6-8f70-299cd38ce3da.png">


*Conditional removal of callout from some outcomes*

[On gov.uk](https://www.gov.uk/pay-leave-for-parents/y/no/2012-02-01/employee/no/yes/10000.0-year/no/no/no)

Before:
<img width="1030" alt="before_callout_removal" src="https://cloud.githubusercontent.com/assets/6338228/23031448/e957d63e-f468-11e6-9b8d-8cccbc8eaa8b.png">

After:
<img width="1002" alt="after_callout_removal" src="https://cloud.githubusercontent.com/assets/6338228/23031454/f290eac4-f468-11e6-9874-68f9dcef9dd1.png">
