### PR TITLE
Only add A/B testing Vary header and meta tag to education pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'uk_postcode', '~> 1.0.1'
 gem 'unicorn', '4.8.3'
 gem 'rails_stdout_logging'
 gem 'govuk_navigation_helpers', '~> 3.0'
-gem 'govuk_ab_testing', '0.1.4'
+gem 'govuk_ab_testing', '1.0.4'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     govuk-lint (0.7.0)
       rubocop (~> 0.35.0)
       scss_lint
-    govuk_ab_testing (0.1.4)
+    govuk_ab_testing (1.0.4)
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -277,7 +277,7 @@ DEPENDENCIES
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 0.1.4)
+  govuk_ab_testing (= 1.0.4)
   govuk_frontend_toolkit (= 4.14.0)
   govuk_navigation_helpers (~> 3.0)
   htmlentities (~> 4)
@@ -313,4 +313,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.6
+   1.14.5

--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -8,7 +8,7 @@ module EducationNavigationABTestable
   end
 
   def education_navigation_variant
-    @education_navigation_variant ||= education_navigation_ab_test.requested_variant request
+    @education_navigation_variant ||= education_navigation_ab_test.requested_variant request.headers
   end
 
   def content_is_tagged_to_a_taxon?

--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -1,26 +1,33 @@
 module EducationNavigationABTestable
-  def education_navigation_ab_test
-    @ab_test ||= GovukAbTesting::AbTest.new("EducationNavigation", dimension: 41)
-  end
-
-  def should_present_new_navigation_view?
-    education_navigation_variant.variant_b? && content_is_tagged_to_a_taxon?
+  def should_present_new_navigation_view?(content_item)
+    education_navigation_variant.variant_b? && content_is_tagged_to_a_taxon?(content_item)
   end
 
   def education_navigation_variant
     @education_navigation_variant ||= education_navigation_ab_test.requested_variant request.headers
   end
 
-  def content_is_tagged_to_a_taxon?
-    content_item.dig("links", "taxons").present?
+  def page_is_under_ab_test?(content_item)
+    content_is_tagged_to_a_taxon?(content_item)
   end
 
-  def set_education_navigation_response_header
-    education_navigation_variant.configure_response response
+  def set_education_navigation_response_header(content_item)
+    if page_is_under_ab_test?(content_item)
+      education_navigation_variant.configure_response response
+    end
   end
 
   def self.included(base)
     base.helper_method :education_navigation_variant
-    base.after_filter :set_education_navigation_response_header
+  end
+
+private
+
+  def education_navigation_ab_test
+    @ab_test ||= GovukAbTesting::AbTest.new("EducationNavigation", dimension: 41)
+  end
+
+  def content_is_tagged_to_a_taxon?(content_item)
+    content_item.dig("links", "taxons").present?
   end
 end

--- a/app/views/smart_answers/show.html.erb
+++ b/app/views/smart_answers/show.html.erb
@@ -5,10 +5,12 @@
     SmartAnswer.AJAX_ENABLED = <%= ajax_enabled_for?(@presenter.name) %>;
   </script>
   <%= javascript_include_tag "application", defer: true %>
-  <%= education_navigation_variant.analytics_meta_tag.html_safe %>
+  <% if page_is_under_ab_test?(@content_item) %>
+    <%= education_navigation_variant.analytics_meta_tag.html_safe %>
+  <% end %>
 <% end %>
 
-<%= render 'govuk_component/beta_label' if should_present_new_navigation_view? %>
+<%= render 'govuk_component/beta_label' if should_present_new_navigation_view?(@content_item) %>
 <%= render partial: 'govuk_component/breadcrumbs', locals: breadcrumbs %>
 
 <div class="grid-row">
@@ -25,7 +27,7 @@
   <% unless @presenter.started? %>
     <div class="related-container">
       <% if @navigation_helpers %>
