### PR TITLE
[Do not merge] Bump navigation helper version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'uglifier'
 gem 'uk_postcode', '~> 1.0.1'
 gem 'unicorn', '4.8.3'
 gem 'rails_stdout_logging'
-gem 'govuk_navigation_helpers', '~> 2.2.0'
+gem 'govuk_navigation_helpers', '~> 2.3.1'
 gem 'govuk_ab_testing', '0.1.4'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.2.0)
+    govuk_navigation_helpers (2.3.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -278,7 +278,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 0.1.4)
   govuk_frontend_toolkit (= 4.14.0)
-  govuk_navigation_helpers (~> 2.2.0)
+  govuk_navigation_helpers (~> 2.3.1)
   htmlentities (~> 4)
   json
   logstasher (= 0.4.8)


### PR DESCRIPTION
The new version of navigation helpers will display the current page in the breadcrumbs.

Dependent on:
- [x] Deployment of `static` [`release_2466`](https://github.com/alphagov/static/commit/07c2bcfb04e87efc9f9bd0c75ecc33573bfd5fc2) to Production

Trello: https://trello.com/c/MVM5bueS/386-add-current-page-to-taxonomy-breadcrumbs