### PR TITLE
Student finance forms: Urgent content update

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_continuing.govspeak.erb
@@ -6,6 +6,8 @@
 
   To apply for a Tuition Fee Loan use form EUPR1A.
 
+  The EUPR1A is for EU students studying in England only.
+
   Academic year | Form
   - | -
   2017 to 2018 | [EUPR1A - form (PDF, 108KB)](http://media.slc.co.uk/sfe/1718/eu/eu_eupr1a_form_1718_d.pdf)

--- a/lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb
@@ -11,7 +11,7 @@
 
   + forms PN1, PR1, PTL1, PFF2 and CYI
   + forms for parents
-  + forms for EU students
+  + forms for EU students studying in England
   + forms for Disabled Students’ Allowances (DSA)
 <% end %>
 

--- a/test/artefacts/student-finance-forms/eu-full-time/year-1718/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/eu-full-time/year-1718/continuing-student.txt
@@ -3,6 +3,8 @@ EU full-time student
 
 To apply for a Tuition Fee Loan use form EUPR1A.
 
+The EUPR1A is for EU students studying in England only.
+
 Academic year | Form
 - | -
 2017 to 2018 | [EUPR1A - form (PDF, 108KB)](http://media.slc.co.uk/sfe/1718/eu/eu_eupr1a_form_1718_d.pdf)

--- a/test/artefacts/student-finance-forms/student-finance-forms.txt
+++ b/test/artefacts/student-finance-forms/student-finance-forms.txt
@@ -4,7 +4,7 @@ Download student finance forms and guidance notes for Student Finance England in
 
 + forms PN1, PR1, PTL1, PFF2 and CYI
 + forms for parents
-+ forms for EU students
++ forms for EU students studying in England
 + forms for Disabled Students’ Allowances (DSA)
 
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -17,7 +17,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1718.govspeak.
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_expenses.govspeak.erb: 0b6963ced4ad5c5a89cac81d7ee873a8
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1617_continuing.govspeak.erb: 5809f0e73d54ab52f933075a4845fe2f
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1617_new.govspeak.erb: de40ad74ec044a07a702c9a4a72447a3
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_continuing.govspeak.erb: 567c62c12d97c8c9708163db3247dcb8
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_continuing.govspeak.erb: d0150398a4c0c129926e97b67ca0cf24
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_new.govspeak.erb: 1107e71aea3d3a79fb8d381b34cb9778
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_continuing.govspeak.erb: 07189e16f1f8d4940fe6a778230ee479
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.govspeak.erb: 02a6092382484da065e75e31194582b0

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -48,4 +48,4 @@ lib/smart_answer_flows/student-finance-forms/questions/pt_course_start.govspeak.
 lib/smart_answer_flows/student-finance-forms/questions/type_of_student.govspeak.erb: 7b236a9aae750540e95e476dace07a3f
 lib/smart_answer_flows/student-finance-forms/questions/what_year_full_time.govspeak.erb: ba33987c1eee3ecd089045ca9e874b0e
 lib/smart_answer_flows/student-finance-forms/questions/what_year_part_time.govspeak.erb: fc407cbafeb1b3ed2a1c726cec57ced3
-lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb: 4e002f95cc761ea3632dcc002f0d7a09
+lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb: 41695473d757c255ec52ef041d662c86


### PR DESCRIPTION
[Trello card](https://trello.com/c/QGYrhRiZ/565-add-in-england-to-student-finance-form-finder)

## Description 

Content update to the following start page and 2017/18 eu continuing.

## Factcheck start page
[Preview link](https://smart-answers-pr-2933.herokuapp.com/student-finance-forms/)

[GOV.UK](https://gov.uk/student-finance-forms/)

## Expected changes
- Content update to start paged and eu continuing student

### Before

![screen shot 2017-02-24 at 11 48 46](https://cloud.githubusercontent.com/assets/84896/23302620/48d8db48-fa87-11e6-90f2-b63b22b7b9cf.png)


### After
![screen shot 2017-02-24 at 11 38 24](https://cloud.githubusercontent.com/assets/84896/23302875/b9d0bb30-fa88-11e6-9f36-31717cd33f88.png)

## Factcheck 2017/18 for EU continuing student
[Preview link](https://smart-answers-pr-2933.herokuapp.com/student-finance-forms/y/eu-full-time/year-1718/continuing-student)

[GOV.UK](https://gov.uk/student-finance-forms/y/eu-full-time/year-1718/continuing-student)

## Expected changes
- Content update to start paged and eu continuing student

### Before

![screen shot 2017-02-24 at 11 35 54](https://cloud.githubusercontent.com/assets/84896/23302145/6e09b894-fa85-11e6-9953-968a2b214095.png)

### After
![screen shot 2017-02-24 at 11 35 24](https://cloud.githubusercontent.com/assets/84896/23302134/5dc43234-fa85-11e6-981e-a5671aaaa8b4.png)