-        <% if should_present_new_navigation_view? %>
+        <% if should_present_new_navigation_view?(@content_item) %>
           <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @navigation_helpers.taxonomy_sidebar %>
         <% else %>
           <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -8,7 +8,9 @@
 <%= javascript_include_tag 'visualise' %>
 <%= stylesheet_link_tag 'joint' %>
 <%= stylesheet_link_tag 'visualise' %>
-<%= education_navigation_variant.analytics_meta_tag.html_safe %>
+<% if page_is_under_ab_test?(@content_item) %>
+  <%= education_navigation_variant.analytics_meta_tag.html_safe %>
+<% end %>
 <% end %>
 
 <% content_for :before_wrapper do %>

--- a/test/fixtures/smart_answer_flows/education-sample.rb
+++ b/test/fixtures/smart_answer_flows/education-sample.rb
@@ -1,0 +1,17 @@
+module SmartAnswer
+  class EducationSampleFlow < Flow
+    def define
+      name "education-sample"
+
+      postcode_question :user_input? do
+        save_input_as :user_input
+
+        next_node do
+          outcome :outcome
+        end
+      end
+
+      outcome :outcome
+    end
+  end
+end

--- a/test/fixtures/smart_answer_flows/education-sample/questions/user_input.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/education-sample/questions/user_input.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :title do %>
+  User input?
+<% end %>

--- a/test/functional/smart_answers_controller_date_question_test.rb
+++ b/test/functional/smart_answers_controller_date_question_test.rb
@@ -11,6 +11,9 @@ class SmartAnswersControllerDateQuestionTest < ActionController::TestCase
 
   def setup
     setup_fixture_flows
+    stub_shared_component_locales
+
+    stub_smart_answer_in_content_store("smart-answers-controller-sample-with-date-question")
   end
 
   def teardown

--- a/test/functional/smart_answers_controller_debug_template_path_test.rb
+++ b/test/functional/smart_answers_controller_debug_template_path_test.rb
@@ -12,6 +12,8 @@ class SmartAnswersControllerDebugTemplatePathTest < ActionController::TestCase
     registry = SmartAnswer::FlowRegistry.instance
     flow_name = 'smart-answers-controller-sample'
     @template_directory = registry.load_path.join(flow_name)
+
+    stub_smart_answer_in_content_store("smart-answers-controller-sample")
   end
 
   def teardown

--- a/test/functional/smart_answers_controller_money_question_test.rb
+++ b/test/functional/smart_answers_controller_money_question_test.rb
@@ -12,6 +12,8 @@ class SmartAnswersControllerMoneyQuestionTest < ActionController::TestCase
   def setup
     stub_shared_component_locales
     setup_fixture_flows
+
+    stub_smart_answer_in_content_store("smart-answers-controller-sample-with-money-question")
   end
 
   def teardown

--- a/test/functional/smart_answers_controller_salary_question_test.rb
+++ b/test/functional/smart_answers_controller_salary_question_test.rb
@@ -12,6 +12,8 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
   def setup
     setup_fixture_flows
     stub_shared_component_locales
+
+    stub_smart_answer_in_content_store("smart-answers-controller-sample-with-salary-question")
   end
 
   def teardown

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -50,6 +50,10 @@ class SmartAnswersControllerTest < ActionController::TestCase
   end
 
   context "GET /<slug>" do
+    setup do
+      stub_smart_answer_in_content_store("smart-answers-controller-sample")
+    end
+
     should "respond with 404 if not found" do
       @registry = stub("Flow registry")
       @registry.stubs(:find).raises(SmartAnswer::FlowRegistry::NotFound)
@@ -196,58 +200,74 @@ class SmartAnswersControllerTest < ActionController::TestCase
     end
 
     context "A/B testing" do
-      setup do
-        content_item = {
-          "links" => {
-            "taxons" => [
-              {
-                "title" => "A Taxon",
-                "base_path" => "/a-taxon",
-              }
-            ],
-          },
-        }
+      context "pages under A/B test" do
+        setup do
+          content_item = {
+            "links" => {
+              "taxons" => [
+                {
+                  "title" => "A Taxon",
+                  "base_path" => "/a-taxon",
+                }
+              ],
+            },
+          }
 
