### PR TITLE
Convert taxon breadcrumbs to back link on mobile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.2.0)
+    govuk_navigation_helpers (3.2.1)
       gds-api-adapters (~> 40.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)


### PR DESCRIPTION
Upgrade the govuk_navigation_helpers gem to pick up the latest breadcrumb config. This adds the taxon back link on mobile.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link