### PR TITLE
Update govuk_navigation_helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'uglifier'
 gem 'uk_postcode', '~> 1.0.1'
 gem 'unicorn', '4.8.3'
 gem 'rails_stdout_logging'
-gem 'govuk_navigation_helpers', '~> 3.2'
+gem 'govuk_navigation_helpers', '~> 4.0'
 gem 'govuk_ab_testing', '1.0.4'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.2.1)
+    govuk_navigation_helpers (4.0.0)
       gds-api-adapters (~> 40.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -280,7 +280,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 1.0.4)
   govuk_frontend_toolkit (= 4.14.0)
-  govuk_navigation_helpers (~> 3.2)
+  govuk_navigation_helpers (~> 4.0)
   htmlentities (~> 4)
   json
   logstasher (= 0.4.8)


### PR DESCRIPTION
This picks up the latest version of the taxonomy sidebar. There should not be any user-visible changes - the library has just switched from a hard-coded list of guidance content to filtering it in search.

https://trello.com/c/PtQXkimK/520-switch-from-using-hardcoded-guidance-document-types-into-using-document-supertypes