-        Services.content_store.expects(:content_item)
-          .with("/smart-answers-controller-sample")
-          .returns(content_item)
+          Services.content_store.stubs(:content_item)
+            .with("/education-sample")
+            .returns(content_item)
 
-        navigation_helper = GovukNavigationHelpers::NavigationHelper.new(content_item)
-        navigation_helper.stubs(:breadcrumbs).returns(breadcrumbs: ['NormalBreadcrumb'])
-        navigation_helper.stubs(:taxon_breadcrumbs).returns(breadcrumbs: ['TaxonBreadcrumb'])
-        GovukNavigationHelpers::NavigationHelper.expects(:new)
-          .with(content_item)
-          .returns(navigation_helper)
-      end
+          navigation_helper = GovukNavigationHelpers::NavigationHelper.new(content_item)
+          navigation_helper.stubs(:breadcrumbs).returns(breadcrumbs: ['NormalBreadcrumb'])
+          navigation_helper.stubs(:taxon_breadcrumbs).returns(breadcrumbs: ['TaxonBreadcrumb'])
+          GovukNavigationHelpers::NavigationHelper.stubs(:new)
+            .with(content_item)
+            .returns(navigation_helper)
+        end
 
-      should "show normal breadcrumbs by default" do
-        get :show, id: 'smart-answers-controller-sample'
-
-        assert_match(/NormalBreadcrumb/, response.body)
-        refute_match(/TaxonBreadcrumb/, response.body)
-        sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
-        refute_match(/A Taxon/, sidebar)
-      end
-
-      should "show normal breadcrumbs for the 'A' version" do
-        with_variant EducationNavigation: "A" do
-          get :show, id: 'smart-answers-controller-sample'
+        should "show normal breadcrumbs by default" do
+          get :show, id: 'education-sample'
 
           assert_match(/NormalBreadcrumb/, response.body)
           refute_match(/TaxonBreadcrumb/, response.body)
           sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
           refute_match(/A Taxon/, sidebar)
         end
+
+        should "show normal breadcrumbs for the 'A' version" do
+          with_variant EducationNavigation: "A" do
+            get :show, id: 'education-sample'
+
+            assert_match(/NormalBreadcrumb/, response.body)
+            refute_match(/TaxonBreadcrumb/, response.body)
+            sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
+            refute_match(/A Taxon/, sidebar)
+          end
+        end
+
+        should "show taxon breadcrumbs for the 'B' version" do
+          with_variant EducationNavigation: "B" do
+            get :show, id: 'education-sample'
+
+            assert_match(/TaxonBreadcrumb/, response.body)
+            refute_match(/NormalBreadcrumb/, response.body)
+            sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
+            assert_match(/A Taxon/, sidebar)
+          end
+        end
       end
 
-      should "show taxon breadcrumbs for the 'B' version" do
-        with_variant EducationNavigation: "B" do
-          get :show, id: 'smart-answers-controller-sample'
+      context "pages outside the A/B test" do
+        %w(A B).each do |variant|
+          should "not modify response when visited in #{variant} variant" do
+            stub_smart_answer_in_content_store("smart-answers-controller-sample")
 
-          assert_match(/TaxonBreadcrumb/, response.body)
-          refute_match(/NormalBreadcrumb/, response.body)
-          sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
-          assert_match(/A Taxon/, sidebar)
+            setup_ab_variant("EducationNavigation", variant)
+
+            get :show, id: 'smart-answers-controller-sample'
+
+            assert_response_not_modified_for_ab_test
+          end
         end
       end
     end
@@ -255,6 +275,8 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
   context "GET /<slug>/visualise" do
     should "display the visualisation" do
+      stub_smart_answer_in_content_store("smart-answers-controller-sample")
+
       get :visualise, id: 'smart-answers-controller-sample'
 
       assert_select "h1", /Smart answers controller sample/

