### PR TITLE
Configure navigation helpers with error handler

### DIFF
--- a/config/initializers/govuk_navigation_helpers.rb
+++ b/config/initializers/govuk_navigation_helpers.rb
@@ -1,0 +1,3 @@
+GovukNavigationHelpers.configure do |config|
+  config.error_handler = Airbrake
+end


### PR DESCRIPTION
In case the search queries error when building the related links
component, we rescue the exceptions and don't show the related links. We
still need to keep track of those errors, though.

This commit configures govuk_navigation_helpers with Airbrake as its
error handler class.

Trello: https://trello.com/c/mzigZrei/487-inject-airbrake-into-govuk-navigation-helpers-in-all-education-apps