### PR TITLE
Fix order dependent test

### DIFF
--- a/test/functional/smart_answers_controller_debug_template_path_test.rb
+++ b/test/functional/smart_answers_controller_debug_template_path_test.rb
@@ -9,6 +9,7 @@ class SmartAnswersControllerDebugTemplatePathTest < ActionController::TestCase
 
   def setup
     setup_fixture_flows
+    stub_shared_component_locales
     registry = SmartAnswer::FlowRegistry.instance
     flow_name = 'smart-answers-controller-sample'
     @template_directory = registry.load_path.join(flow_name)


### PR DESCRIPTION
This test sometimes works when a previous test has called `stub_shared_component_locales`. If this is the first test, it will fail.

For example:

https://ci.integration.publishing.service.gov.uk/job/smartanswers/job/master/3519/console

https://trello.com/c/75b8zLhG