### PR TITLE
Remove the New Navigation feature flag

### DIFF
--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -4,15 +4,11 @@ module EducationNavigationABTestable
   end
 
   def should_present_new_navigation_view?
-    education_navigation_variant.variant_b? && new_navigation_enabled? && content_is_tagged_to_a_taxon?
+    education_navigation_variant.variant_b? && content_is_tagged_to_a_taxon?
   end
 
   def education_navigation_variant
     @education_navigation_variant ||= education_navigation_ab_test.requested_variant request
-  end
-
-  def new_navigation_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
   end
 
   def content_is_tagged_to_a_taxon?

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -197,8 +197,6 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     context "A/B testing" do
       setup do
-        ENV['ENABLE_NEW_NAVIGATION'] = 'yes'
-
         content_item = {
           "links" => {
             "taxons" => [
@@ -220,10 +218,6 @@ class SmartAnswersControllerTest < ActionController::TestCase
         GovukNavigationHelpers::NavigationHelper.expects(:new)
           .with(content_item)
           .returns(navigation_helper)
-      end
-
-      teardown do
-        ENV['ENABLE_NEW_NAVIGATION'] = nil
       end
 
       should "show normal breadcrumbs by default" do


### PR DESCRIPTION
This means we can toggle the A/B variant in production via the chrome
extension. When we rollout the new navigation with a Fastly
configuration change, the % of users we select will start seeing these
new pages.

Trello: https://trello.com/c/940kowVa/484-remove-enable-new-navigation-check-from-repos-and-from-puppet