### PR TITLE
Enable taxonomy breadcrumb back link on mobile

### DIFF
--- a/app/views/smart_answers/show.html.erb
+++ b/app/views/smart_answers/show.html.erb
@@ -26,7 +26,11 @@
   %>
 <% end %>
 
-<%= render partial: 'govuk_component/breadcrumbs', locals: breadcrumbs %>
+<%= render partial: 'govuk_component/breadcrumbs',
+    locals: {
+      breadcrumbs: breadcrumbs[:breadcrumbs],
+      collapse_on_mobile: should_present_new_navigation_view?(@content_item)
+    } %>
 
 <div class="grid-row">
   <main id="content" role="main">


### PR DESCRIPTION
Pass `collapse_on_mobile` parameter to enable the collapse of the taxonomy breadcrumbs to a single back link.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link