### PR TITLE
Update regression tests scripts jenkins 2 (Continued)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,11 @@ node {
     }
 
     if (env.BRANCH_NAME == 'master') {
+      stage('Regression tests') {
+        govuk.setEnvar("RUN_REGRESSION_TESTS", "true")
+        sh("bundle exec ruby test/regression/smart_answers_regression_test.rb")
+      }
+
       stage('Push release tag') {
         govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
       }

--- a/doc/regression-tests.md
+++ b/doc/regression-tests.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Unusually this project includes a set of regression tests. These tests are not *normally* run as part of the `default` Rake task, because they take a long time to run. Thus they do not normally run as part of the [main CI build](continuous-integration#main). However, they *always* run as part of the [regression CI build](continuous-integration#regression) (currently every 2 hours).
+Unusually this project includes a set of regression tests. These tests are not *normally* run as part of the `default` Rake task, because they take a long time to run. Thus they do not normally run as part of the [main CI build](continuous-integration#main). However, they *always* run as part of the [regression CI build](continuous-integration#regression) on the master branch only. Go to this [Jenkins Job](https://ci.integration.publishing.service.gov.uk/job/smartanswers/job/master/), click on the lastest build, click replay and edit the script in the first textarea to run the regressions tests. 
 
 Having said all that, there is a [primitive mechanism](#checksum-file) which detects changes to the files associated with a given flow since the last time the regression tests ran successfully for that flow.
 


### PR DESCRIPTION
Supersedes #2918 

[Trello card](https://trello.com/c/an1K8uBx/503-5-create-a-job-on-the-new-jenkins-environment-to-run-the-regression-tests-every-two-hours-and-manually)