--- a/test/functional/smart_answers_controller_value_question_test.rb
+++ b/test/functional/smart_answers_controller_value_question_test.rb
@@ -12,6 +12,8 @@ class SmartAnswersControllerValueQuestionTest < ActionController::TestCase
   def setup
     stub_shared_component_locales
     setup_fixture_flows
+
+    stub_smart_answer_in_content_store("smart-answers-controller-sample-with-value-question")
   end
 
   def teardown

--- a/test/helpers/fixture_flows_helper.rb
+++ b/test/helpers/fixture_flows_helper.rb
@@ -15,4 +15,10 @@ module FixtureFlowsHelper
     FLOW_REGISTRY_OPTIONS[:preload_flows] = @preload_flows
     SmartAnswer::FlowRegistry.reset_instance
   end
+
+  def stub_smart_answer_in_content_store(smart_answer_id)
+    Services.content_store.stubs(:content_item)
+      .with("/#{smart_answer_id}")
+      .returns({})
+  end
 end

--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -3,6 +3,8 @@ require_relative 'engine_test_helper'
 class ChangingAnswerTest < EngineIntegrationTest
   with_and_without_javascript do
     should "be able to change country and date answers" do
+      stub_smart_answer_in_content_store("country-and-date-sample")
+
       stub_world_locations(%w(argentina belarus))
 
       visit "/country-and-date-sample/y"
@@ -52,6 +54,8 @@ class ChangingAnswerTest < EngineIntegrationTest
     end
 
     should "be able to change money and salary answers" do
+      stub_smart_answer_in_content_store("money-and-salary-sample")
+
       visit "/money-and-salary-sample/y"
 
       fill_in "response[amount]", with: "5000"
@@ -90,6 +94,8 @@ class ChangingAnswerTest < EngineIntegrationTest
     end
 
     should "be able to change value and multiple choice answers" do
+      stub_smart_answer_in_content_store("bridge-of-death")
+
       visit "/bridge-of-death/y"
 
       fill_in "response", with: "Lancelot"
@@ -154,6 +160,8 @@ class ChangingAnswerTest < EngineIntegrationTest
     end
 
     should "be able to change checkbox answers" do
+      stub_smart_answer_in_content_store("checkbox-sample")
+
       visit "/checkbox-sample/y"
 
       check "Peppers"
@@ -178,6 +186,8 @@ class ChangingAnswerTest < EngineIntegrationTest
     end
 
     should "be able to change postcode answer" do
+      stub_smart_answer_in_content_store("postcode-sample")
+
       visit "/postcode-sample/y"
 
       fill_in "response", with: "B1 1PW"

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -2,6 +2,10 @@ require_relative 'engine_test_helper'
 
 class CheckboxQuestionsTest < EngineIntegrationTest
   with_and_without_javascript do
+    setup do
+      stub_smart_answer_in_content_store("checkbox-sample")
+    end
+
     should "handle checkbox questions" do
       visit "/checkbox-sample/y"
 

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -12,6 +12,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       )
       stub_world_locations(@location_slugs)
       Timecop.travel("2013-01-01")
+
+      stub_smart_answer_in_content_store("country-and-date-sample")
     end
 
     should "handle country and date questions" do

--- a/test/integration/engine/data_partials_test.rb
+++ b/test/integration/engine/data_partials_test.rb
@@ -1,6 +1,10 @@
 require_relative 'engine_test_helper'
 
 class DataPartialsTest < EngineIntegrationTest
+  setup do
+    stub_smart_answer_in_content_store("data-partial-sample")
+  end
+
   should "output data partials correctly" do
     visit "/data-partial-sample/y/data_partial_with_scalar"
 

--- a/test/integration/engine/html_escaping_user_input_test.rb
+++ b/test/integration/engine/html_escaping_user_input_test.rb
@@ -2,6 +2,7 @@ require_relative 'engine_test_helper'
 
 class HtmlEscapingUserInputTest < EngineIntegrationTest
   setup do
+    stub_smart_answer_in_content_store("value-sample")
     visit "/value-sample"
     click_on "Start now"
   end

