### PR TITLE
Fix casing of A/B test name

### DIFF
--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -1,6 +1,6 @@
 module EducationNavigationABTestable
   def education_navigation_ab_test
-    @ab_test ||= GovukAbTesting::AbTest.new("educationnavigation", dimension: 41)
+    @ab_test ||= GovukAbTesting::AbTest.new("EducationNavigation", dimension: 41)
   end
 
   def should_present_new_navigation_view?

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -229,7 +229,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
       end
 
       should "show normal breadcrumbs for the 'A' version" do
-        with_variant educationnavigation: "A" do
+        with_variant EducationNavigation: "A" do
           get :show, id: 'smart-answers-controller-sample'
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
@@ -237,7 +237,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
-        with_variant educationnavigation: "B" do
+        with_variant EducationNavigation: "B" do
           get :show, id: 'smart-answers-controller-sample'
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)


### PR DESCRIPTION
The name of the A/B test must match the cookie name exactly. The name of this test is defined as `EducationNavigation` in alphagov/govuk-cdn-config#17.
