### PR TITLE
Add content and forms for EU new 2017-18 students

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_new.govspeak.erb
@@ -3,5 +3,27 @@
 <% end %>
 
 <% content_for :body do %>
-  You can't apply for the 2017 to 2018 academic year yet.
+
+  To apply for a Tuition Fee Loan use form EU17N.
+
+  The EU17N form is for EU students studying in England only.
+
+  Academic year | Form
+  - | -
+  2017 to 2018 | [EU17N - form and notes (PDF, 221KB)](http://media.slc.co.uk/sfe/1718/eu/eu_eu17n_form_1718_d.pdf)
+
+  ##Additional information
+
+  You may need to include additional information on the following forms.
+
+  Form | When to use the form
+  - | -
+  [EUTFLR - form (PDF, 40KB)](http://media.slc.co.uk/sfe/1718/eu/eu_tfl_request_form_1718_d.pdf)  | To change the amount of loan you want to apply for
+  [Evidence factsheet (PDF, 79KB)](http://media.slc.co.uk/sfe/1718/eu/eu_evidence_fs_1718_d.pdf) | List of evidence to send with your application - for example, proof of identity or income
+  [Certifier checklist (PDF, 59KB)](http://media.slc.co.uk/sfe/1718/eu/eu_certifier_checklist_form_1718_d.pdf) | Get the person who verifies your evidence to sign this form
+  [EUCO1 - form (PDF, 137KB)](http://media.slc.co.uk/sfe/1718/eu/eu_euco1_form_1718_d.pdf) | To update your course, name and other details
+
+  <%= render partial: 'when_you_can_apply.govspeak.erb' %>
+
+  <%= render partial: 'where_to_send_your_forms_non_uk.govspeak.erb' %>
 <% end %>

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1718.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1718.govspeak.erb
@@ -16,7 +16,7 @@
   Academic year | Form
   - | -
   2017 to 2018 | [PFF2 - income details form (PDF, 245KB)](http://media.slc.co.uk/sfe/1718/ft/sfe_pff2_form_1718_d.pdf)
-  2017 to 2018 | CYI - current tax year income assessment form (available in April 2017)
+  2017 to 2018 | [CYI - current tax year income assessment form (PDF, 566KB)](http://media.slc.co.uk/sfe/1718/ft/sfe_cyi_form_1718_d.pdf)
 
   %Income means your [household income](/apply-for-student-finance/household-income).%
 

--- a/test/artefacts/student-finance-forms/eu-full-time/year-1718/new-student.txt
+++ b/test/artefacts/student-finance-forms/eu-full-time/year-1718/new-student.txt
@@ -1,6 +1,38 @@
 EU full-time student
 
-You can't apply for the 2017 to 2018 academic year yet.
+
+To apply for a Tuition Fee Loan use form EU17N.
+
+The EU17N form is for EU students studying in England only.
+
+Academic year | Form
+- | -
+2017 to 2018 | [EU17N - form and notes (PDF, 221KB)](http://media.slc.co.uk/sfe/1718/eu/eu_eu17n_form_1718_d.pdf)
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 40KB)](http://media.slc.co.uk/sfe/1718/eu/eu_tfl_request_form_1718_d.pdf)  | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 79KB)](http://media.slc.co.uk/sfe/1718/eu/eu_evidence_fs_1718_d.pdf) | List of evidence to send with your application - for example, proof of identity or income
+[Certifier checklist (PDF, 59KB)](http://media.slc.co.uk/sfe/1718/eu/eu_certifier_checklist_form_1718_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 137KB)](http://media.slc.co.uk/sfe/1718/eu/eu_euco1_form_1718_d.pdf) | To update your course, name and other details
+
+^The deadline is 9 months after the first day of the course's academic year. Academic years begin on 1 September, 1 January, 1 April and 1 July. Ask someone who runs your course if you don't know which one applies.^
+
+##Where to send your forms
+
+$A
+Student Finance Services non-UK Team
+Student Loans Company
+PO Box 89
+Darlington
+County Durham
+England
+DL1 9AZ
+$A
 
 
 

--- a/test/artefacts/student-finance-forms/uk-full-time/income-details/year-1718.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/income-details/year-1718.txt
@@ -13,7 +13,7 @@ If you think your income has dropped by 15% or more since the 2015 to 2016 tax y
 Academic year | Form
 - | -
 2017 to 2018 | [PFF2 - income details form (PDF, 245KB)](http://media.slc.co.uk/sfe/1718/ft/sfe_pff2_form_1718_d.pdf)
-2017 to 2018 | CYI - current tax year income assessment form (available in April 2017)
+2017 to 2018 | [CYI - current tax year income assessment form (PDF, 566KB)](http://media.slc.co.uk/sfe/1718/ft/sfe_cyi_form_1718_d.pdf)
 
 %Income means your [household income](/apply-for-student-finance/household-income).%
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -18,7 +18,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_expenses.govsp
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1617_continuing.govspeak.erb: 5809f0e73d54ab52f933075a4845fe2f
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1617_new.govspeak.erb: de40ad74ec044a07a702c9a4a72447a3
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_continuing.govspeak.erb: d0150398a4c0c129926e97b67ca0cf24
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_new.govspeak.erb: 1107e71aea3d3a79fb8d381b34cb9778
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_new.govspeak.erb: fb26ff222b50a6f25a094ffcfa5c8280
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_continuing.govspeak.erb: 07189e16f1f8d4940fe6a778230ee479
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.govspeak.erb: 02a6092382484da065e75e31194582b0
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_continuing.govspeak.erb: f2613a4435a7694756baad1b104d4f2e

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -24,7 +24,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.gov
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_continuing.govspeak.erb: f2613a4435a7694756baad1b104d4f2e
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_new.govspeak.erb: 320fa759eec25e2330a0581e84b27c2c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1617.govspeak.erb: 41fea6bde7503488a9ee3e88fb3bbd90
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1718.govspeak.erb: 6daa8e6dab8c518a69deed6774f40ce5
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1718.govspeak.erb: ccf49644f9266e50ec7a3e1dde7770e4
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1516.govspeak.erb: 1503d5117dc579523d0ffb3b627175c1
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1617.govspeak.erb: 6a57b5c992b299981e407b3c08894848
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1718.govspeak.erb: 93b4c3194eec911e7de753de3e871a29


### PR DESCRIPTION
Trello card: https://trello.com/c/aJzPGVjl
Supersedes PR #2940 

## Factcheck
[student-finance-forms](https://smart-answers-pr-2957.herokuapp.com/student-finance-forms/y/eu-full-time/year-1718/new-student)

## Expected changes
* [URL on GOV.UK](https://www.gov.uk/student-finance-forms/y/eu-full-time/year-1718/new-student)
   * Add details for how EU students can apply for finance in the 2017-2018 academic year.

### Before
![screen shot 2017-03-09 at 17 59 02](https://cloud.githubusercontent.com/assets/5793815/23763582/1ec2646c-04f2-11e7-80a3-4209c568fe33.png)

### After
![screen shot 2017-03-10 at 11 06 56](https://cloud.githubusercontent.com/assets/5793815/23793124/b95d0c0e-0581-11e7-826a-519748a4ac20.png)
