### PR TITLE
Landlord immigration check: Factcheck amends affecting EU and British paths

### DIFF
--- a/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
@@ -11,6 +11,8 @@
 
   You must check anyone aged 18 or over who pays to use your property as their main home, eg tenants, sub-tenants and paying house guests.
 
+  You might get a [fine (civil penalty)](/penalties-illegal-renting) if you rent your property to someone who doesn’t have the right to rent.
+
   If you've bought a property that already has tenants, you need proof that their last landlord did the check. You’ll still be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents/further-checks) in future.
 
   ^Read more about the [right to rent documents](/government/publications/right-to-rent-document-checks-a-user-guide) you can accept.^  

--- a/lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb
@@ -1,11 +1,7 @@
 <% content_for :body do %>
-  This person can’t rent your property because they haven't shown you documents to prove their right to rent.
+  This person can’t rent your property because they haven’t shown you documents to prove their right to rent.
 
-  You might get a [fine (civil penalty)](/penalties-illegal-renting) if you rent your property to them.
-
-  If the person is already renting your property, you must [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
-
-  ^If you think they do have the right to rent, [check the full list of documents](/government/publications/right-to-rent-document-checks-a-user-guide) they can show you as proof.^
+  If you think they do have the right to rent, [check the full list of documents](/government/publications/right-to-rent-document-checks-a-user-guide) they can show you as proof.
 
   You can read the landlord’s [code of practice](/government/publications/right-to-rent-landlords-code-of-practice) on making checks for more information.
 

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/british-or-irish/no/no.txt
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/british-or-irish/no/no.txt
@@ -1,12 +1,8 @@
 
 
-This person can’t rent your property because they haven't shown you documents to prove their right to rent.
+This person can’t rent your property because they haven’t shown you documents to prove their right to rent.
 
-You might get a [fine (civil penalty)](/penalties-illegal-renting) if you rent your property to them.
-
-If the person is already renting your property, you must [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
-
-^If you think they do have the right to rent, [check the full list of documents](/government/publications/right-to-rent-document-checks-a-user-guide) they can show you as proof.^
+If you think they do have the right to rent, [check the full list of documents](/government/publications/right-to-rent-document-checks-a-user-guide) they can show you as proof.
 
 You can read the landlord’s [code of practice](/government/publications/right-to-rent-landlords-code-of-practice) on making checks for more information.
 

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/eea/no/no.txt
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/eea/no/no.txt
@@ -1,12 +1,8 @@
 
 
-This person can’t rent your property because they haven't shown you documents to prove their right to rent.
+This person can’t rent your property because they haven’t shown you documents to prove their right to rent.
 
-You might get a [fine (civil penalty)](/penalties-illegal-renting) if you rent your property to them.
-
-If the person is already renting your property, you must [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
-
-^If you think they do have the right to rent, [check the full list of documents](/government/publications/right-to-rent-document-checks-a-user-guide) they can show you as proof.^
+If you think they do have the right to rent, [check the full list of documents](/government/publications/right-to-rent-document-checks-a-user-guide) they can show you as proof.
 
 You can read the landlord’s [code of practice](/government/publications/right-to-rent-landlords-code-of-practice) on making checks for more information.
 

--- a/test/artefacts/landlord-immigration-check/landlord-immigration-check.txt
+++ b/test/artefacts/landlord-immigration-check/landlord-immigration-check.txt
@@ -4,6 +4,8 @@ Find out if someone can rent your private residential property in England.
 
 You must check anyone aged 18 or over who pays to use your property as their main home, eg tenants, sub-tenants and paying house guests.
 
+You might get a [fine (civil penalty)](/penalties-illegal-renting) if you rent your property to someone who doesn’t have the right to rent.
+
 If you've bought a property that already has tenants, you need proof that their last landlord did the check. You’ll still be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents/further-checks) in future.
 
 ^Read more about the [right to rent documents](/government/publications/right-to-rent-document-checks-a-user-guide) you can accept.^  

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -4,7 +4,7 @@ test/data/landlord-immigration-check-questions-and-responses.yml: 36d2d5613fb604
 test/data/landlord-immigration-check-responses-and-expected-results.yml: 4eb1cf7c87a8c79c82b16e7b8983f31c
 lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: 0665a43e76e6184bab15ef6e19c79cc8
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_landlord_code_of_practice.govspeak.erb: cfb1261ac17c7aa40445173406459290
-lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb: 27a5d4936b713e09fa12059ac230ba56
+lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb: 8af976b51704d6efe3e7cab8947332ce
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent.govspeak.erb: cccbf4f13c188615b2c3afe23c0d55d1
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent_but_check_will_be_needed_again.govspeak.erb: 77211f295e408d82e933f234109cb7de
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent_for_12_months.govspeak.erb: 90300c65f362f43d90028c976ca4a64e

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/landlord-immigration-check.rb: 88c5cbe1cfe60a0674044e01b8e720d9
 test/data/landlord-immigration-check-questions-and-responses.yml: 36d2d5613fb6046704d658ab8fac27ab
 test/data/landlord-immigration-check-responses-and-expected-results.yml: 4eb1cf7c87a8c79c82b16e7b8983f31c
-lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: 60507bfc657cf13a750b258017453743
+lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: 0665a43e76e6184bab15ef6e19c79cc8
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_landlord_code_of_practice.govspeak.erb: cfb1261ac17c7aa40445173406459290
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb: 27a5d4936b713e09fa12059ac230ba56
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent.govspeak.erb: cccbf4f13c188615b2c3afe23c0d55d1


### PR DESCRIPTION
Trello cards 
- [British and Irish](https://trello.com/c/HAuefTUr/312-implement-british-or-irish-route-landlord-immigration-check)
- [EU](https://trello.com/c/P3y4E5sg/316-implement-eu-country-the-eea-or-switzerland-landlord-immigration-check)


## Description

This PR adds a new outcome that warns landlords of the possible ineligibility of a prospective tenant to rent and also provides information to other Home Office relevant documents.

The addition of this new outcomes replaces outcome_can_not_rent, so at the moment this node is no longer being exercised.

Also removes the "You might get fine.." line from the can't rent outcome and adds it to the start page.

This is to forewarn landlords upfront.


## Factcheck 
[Parent preview link](https://smart-answers-pr-2803.herokuapp.com/landlord-immigration-check/y/B11PW/yes/yes/british-or-irish/no/no)
[Preview link](https://smart-answers-pr-2922.herokuapp.com/landlord-immigration-check/y/B11PW/yes/yes/british-or-irish/no/no)
[GOV.UK](http://gov.uk/landlord-immigration-check/y)

## Expected changes
- Change in can't rent content 
- Removal of "You might get fine.." from outcome
- Addition of "You might get fine.." to start page


### Before
![screen shot 2017-02-20 at 16 17 58](https://cloud.githubusercontent.com/assets/84896/23133220/49cbb310-f788-11e6-96db-27a685eb31f9.png)




### After
![screen shot 2017-02-20 at 16 15 48](https://cloud.githubusercontent.com/assets/84896/23133115/e2303a28-f787-11e6-8027-d22390112ad2.png)

