### PR TITLE
Change the repo name in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ node {
 
       stage('Deploy to Integration') {
         // Deploy on Integration (only master)
-        govuk.deployIntegration(REPOSITORY, BRANCH_NAME, 'release', 'deploy')
+        govuk.deployIntegration('smartanswers', BRANCH_NAME, 'release', 'deploy')
       }
     }
 


### PR DESCRIPTION
This commit changes the repo name passed to govuk.deployIntegration

This is because repo name contains a dash and isn’t equal to the name
defined. 

The repo name has been changed from smart-answers to smartanswers