--- a/test/integration/engine/input_validation_test.rb
+++ b/test/integration/engine/input_validation_test.rb
@@ -3,6 +3,8 @@ require_relative 'engine_test_helper'
 class InputValidationTest < EngineIntegrationTest
   with_and_without_javascript do
     should "validate input and display errors" do
+      stub_smart_answer_in_content_store("money-and-salary-sample")
+
       visit "/money-and-salary-sample/y"
 
       fill_in "response[amount]", with: "-123"
@@ -36,6 +38,8 @@ class InputValidationTest < EngineIntegrationTest
     end
 
     should "allow custom validation in calculations" do
+      stub_smart_answer_in_content_store("money-and-salary-sample")
+
       visit "/money-and-salary-sample/y/4000.0-month"
 
       fill_in "response", with: "3000"
@@ -61,6 +65,8 @@ class InputValidationTest < EngineIntegrationTest
     end
 
     should "allow custom error messages with interpolation" do
+      stub_smart_answer_in_content_store("custom-errors-sample")
+
       visit "/custom-errors-sample/y"
 
       fill_in "response", with: "asdfasdf"
@@ -75,6 +81,8 @@ class InputValidationTest < EngineIntegrationTest
   end # with_and_without_javascript
 
   should "400 when given invalid UTF-8 in responses" do
+    stub_smart_answer_in_content_store("custom-errors-sample")
+
     assert_raises(ActionController::BadRequest) do
       get "/custom-errors-sample/y/age/female/%bf'%bf%22-01-02"
     end

--- a/test/integration/engine/money_and_salary_questions_test.rb
+++ b/test/integration/engine/money_and_salary_questions_test.rb
@@ -2,6 +2,10 @@ require_relative 'engine_test_helper'
 
 class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
   with_and_without_javascript do
+    setup do
+      stub_smart_answer_in_content_store("money-and-salary-sample")
+    end
+
     should "handle money and salary questions" do
       visit "/money-and-salary-sample/y"
 

--- a/test/integration/engine/multiple_choice_and_value_questions_test.rb
+++ b/test/integration/engine/multiple_choice_and_value_questions_test.rb
@@ -2,6 +2,10 @@ require_relative 'engine_test_helper'
 
 class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
   with_and_without_javascript do
+    setup do
+      stub_smart_answer_in_content_store("bridge-of-death")
+    end
+
     should "handle multiple-choice and value questions" do
       visit "/bridge-of-death"
 

--- a/test/integration/engine/precalculations_test.rb
+++ b/test/integration/engine/precalculations_test.rb
@@ -2,6 +2,10 @@ require_relative 'engine_test_helper'
 
 class PrecalculationsTest < EngineIntegrationTest
   with_and_without_javascript do
+    setup do
+      stub_smart_answer_in_content_store("precalculation-sample")
+    end
+
     should "handle precalculations" do
       visit "/precalculation-sample"
 

--- a/test/integration/engine/report_a_problem_test.rb
+++ b/test/integration/engine/report_a_problem_test.rb
@@ -4,6 +4,8 @@ class ReportAProblemTest < EngineIntegrationTest
   with_and_without_javascript do
     context "smart-answer" do
       setup do
+        stub_smart_answer_in_content_store("bridge-of-death")
+
         visit "/bridge-of-death"
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,3 +57,7 @@ GovukContentSchemaTestHelpers.configure do |config|
   config.schema_type = 'publisher_v2'
   config.project_root = Rails.root
 end
+
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end


### PR DESCRIPTION
Ensure that only pages in the navigation A/B test (those which are tagged to taxons) are cached separately and tracked in the A/B test analytics.

This change touches a lot files because we now have to set up a content item in all the tests which call `SmartAnswersController`. I think that's the correct thing to do, though, short of major refactoring to make the tests more isolated from the controller logic.

https://trello.com/c/Xehe42eM/464-only-add-a-b-meta-tag-to-pages-in-the-navigation-a-b-test