### PR TITLE
Migrate smart-answers to new CI environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,11 +32,11 @@ gem 'govuk_ab_testing', '0.1.4'
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'govuk-lint'
   gem 'nokogiri'
 end
 
 group :development, :test do
+  gem 'govuk-lint'
   gem 'pry'
 end
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,53 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'smart-answers'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  try {
+    stage('Checkout') {
+      checkout scm
+      govuk.cleanupGit()
+      govuk.mergeMasterBranch()
+      govuk.contentSchemaDependency()
+      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
+      govuk.setEnvar("DISPLAY", ":99")
+    }
+
+    stage('Bundle') {
+      govuk.bundleApp()
+    }
+
+    stage('Linter') {
+      govuk.rubyLinter()
+    }
+
+    stage("Assets") {
+      govuk.precompileAssets()
+    }
+
+    stage('Tests') {
+      govuk.runTests()
+    }
+
+    if (env.BRANCH_NAME == 'master') {
+      stage('Push release tag') {
+        govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
+      }
+
+      stage('Deploy to Integration') {
+        // Deploy on Integration (only master)
+        govuk.deployIntegration(REPOSITORY, BRANCH_NAME, 'release', 'deploy')
+      }
+    }
+
+  } catch (e) {
+    currentBuild.result = 'FAILED'
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}


### PR DESCRIPTION
Trello card: https://trello.com/c/94VbayRY

## Motivation

The old CI environment is being turned off, so we need to start building smart-answers on the new Jenkins2 environment.

Jenkins2 looks for the presence of a `Jenkinsfile` and runs that by default.