### PR TITLE
Add taxonomy sidebar to pages displaying the new navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'uglifier'
 gem 'uk_postcode', '~> 1.0.1'
 gem 'unicorn', '4.8.3'
 gem 'rails_stdout_logging'
-gem 'govuk_navigation_helpers', '~> 2.3.1'
+gem 'govuk_navigation_helpers', '~> 2.4.0'
 gem 'govuk_ab_testing', '0.1.4'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.3.1)
+    govuk_navigation_helpers (2.4.0)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -278,7 +278,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 0.1.4)
   govuk_frontend_toolkit (= 4.14.0)
-  govuk_navigation_helpers (~> 2.3.1)
+  govuk_navigation_helpers (~> 2.4.0)
   htmlentities (~> 4)
   json
   logstasher (= 0.4.8)

--- a/app/views/smart_answers/show.html.erb
+++ b/app/views/smart_answers/show.html.erb
@@ -25,7 +25,11 @@
   <% unless @presenter.started? %>
     <div class="related-container">
       <% if @navigation_helpers %>
-        <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+        <% if should_present_new_navigation_view? %>
+          <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @navigation_helpers.taxonomy_sidebar %>
+        <% else %>
+          <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -199,23 +199,27 @@ class SmartAnswersControllerTest < ActionController::TestCase
       setup do
         ENV['ENABLE_NEW_NAVIGATION'] = 'yes'
 
-        @controller.stubs(:content_item).returns(
+        content_item = {
           "links" => {
-            "taxons" => 'foo',
+            "taxons" => [
+              {
+                "title" => "A Taxon",
+                "base_path" => "/a-taxon",
+              }
+            ],
           },
-        )
+        }
 
-        @controller.stubs(
-          navigation_helpers: stub(
-            'navigation_helpers',
-            breadcrumbs: {
-              breadcrumbs: ['NormalBreadcrumb'],
-            },
-            taxon_breadcrumbs: {
-              breadcrumbs: ['TaxonBreadcrumb'],
-            },
-          )
-        )
+        Services.content_store.expects(:content_item!)
+          .with("/smart-answers-controller-sample")
+          .returns(content_item)
+
+        navigation_helper = GovukNavigationHelpers::NavigationHelper.new(content_item)
+        navigation_helper.stubs(:breadcrumbs).returns(breadcrumbs: ['NormalBreadcrumb'])
+        navigation_helper.stubs(:taxon_breadcrumbs).returns(breadcrumbs: ['TaxonBreadcrumb'])
+        GovukNavigationHelpers::NavigationHelper.expects(:new)
+          .with(content_item)
+          .returns(navigation_helper)
       end
 
       teardown do

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -228,23 +228,32 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
       should "show normal breadcrumbs by default" do
         get :show, id: 'smart-answers-controller-sample'
+
         assert_match(/NormalBreadcrumb/, response.body)
         refute_match(/TaxonBreadcrumb/, response.body)
+        sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
+        refute_match(/A Taxon/, sidebar)
       end
 
       should "show normal breadcrumbs for the 'A' version" do
         with_variant EducationNavigation: "A" do
           get :show, id: 'smart-answers-controller-sample'
+
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
+          sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
+          refute_match(/A Taxon/, sidebar)
         end
       end
 
       should "show taxon breadcrumbs for the 'B' version" do
         with_variant EducationNavigation: "B" do
           get :show, id: 'smart-answers-controller-sample'
+
           assert_match(/TaxonBreadcrumb/, response.body)
           refute_match(/NormalBreadcrumb/, response.body)
+          sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
+          assert_match(/A Taxon/, sidebar)
         end
       end
     end


### PR DESCRIPTION
Use the taxonomy sidebar component in static and rework the tests to
assert for the presence of the sidebar and breadcrumbs where
appropriate.

<img width="1008" alt="look_up_meursing_code_-_gov_uk" src="https://cloud.githubusercontent.com/assets/519250/23370618/31713fc6-fd0d-11e6-8b44-53502ad11a75.png">


https://trello.com/c/0BD3POzu/403-show-parent-taxons-in-the-side-navigation-on-all-education-content-pages