### PR TITLE
Show old related links for some mainstream pages

### DIFF
--- a/app/controllers/concerns/education_navigation_ab_testable.rb
+++ b/app/controllers/concerns/education_navigation_ab_testable.rb
@@ -3,6 +3,13 @@ module EducationNavigationABTestable
     education_navigation_variant.variant_b? && content_is_tagged_to_a_taxon?(content_item)
   end
 
+  def present_taxonomy_sidebar?(content_item)
+    should_present_new_navigation_view?(content_item) &&
+      MainstreamContentFetcher.with_curated_sidebar.exclude?(
+        content_item['base_path']
+      )
+  end
+
   def education_navigation_variant
     @education_navigation_variant ||= education_navigation_ab_test.requested_variant request.headers
   end

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -10,7 +10,12 @@ class SmartAnswersController < ApplicationController
 
   attr_accessor :navigation_helpers, :content_item
 
-  helper_method :breadcrumbs, :should_present_new_navigation_view?, :page_is_under_ab_test?
+  helper_method(
+    :breadcrumbs,
+    :should_present_new_navigation_view?,
+    :page_is_under_ab_test?,
+    :present_taxonomy_sidebar?
+  )
 
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
   rescue_from SmartAnswer::InvalidNode, with: :error_404

--- a/app/services/mainstream_content_fetcher.rb
+++ b/app/services/mainstream_content_fetcher.rb
@@ -1,0 +1,12 @@
+class MainstreamContentFetcher
+  def self.with_curated_sidebar
+    JSON.parse(
+      File.read(
+        Rails.root.join(
+          "config",
+          "mainstream_content_with_curated_sidebar.json"
+        )
+      )
+    )
+  end
+end

--- a/app/views/smart_answers/show.html.erb
+++ b/app/views/smart_answers/show.html.erb
@@ -27,7 +27,7 @@
   <% unless @presenter.started? %>
     <div class="related-container">
       <% if @navigation_helpers %>
-        <% if should_present_new_navigation_view?(@content_item) %>
+        <% if present_taxonomy_sidebar?(@content_item) %>
           <%= render partial: 'govuk_component/taxonomy_sidebar', locals: @navigation_helpers.taxonomy_sidebar %>
         <% else %>
           <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>

--- a/config/mainstream_content_with_curated_sidebar.json
+++ b/config/mainstream_content_with_curated_sidebar.json
@@ -1,0 +1,4 @@
+[
+  "/student-finance-calculator",
+  "/student-finance-forms"
+]

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -203,6 +203,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
       context "pages under A/B test" do
         setup do
           content_item = {
+            "base_path" => '/education-sample',
             "links" => {
               "taxons" => [
                 {
@@ -253,6 +254,19 @@ class SmartAnswersControllerTest < ActionController::TestCase
             refute_match(/NormalBreadcrumb/, response.body)
             sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
             assert_match(/A Taxon/, sidebar)
+          end
+        end
+
+        should "show the old sidebar for a flagged mainstream page for the 'B' version" do
+          MainstreamContentFetcher.stubs(:with_curated_sidebar).returns(
+            ['/education-sample']
+          )
+
+          with_variant EducationNavigation: "B" do
+            get :show, id: 'education-sample'
+
+            sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
+            refute_match(/A Taxon/, sidebar)
           end
         end
       end


### PR DESCRIPTION
Until we have the ability to create curated related links for the new
taxonomy, we need to still show the old sidebar because the links shown
in there are quite important.

This is a temporary fix that allows us to show the old sidebar on the
new navigation for a number of mainstream pages.

When content-tagger allows to do this, we should revert this commit.

Trello: https://trello.com/c/m3ziS0lh/503-show-old-curated-links-for-a-defined-list-of-content-before-new-curation-is-ready

### Before

<img width="1081" alt="screen shot 2017-03-07 at 17 55 17" src="https://cloud.githubusercontent.com/assets/416701/23670337/44677ad4-035f-11e7-8c6d-4af6b4af598b.png">

### After

<img width="1078" alt="screen shot 2017-03-07 at 17 55 02" src="https://cloud.githubusercontent.com/assets/416701/23670338/472f9d64-035f-11e7-91d8-8e99a1ff28eb.png">
