### PR TITLE
Update navigation helpers gem to pick up the latest taxonomy sidebar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.1.0)
+    govuk_navigation_helpers (3.1.1)
       gds-api-adapters (~> 40.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)


### PR DESCRIPTION
The list of document types which appear in the sidebar has changed. This gem upgrade picks up the latest version.

https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list